### PR TITLE
fix(archives): correct recording metadata in S3 tags

### DIFF
--- a/src/main/java/io/cryostat/recordings/RecordingHelper.java
+++ b/src/main/java/io/cryostat/recordings/RecordingHelper.java
@@ -75,6 +75,7 @@ import jakarta.ws.rs.ServerErrorException;
 import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.core.Response.ResponseBuilder;
 import jdk.jfr.RecordingState;
+import org.apache.commons.codec.binary.Base32;
 import org.apache.commons.codec.binary.Base64;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.tuple.Pair;
@@ -121,6 +122,8 @@ public class RecordingHelper {
 
     @Inject Clock clock;
     @Inject S3Presigner presigner;
+
+    @Inject Base32 base32;
 
     @Inject
     @Named(Producers.BASE64_URL)
@@ -369,7 +372,7 @@ public class RecordingHelper {
         String filename =
                 String.format("%s_%s_%s.jfr", transformedAlias, recording.name, timestamp);
         int mib = 1024 * 1024;
-        String key = String.format("%s/%s", recording.target.jvmId, filename);
+        String key = archivedRecordingKey(recording.target.jvmId, filename);
         String multipartId = null;
         List<Pair<Integer, String>> parts = new ArrayList<>();
         try (var stream = remoteRecordingStreamFactory.open(recording);
@@ -467,12 +470,17 @@ public class RecordingHelper {
             throw e;
         }
         if (expiry == null) {
+            LinkedRecordingDescriptor serializedRecording = toExternalForm(recording);
             bus.publish(
                     MessagingServer.class.getName(),
                     new Notification(
                             "ActiveRecordingSaved",
-                            new RecordingEvent(
-                                    recording.target.connectUrl, toExternalForm(recording))));
+                            new RecordingEvent(recording.target.connectUrl, serializedRecording)));
+            bus.publish(
+                    MessagingServer.class.getName(),
+                    new Notification(
+                            "ArchivedRecordingCreated",
+                            new RecordingEvent(recording.target.connectUrl, serializedRecording)));
         }
         return filename;
     }
@@ -497,7 +505,11 @@ public class RecordingHelper {
         }
     }
 
-    private String decodeBase64(String encoded) {
+    String decodeBase32(String encoded) {
+        return new String(base32.decode(encoded), StandardCharsets.UTF_8);
+    }
+
+    String decodeBase64(String encoded) {
         return new String(base64Url.decode(encoded), StandardCharsets.UTF_8);
     }
 
@@ -588,7 +600,7 @@ public class RecordingHelper {
         storage.deleteObject(
                 DeleteObjectRequest.builder()
                         .bucket(archiveBucket)
-                        .key(String.format("%s/%s", jvmId, filename))
+                        .key(archivedRecordingKey(jvmId, filename))
                         .build());
         bus.publish(
                 MessagingServer.class.getName(),
@@ -598,7 +610,7 @@ public class RecordingHelper {
     }
 
     // Metadata
-    private Tagging createMetadataTagging(Metadata metadata) {
+    Tagging createMetadataTagging(Metadata metadata) {
         // TODO attach other metadata than labels somehow. Prefixed keys to create partitioning?
         var tags = new ArrayList<Tag>();
         tags.addAll(
@@ -722,6 +734,14 @@ public class RecordingHelper {
                                 throw new BadRequestException(e);
                             }
                         });
+    }
+
+    private Tagging createActiveRecordingTagging(ActiveRecording recording) {
+        Map<String, String> labels = new HashMap<>(recording.metadata.labels());
+        labels.put("connectUrl", recording.target.connectUrl.toString());
+        labels.put("jvmId", recording.target.jvmId);
+        Metadata metadata = new Metadata(labels);
+        return createMetadataTagging(metadata);
     }
 
     public enum RecordingReplace {

--- a/src/main/java/io/cryostat/recordings/RecordingHelper.java
+++ b/src/main/java/io/cryostat/recordings/RecordingHelper.java
@@ -383,9 +383,7 @@ public class RecordingHelper {
                             .bucket(archiveBucket)
                             .key(key)
                             .contentType(JFR_MIME)
-                            .tagging(
-                                    createMetadataTagging(
-                                            new Metadata(recording.metadata, expiry)));
+                            .tagging(createActiveRecordingTagging(recording, expiry));
             if (expiry != null && expiry.isAfter(Instant.now())) {
                 builder = builder.expires(expiry);
             }
@@ -609,6 +607,14 @@ public class RecordingHelper {
                         new RecordingEvent(URI.create("localhost:0"), Map.of("name", filename))));
     }
 
+    Tagging createActiveRecordingTagging(ActiveRecording recording, Instant expiry) {
+        Map<String, String> labels = new HashMap<>(recording.metadata.labels());
+        labels.put("connectUrl", recording.target.connectUrl.toString());
+        labels.put("jvmId", recording.target.jvmId);
+        Metadata metadata = new Metadata(labels, expiry);
+        return createMetadataTagging(metadata);
+    }
+
     // Metadata
     Tagging createMetadataTagging(Metadata metadata) {
         // TODO attach other metadata than labels somehow. Prefixed keys to create partitioning?
@@ -734,14 +740,6 @@ public class RecordingHelper {
                                 throw new BadRequestException(e);
                             }
                         });
-    }
-
-    private Tagging createActiveRecordingTagging(ActiveRecording recording) {
-        Map<String, String> labels = new HashMap<>(recording.metadata.labels());
-        labels.put("connectUrl", recording.target.connectUrl.toString());
-        labels.put("jvmId", recording.target.jvmId);
-        Metadata metadata = new Metadata(labels);
-        return createMetadataTagging(metadata);
     }
 
     public enum RecordingReplace {


### PR DESCRIPTION
Cleans up some archived recording metadata handling and ensures that the `jvmId` and `connectUrl` labels get applied.

Related to #62 

To test:
1. `./mvnw clean verify`
2. `./smoketest.bash -OXtb`, wait for everything to come up
3. Select a target ex. `Podman > service:jmx:rmi:///jndi/rmi://sample-app:9093/jmxrmi`
4. Recordings > Create > create a recording
5. Wait a few seconds, then archive that recording
6. Go to Archives > All Archives > expand the target
7. Check that the archived recording is present and has the expected labels

Before:
![image](https://github.com/cryostatio/cryostat3/assets/3787464/61103af7-0ee1-41ee-88cc-67ba832711f9)
(notice that the `connectUrl` label is actually the `jvmId`, and there is no `jvmId` label)

After:
![image](https://github.com/cryostatio/cryostat3/assets/3787464/c2ec568f-463a-4817-933a-7a930f104c2c)
