### PR TITLE
test(redirects): refactor redirect handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Cryostat3
 
-[![CI build and push](https://github.com/cryostatio/cryostat3/actions/workflows/ci.yaml/badge.svg)](https://github.com/cryostatio/cryostat3/actions/workflows/ci.yaml)
+[![CI build and push](https://github.com/cryostatio/cryostat3/actions/workflows/push-ci.yaml/badge.svg)](https://github.com/cryostatio/cryostat3/actions/workflows/push-ci.yaml)
 [![Google Group : Cryostat Development](https://img.shields.io/badge/Google%20Group-Cryostat%20Development-blue.svg)](https://groups.google.com/g/cryostat-development)
 
 This project uses Quarkus, the Supersonic Subatomic Java Framework.

--- a/src/test/java/itest/UploadRecordingTest.java
+++ b/src/test/java/itest/UploadRecordingTest.java
@@ -67,7 +67,7 @@ public class UploadRecordingTest extends StandardSelfTest {
         CREATE_RECORDING_URL =
                 String.format("/api/v1/targets/%s/recordings", getSelfReferenceConnectUrlEncoded());
         HttpResponse<Buffer> resp =
-                post(CREATE_RECORDING_URL, true, form, RECORDING_DURATION_SECONDS);
+                webClient.post(CREATE_RECORDING_URL, true, form, RECORDING_DURATION_SECONDS);
         MatcherAssert.assertThat(resp.statusCode(), Matchers.equalTo(201));
         Thread.sleep(
                 Long.valueOf(
@@ -78,7 +78,7 @@ public class UploadRecordingTest extends StandardSelfTest {
     public static void deleteRecording() throws Exception {
         try {
             HttpResponse<Buffer> resp =
-                    delete(
+                    webClient.delete(
                             String.format(
                                     "/api/v1/targets/%s/recordings/%s",
                                     getSelfReferenceConnectUrlEncoded(), RECORDING_NAME),
@@ -97,7 +97,7 @@ public class UploadRecordingTest extends StandardSelfTest {
     public void shouldLoadRecordingToDatasource() throws Exception {
 
         HttpResponse<Buffer> resp =
-                post(
+                webClient.post(
                         String.format(
                                 "/api/v1/targets/%s/recordings/%s/upload",
                                 getSelfReferenceConnectUrlEncoded(), RECORDING_NAME),

--- a/src/test/java/itest/UploadRecordingTest.java
+++ b/src/test/java/itest/UploadRecordingTest.java
@@ -67,7 +67,9 @@ public class UploadRecordingTest extends StandardSelfTest {
         CREATE_RECORDING_URL =
                 String.format("/api/v1/targets/%s/recordings", getSelfReferenceConnectUrlEncoded());
         HttpResponse<Buffer> resp =
-                webClient.post(CREATE_RECORDING_URL, true, form, RECORDING_DURATION_SECONDS);
+                webClient
+                        .extensions()
+                        .post(CREATE_RECORDING_URL, true, form, RECORDING_DURATION_SECONDS);
         MatcherAssert.assertThat(resp.statusCode(), Matchers.equalTo(201));
         Thread.sleep(
                 Long.valueOf(
@@ -78,12 +80,14 @@ public class UploadRecordingTest extends StandardSelfTest {
     public static void deleteRecording() throws Exception {
         try {
             HttpResponse<Buffer> resp =
-                    webClient.delete(
-                            String.format(
-                                    "/api/v1/targets/%s/recordings/%s",
-                                    getSelfReferenceConnectUrlEncoded(), RECORDING_NAME),
-                            true,
-                            REQUEST_TIMEOUT_SECONDS);
+                    webClient
+                            .extensions()
+                            .delete(
+                                    String.format(
+                                            "/api/v1/targets/%s/recordings/%s",
+                                            getSelfReferenceConnectUrlEncoded(), RECORDING_NAME),
+                                    true,
+                                    REQUEST_TIMEOUT_SECONDS);
             MatcherAssert.assertThat(resp.statusCode(), Matchers.equalTo(204));
         } catch (InterruptedException | ExecutionException | TimeoutException e) {
             logger.error(
@@ -97,13 +101,15 @@ public class UploadRecordingTest extends StandardSelfTest {
     public void shouldLoadRecordingToDatasource() throws Exception {
 
         HttpResponse<Buffer> resp =
-                webClient.post(
-                        String.format(
-                                "/api/v1/targets/%s/recordings/%s/upload",
-                                getSelfReferenceConnectUrlEncoded(), RECORDING_NAME),
-                        true,
-                        null,
-                        0);
+                webClient
+                        .extensions()
+                        .post(
+                                String.format(
+                                        "/api/v1/targets/%s/recordings/%s/upload",
+                                        getSelfReferenceConnectUrlEncoded(), RECORDING_NAME),
+                                true,
+                                null,
+                                0);
 
         MatcherAssert.assertThat(resp.statusCode(), Matchers.equalTo(200));
 

--- a/src/test/java/itest/util/Utils.java
+++ b/src/test/java/itest/util/Utils.java
@@ -92,56 +92,38 @@ public class Utils {
 
     public static class TestWebClient extends WebClientBase {
 
+        private final RedirectExtensions extensions;
+
         public TestWebClient(HttpClient client, WebClientOptions options) {
             super(client, options);
+            this.extensions = new RedirectExtensionsImpl();
         }
 
         public RedirectExtensions extensions() {
-            return new RedirectExtensions() {
-                public HttpResponse<Buffer> post(
-                        String url, boolean authentication, MultiMap form, int timeout)
-                        throws InterruptedException, ExecutionException, TimeoutException {
-                    CompletableFuture<HttpResponse<Buffer>> future = new CompletableFuture<>();
-                    RequestOptions options = new RequestOptions().setURI(url);
-                    HttpRequest<Buffer> req = TestWebClient.this.request(HttpMethod.POST, options);
-                    if (authentication) {
-                        req.basicAuthentication("user", "pass");
-                    }
-                    if (form != null) {
-                        req.sendForm(
-                                form,
-                                ar -> {
-                                    if (ar.succeeded()) {
-                                        future.complete(ar.result());
-                                    } else {
-                                        future.completeExceptionally(ar.cause());
-                                    }
-                                });
-                    } else {
-                        req.send(
-                                ar -> {
-                                    if (ar.succeeded()) {
-                                        future.complete(ar.result());
-                                    } else {
-                                        future.completeExceptionally(ar.cause());
-                                    }
-                                });
-                    }
-                    if (future.get().statusCode() == 308) {
-                        return post(future.get().getHeader("Location"), true, form, timeout);
-                    }
-                    return future.get(timeout, TimeUnit.SECONDS);
-                }
+            return extensions;
+        }
 
-                public HttpResponse<Buffer> delete(String url, boolean authentication, int timeout)
-                        throws InterruptedException, ExecutionException, TimeoutException {
-                    CompletableFuture<HttpResponse<Buffer>> future = new CompletableFuture<>();
-                    RequestOptions options = new RequestOptions().setURI(url);
-                    HttpRequest<Buffer> req =
-                            TestWebClient.this.request(HttpMethod.DELETE, options);
-                    if (authentication) {
-                        req.basicAuthentication("user", "pass");
-                    }
+        private class RedirectExtensionsImpl implements RedirectExtensions {
+            public HttpResponse<Buffer> post(
+                    String url, boolean authentication, MultiMap form, int timeout)
+                    throws InterruptedException, ExecutionException, TimeoutException {
+                CompletableFuture<HttpResponse<Buffer>> future = new CompletableFuture<>();
+                RequestOptions options = new RequestOptions().setURI(url);
+                HttpRequest<Buffer> req = TestWebClient.this.request(HttpMethod.POST, options);
+                if (authentication) {
+                    req.basicAuthentication("user", "pass");
+                }
+                if (form != null) {
+                    req.sendForm(
+                            form,
+                            ar -> {
+                                if (ar.succeeded()) {
+                                    future.complete(ar.result());
+                                } else {
+                                    future.completeExceptionally(ar.cause());
+                                }
+                            });
+                } else {
                     req.send(
                             ar -> {
                                 if (ar.succeeded()) {
@@ -150,12 +132,34 @@ public class Utils {
                                     future.completeExceptionally(ar.cause());
                                 }
                             });
-                    if (future.get().statusCode() == 308) {
-                        return delete(future.get().getHeader("Location"), true, timeout);
-                    }
-                    return future.get(timeout, TimeUnit.SECONDS);
                 }
-            };
+                if (future.get().statusCode() == 308) {
+                    return post(future.get().getHeader("Location"), true, form, timeout);
+                }
+                return future.get(timeout, TimeUnit.SECONDS);
+            }
+
+            public HttpResponse<Buffer> delete(String url, boolean authentication, int timeout)
+                    throws InterruptedException, ExecutionException, TimeoutException {
+                CompletableFuture<HttpResponse<Buffer>> future = new CompletableFuture<>();
+                RequestOptions options = new RequestOptions().setURI(url);
+                HttpRequest<Buffer> req = TestWebClient.this.request(HttpMethod.DELETE, options);
+                if (authentication) {
+                    req.basicAuthentication("user", "pass");
+                }
+                req.send(
+                        ar -> {
+                            if (ar.succeeded()) {
+                                future.complete(ar.result());
+                            } else {
+                                future.completeExceptionally(ar.cause());
+                            }
+                        });
+                if (future.get().statusCode() == 308) {
+                    return delete(future.get().getHeader("Location"), true, timeout);
+                }
+                return future.get(timeout, TimeUnit.SECONDS);
+            }
         }
     }
 }


### PR DESCRIPTION
# Welcome to Cryostat3! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat3/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] [Signed all commits using a GPG signature](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#gpg-commit-signature-verification)

**To recreate commits with GPG signature** `git fetch upstream && git rebase --force --gpg-sign upstream/main`
_______________________________________________

Related to #150

## Description of the change:
Refactors redirect handling utility methods into a WebClient extension

## Motivation for the change:
Slight clean up for encapsulation and clarify between what is a base webclient capability versus what is an extension for our integration tests only
