### PR TITLE
ci(build-test): persist PATH modifications with GITHUB_ENV

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -88,8 +88,7 @@ jobs:
         mkdir -p $HOME/.bin
         cat <(echo '#!/usr/bin/env bash') <(echo 'exec podman "$@"') > $HOME/.bin/docker
         chmod +x $HOME/.bin/docker
-        export PATH="$HOME/.bin:$PATH"
-        docker --version
+        echo "PATH=$HOME/.bin:$PATH" >> "$GITHUB_ENV"
     - name: Set up testcontainers for podman
       run:  echo ryuk.container.privileged=true > ~/.testcontainers.properties
     - name: Start Podman API


### PR DESCRIPTION
Fixes #99 

The `PATH` environment variable is not persisted (previously) with the `export` syntax. This must be done via `GITHUB_ENV`.