### PR TITLE
WIP feat(archives): include recording metadata in S3 tags

### DIFF
--- a/src/main/java/io/cryostat/ExceptionMappers.java
+++ b/src/main/java/io/cryostat/ExceptionMappers.java
@@ -21,6 +21,7 @@ import org.hibernate.exception.ConstraintViolationException;
 import org.jboss.resteasy.reactive.RestResponse;
 import org.jboss.resteasy.reactive.server.ServerExceptionMapper;
 import org.projectnessie.cel.tools.ScriptException;
+import software.amazon.awssdk.services.s3.model.NoSuchKeyException;
 
 public class ExceptionMappers {
     @ServerExceptionMapper
@@ -41,5 +42,10 @@ public class ExceptionMappers {
     @ServerExceptionMapper
     public RestResponse<Void> mapScriptException(ScriptException ex) {
         return RestResponse.status(HttpResponseStatus.BAD_REQUEST.code());
+    }
+
+    @ServerExceptionMapper
+    public RestResponse<Void> mapNoSuchKeyException(NoSuchKeyException ex) {
+        return RestResponse.status(HttpResponseStatus.NOT_FOUND.code());
     }
 }

--- a/src/main/java/io/cryostat/Producers.java
+++ b/src/main/java/io/cryostat/Producers.java
@@ -32,6 +32,7 @@ import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.context.RequestScoped;
 import jakarta.enterprise.inject.Produces;
 import jakarta.inject.Named;
+import org.apache.commons.codec.binary.Base32;
 import org.apache.commons.codec.binary.Base64;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.projectnessie.cel.tools.ScriptHost;
@@ -57,6 +58,12 @@ public class Producers {
     @DefaultBean
     public static FileSystem produceFileSystem() {
         return new FileSystem();
+    }
+
+    @Produces
+    @ApplicationScoped
+    public static Base32 produceBase32() {
+        return new Base32();
     }
 
     @Produces

--- a/src/main/java/io/cryostat/recordings/ActiveRecording.java
+++ b/src/main/java/io/cryostat/recordings/ActiveRecording.java
@@ -223,6 +223,10 @@ public class ActiveRecording extends PanacheEntity {
                                     recordingHelper.toExternalForm(recording))));
         }
 
