### PR TITLE
ci(dependabot): remove reviewers config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,8 +10,6 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
-    reviewers:
-      - "cryostatio/reviewers"
     labels:
       - "dependencies"
       - "chore"
@@ -24,8 +22,6 @@ updates:
     directory: "/src/main/docker"
     schedule:
       interval: "weekly"
-    reviewers:
-      - "cryostatio/reviewers"
     labels:
       - "dependencies"
       - "chore"


### PR DESCRIPTION
# Welcome to Cryostat3! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat3/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] [Signed all commits using a GPG signature](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#gpg-commit-signature-verification)

**To recreate commits with GPG signature** `git fetch upstream && git rebase --force --gpg-sign upstream/main`
_______________________________________________

Fixes: #118 

## Description of the change:
Dependabot should not be requesting review from both maintainers and reviewers teams. With this change only maintainers should be requested

## Motivation for the change:
Bug reported by @andrewazores: Dependabot PRs end up requesting review from both maintainers and reviewers teams.

## How to manually test:
1. *Run CRYOSTAT_IMAGE=quay.io... sh smoketest.sh...*
2. *...*
