### PR TITLE
fix(properties): disable podman discovery in production by default

### DIFF
--- a/src/main/resources/application-dev.properties
+++ b/src/main/resources/application-dev.properties
@@ -16,4 +16,4 @@ quarkus.hibernate-orm.log.sql=true
 quarkus.log.category."org.jboss.resteasy.reactive.common.core.AbstractResteasyReactiveContext".level=DEBUG
 cryostat.discovery.jdp.enabled=true
 cryostat.discovery.podman.enabled=true
-cryostat.discovery.docker.enabled=false
+cryostat.discovery.docker.enabled=true

--- a/src/main/resources/application-test.properties
+++ b/src/main/resources/application-test.properties
@@ -2,7 +2,7 @@ quarkus.smallrye-openapi.info-title=Cryostat API (test)
 
 cryostat.discovery.jdp.enabled=true
 cryostat.discovery.podman.enabled=true
-cryostat.discovery.docker.enabled=false
+cryostat.discovery.docker.enabled=true
 cryostat.auth.disabled=true
 
 grafana-dashboard.url=http://grafana:3000

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,6 +1,6 @@
 quarkus.naming.enable-jndi=true
 cryostat.discovery.jdp.enabled=false
-cryostat.discovery.podman.enabled=true
+cryostat.discovery.podman.enabled=false
 cryostat.discovery.docker.enabled=false
 quarkus.test.integration-test-profile=test
 


### PR DESCRIPTION
Related to #73 

This disables all discovery mechanisms in production unless explicitly turned on.

> I would prefer to keep all the builtin discoveries toggled off by default in production builds, so each one is an opt-in feature specified when the Cryostat container is deployed. That's the opposite of previous Cryostat versions where everything is on by default and things need to be turned off either all at once or by listing out only the ones to turn on, which made some sense with how discovery used to work but I don't think necessarily makes sense anymore when there are multiple built-in options that can all be enabled in parallel.

See https://github.com/cryostatio/cryostat3/pull/26#discussion_r1242592780

I realized I misread the comment when porting the docker discovery: https://github.com/cryostatio/cryostat3/pull/73#discussion_r1331666436. Sorry about that :)))
