### PR TITLE
test(itest): updated UploadRecordingTest to handle the redirects to V3 endpoints

### DIFF
--- a/src/main/java/io/cryostat/recordings/Recordings.java
+++ b/src/main/java/io/cryostat/recordings/Recordings.java
@@ -507,7 +507,7 @@ public class Recordings {
     @Blocking
     @Path("/api/v3/targets/{id}/recordings")
     @RolesAllowed("write")
-    public LinkedRecordingDescriptor createRecording(
+    public Response createRecording(
             @RestPath long id,
             @RestForm String recordingName,
             @RestForm String events,
@@ -586,7 +586,9 @@ public class Recordings {
                     TimeUnit.MILLISECONDS);
         }
 
-        return recordingHelper.toExternalForm(recording);
+        return Response.status(Response.Status.CREATED)
+                .entity(recordingHelper.toExternalForm(recording).toString())
+                .build();
     }
 
     @Transactional


### PR DESCRIPTION
# Welcome to Cryostat3! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat3/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [ ] [Signed all commits using a GPG signature](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#gpg-commit-signature-verification)

**To recreate commits with GPG signature** `git fetch upstream && git rebase --force --gpg-sign upstream/main`
_______________________________________________

Related to #42

## Description of the change:
*Created new methods to handle the redirects to new V3 endpoints for the UploadRecordingTest*

Notes: It will fail during the create recording ("/api/v1/targets/%s/recordings") as it is expecting 201 and it is currently is returning 200 (updated Recordings to return 201) 
The original test to delete recording was expecting 200 code, but I think that the current 204 makes more sense. 

## Motivation for the change:
*vertx does not follow redirects for non GET and HEAP methods*

## How to manually test:
*mvn package*

