### PR TITLE
ci(image): correct expression condition syntax

### DIFF
--- a/.github/workflows/push-ci.yaml
+++ b/.github/workflows/push-ci.yaml
@@ -103,8 +103,7 @@ jobs:
       run: ./mvnw -B -U clean verify
       continue-on-error: ${{ matrix.java != '17' }}
     - name: Delete local integration test image
-      run: |
-        podman rmi ${{ env.CI_IMG }}:latest ${{ env.CI_IMG }}:dev ${{ env.CI_IMG }}:${{ env.IMAGE_VERSION }}
+      run: podman rmi ${{ env.CI_IMG }}:latest ${{ env.CI_IMG }}:dev ${{ env.CI_IMG }}:${{ env.IMAGE_VERSION }}
       continue-on-error: true
     - name: Build container images and manifest
       if: ${{ matrix.java == '17' && github.repository_owner == 'cryostatio' }}

--- a/.github/workflows/push-ci.yaml
+++ b/.github/workflows/push-ci.yaml
@@ -107,7 +107,7 @@ jobs:
         podman rmi ${{ env.CI_IMG }}:latest ${{ env.CI_IMG }}:dev ${{ env.CI_IMG }}:${{ env.IMAGE_VERSION }}
       continue-on-error: true
     - name: Build container images and manifest
-      if: ${{ matrix.java == '17' }} && ${{ github.repository_owner == 'cryostatio' }}
+      if: ${{ matrix.java == '17' && github.repository_owner == 'cryostatio' }}
       id: buildah-build
       uses: redhat-actions/buildah-build@v2
       with:
@@ -126,7 +126,7 @@ jobs:
         registry: ${{ env.CI_REGISTRY }}
         username: ${{ env.CI_USER }}
         password: ${{ secrets.REGISTRY_PASSWORD }}
-      if: ${{ matrix.java == '17' }} && ${{ github.repository_owner == 'cryostatio' }}
+      if: ${{ matrix.java == '17' && github.repository_owner == 'cryostatio' }}
     - name: Print image URL
       run: echo "Image pushed to ${{ steps.push-to-quay.outputs.registry-paths }}"
-      if: ${{ matrix.java == '17' }} && ${{ github.repository_owner == 'cryostatio' }}
+      if: ${{ matrix.java == '17' && github.repository_owner == 'cryostatio' }}


### PR DESCRIPTION
# Welcome to Cryostat3! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat3/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] [Signed all commits using a GPG signature](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#gpg-commit-signature-verification)

**To recreate commits with GPG signature** `git fetch upstream && git rebase --force --gpg-sign upstream/main`
_______________________________________________

Related to #144

https://github.com/cryostatio/cryostat3/actions/runs/6791664907/job/18463577147

I believe this failed because of the curly brace syntax. In my fork this was commented out to make sure it progressed to the "push to quay.io" stage and then failed as expected. Uncommenting this condition resulted in the JDK 21 build attempting to build the multiarch manifest image when it should have skipped that step.