+        // FIXME the target connectUrl URI may no longer be known if the target
+        // has disappeared and we are emitting an event regarding an archived recording originally
+        // sourced from that target.
+        // This should embed the target jvmId and optionally the database ID.
         public record RecordingEvent(URI target, Object recording) {
             public RecordingEvent {
                 Objects.requireNonNull(target);

--- a/src/main/java/io/cryostat/recordings/RecordingHelper.java
+++ b/src/main/java/io/cryostat/recordings/RecordingHelper.java
@@ -99,7 +99,8 @@ import software.amazon.awssdk.services.s3.presigner.S3Presigner;
 @ApplicationScoped
 public class RecordingHelper {
 
-    private static final String JFR_MIME = "application/jfr";
+    public static final String JFR_MIME = HttpMimeType.JFR.mime();
+
     private static final Pattern TEMPLATE_PATTERN =
             Pattern.compile("^template=([\\w]+)(?:,type=([\\w]+))?$");
     public static final String DATASOURCE_FILENAME = "cryostat-analysis.jfr";
@@ -596,10 +597,7 @@ public class RecordingHelper {
         MultipartForm form =
                 MultipartForm.create()
                         .binaryFileUpload(
-                                "file",
-                                DATASOURCE_FILENAME,
-                                recordingPath.toString(),
-                                HttpMimeType.OCTET_STREAM.toString());
+                                "file", DATASOURCE_FILENAME, recordingPath.toString(), JFR_MIME);
 
         try {
             ResponseBuilder builder = new ResponseBuilderImpl();

--- a/src/main/java/io/cryostat/recordings/RecordingHelper.java
+++ b/src/main/java/io/cryostat/recordings/RecordingHelper.java
@@ -459,9 +459,24 @@ public class RecordingHelper {
         return filename;
     }
 
+    public String archivedRecordingKey(String jvmId, String filename) {
+        return (jvmId + "/" + filename).strip();
+    }
+
+    public String archivedRecordingKey(Pair<String, String> pair) {
+        return archivedRecordingKey(pair.getKey(), pair.getValue());
+    }
+
     public String encodedKey(String jvmId, String filename) {
         return base64Url.encodeAsString(
-                (jvmId + "/" + filename.strip()).getBytes(StandardCharsets.UTF_8));
+                (archivedRecordingKey(jvmId, filename)).getBytes(StandardCharsets.UTF_8));
+    }
+
+    // TODO refactor this and encapsulate archived recording keys as a record with override toString
+    public Pair<String, String> decodedKey(String encodedKey) {
+        String key = new String(base64Url.decode(encodedKey), StandardCharsets.UTF_8);
+        String[] parts = key.split("/");
+        return Pair.of(parts[0], parts[1]);
     }
 
     public InputStream getActiveInputStream(ActiveRecording recording) throws Exception {

--- a/src/main/java/io/cryostat/recordings/Recordings.java
+++ b/src/main/java/io/cryostat/recordings/Recordings.java
@@ -74,6 +74,7 @@ import jakarta.ws.rs.NotFoundException;
 import jakarta.ws.rs.PATCH;
 import jakarta.ws.rs.POST;
 import jakarta.ws.rs.Path;
+import jakarta.ws.rs.core.HttpHeaders;
 import jakarta.ws.rs.core.Response;
 import jdk.jfr.RecordingState;
 import org.apache.commons.codec.binary.Base32;
@@ -800,6 +801,9 @@ public class Recordings {
                         Instant.now().plusSeconds(60)); // TODO make expiry configurable
         String encodedKey = recordingHelper.encodedKey(recording.target.jvmId, filename);
         return Response.status(RestResponse.Status.PERMANENT_REDIRECT)
+                .header(
+                        HttpHeaders.CONTENT_DISPOSITION,
+                        String.format("attachment; filename=\"%s\"", filename))
                 .location(URI.create(String.format("/api/v3/download/%s", encodedKey)))
                 .build();
     }

--- a/src/main/java/io/cryostat/recordings/Recordings.java
+++ b/src/main/java/io/cryostat/recordings/Recordings.java
@@ -304,7 +304,7 @@ public class Recordings {
         storage.deleteObject(
                 DeleteObjectRequest.builder()
                         .bucket(archiveBucket)
-                        .key(String.format("%s/%s", jvmId, filename))
+                        .key(recordingHelper.archivedRecordingKey(jvmId, filename))
                         .build());
     }
 
@@ -320,7 +320,7 @@ public class Recordings {
         if (!filename.endsWith(".jfr")) {
             filename = filename + ".jfr";
         }
-        String key = String.format("%s/%s", jvmId, filename);
+        String key = recordingHelper.archivedRecordingKey(jvmId, filename);
         storage.putObject(
                 PutObjectRequest.builder()
                         .bucket(archiveBucket)
@@ -748,10 +748,13 @@ public class Recordings {
     @RolesAllowed("read")
     public Response redirectPresignedDownload(@RestPath String encodedKey)
             throws URISyntaxException {
-        String key = new String(base64Url.decode(encodedKey), StandardCharsets.UTF_8);
-        logger.infov("Handling presigned download request for {0}", key);
+        Pair<String, String> pair = recordingHelper.decodedKey(encodedKey);
+        logger.infov("Handling presigned download request for {0}", pair);
         GetObjectRequest getRequest =
-                GetObjectRequest.builder().bucket(archiveBucket).key(key).build();
+                GetObjectRequest.builder()
+                        .bucket(archiveBucket)
+                        .key(recordingHelper.archivedRecordingKey(pair))
+                        .build();
         GetObjectPresignRequest presignRequest =
                 GetObjectPresignRequest.builder()
                         .signatureDuration(Duration.ofMinutes(1))
@@ -805,7 +808,7 @@ public class Recordings {
                 storage.getObjectTagging(
                                 GetObjectTaggingRequest.builder()
                                         .bucket(archiveBucket)
-                                        .key(String.format("%s/%s", jvmId, filename))
+                                        .key(recordingHelper.archivedRecordingKey(jvmId, filename))
                                         .build())
                         .tagSet());
     }

--- a/src/main/java/io/cryostat/targets/Target.java
+++ b/src/main/java/io/cryostat/targets/Target.java
@@ -23,6 +23,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
 
 import org.openjdk.jmc.rjmx.services.jfr.IRecordingDescriptor;
@@ -107,6 +108,10 @@ public class Target extends PanacheEntity {
 
     public static Target getTargetByConnectUrl(URI connectUrl) {
         return find("connectUrl", connectUrl).singleResult();
+    }
+
+    public static Optional<Target> getTargetByJvmId(String jvmId) {
+        return find("jvmId", jvmId).firstResultOptional();
     }
 
     public static boolean deleteByConnectUrl(URI connectUrl) {

--- a/src/main/java/io/cryostat/util/HttpMimeType.java
+++ b/src/main/java/io/cryostat/util/HttpMimeType.java
@@ -23,6 +23,7 @@ public enum HttpMimeType {
     JSON("application/json"),
     JSON_RAW("application/json"),
     OCTET_STREAM("application/octet-stream"),
+    JFR("binary/octet-stream"),
     JFC("application/jfc+xml"),
     XML("application/xml"),
     MULTIPART_FORM("multipart/form-data"),


### PR DESCRIPTION
Depends on #62 
Based on #62 

As title suggests - copy active recording metadata into S3 object tagging so metadata (labels etc.) are preserved with archives.