### PR TITLE
feat(custom_targets): handle embedded credentials, enable tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -55,7 +55,6 @@
     <surefire.rerunFailingTestsCount>2</surefire.rerunFailingTestsCount>
     <failsafe-plugin.version>3.2.3</failsafe-plugin.version>
     <failsafe.rerunFailingTestsCount>${surefire.rerunFailingTestsCount}</failsafe.rerunFailingTestsCount>
-    <com.google.code.gson.version>2.10.1</com.google.code.gson.version><!-- TODO drop this -->
   </properties>
   <dependencyManagement>
     <dependencies>
@@ -229,12 +228,6 @@
       <artifactId>spotbugs-annotations</artifactId>
       <version>${com.github.spotbugs.version}</version>
       <scope>provided</scope>
-    </dependency>
-    <dependency>
-      <groupId>com.google.code.gson</groupId>
-      <artifactId>gson</artifactId>
-      <version>${com.google.code.gson.version}</version>
-      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>io.rest-assured</groupId>

--- a/smoketest/compose/sample-apps.yml
+++ b/smoketest/compose/sample-apps.yml
@@ -97,7 +97,7 @@ services:
     expose:
       - "9977"
     environment:
-      JAVA_OPTS: "-Dquarkus.http.host=0.0.0.0 -Djava.util.logging.manager=org.jboss.logmanager.LogManager -javaagent:/deployments/app/cryostat-agent.jar"
+      JAVA_OPTS_APPEND: "-Dquarkus.http.host=0.0.0.0 -Djava.util.logging.manager=org.jboss.logmanager.LogManager -javaagent:/deployments/app/cryostat-agent.jar"
       QUARKUS_HTTP_PORT: 10010
       ORG_ACME_CRYOSTATSERVICE_ENABLED: "false"
       CRYOSTAT_AGENT_APP_NAME: quarkus-test-agent

--- a/smoketest/compose/sample-apps.yml
+++ b/smoketest/compose/sample-apps.yml
@@ -1,6 +1,6 @@
 version: "3"
 services:
-  sample-app:
+  sample-app-1:
     depends_on:
       cryostat:
         condition: service_healthy
@@ -12,9 +12,9 @@ services:
       CRYOSTAT_AGENT_APP_NAME: "vertx-fib-demo-1"
       CRYOSTAT_AGENT_WEBCLIENT_SSL_TRUST_ALL: "true"
       CRYOSTAT_AGENT_WEBCLIENT_SSL_VERIFY_HOSTNAME: "false"
-      CRYOSTAT_AGENT_WEBSERVER_HOST: "sample-app"
+      CRYOSTAT_AGENT_WEBSERVER_HOST: "sample-app-1"
       CRYOSTAT_AGENT_WEBSERVER_PORT: "8910"
-      CRYOSTAT_AGENT_CALLBACK: "http://sample-app:8910/"
+      CRYOSTAT_AGENT_CALLBACK: "http://sample-app-1:8910/"
       CRYOSTAT_AGENT_BASEURI: "http://cryostat:8181/"
       CRYOSTAT_AGENT_TRUST_ALL: "true"
       CRYOSTAT_AGENT_AUTHORIZATION: "Basic dXNlcjpwYXNz"
@@ -22,8 +22,65 @@ services:
       - "8081:8081"
     labels:
       io.cryostat.discovery: "true"
-      io.cryostat.jmxHost: "sample-app"
+      io.cryostat.jmxHost: "sample-app-1"
       io.cryostat.jmxPort: "9093"
+    restart: always
+    healthcheck:
+      test: curl --fail http://localhost:8081 || exit 1
+      interval: 10s
+      retries: 3
+      start_period: 10s
+      timeout: 5s
+  sample-app-2:
+    depends_on:
+      cryostat:
+        condition: service_healthy
+    image: quay.io/andrewazores/vertx-fib-demo:0.13.0
+    hostname: vertx-fib-demo-2
+    environment:
+      HTTP_PORT: 8082
+      JMX_PORT: 9094
+      USE_AUTH: "true"
+      CRYOSTAT_AGENT_APP_NAME: "vertx-fib-demo-2"
+      CRYOSTAT_AGENT_WEBCLIENT_SSL_TRUST_ALL: "true"
+      CRYOSTAT_AGENT_WEBCLIENT_SSL_VERIFY_HOSTNAME: "false"
+      CRYOSTAT_AGENT_WEBSERVER_HOST: "sample-app-2"
+      CRYOSTAT_AGENT_WEBSERVER_PORT: "8911"
+      CRYOSTAT_AGENT_CALLBACK: "http://sample-app-2:8911/"
+      CRYOSTAT_AGENT_BASEURI: "http://cryostat:8181/"
+      CRYOSTAT_AGENT_TRUST_ALL: "true"
+      CRYOSTAT_AGENT_AUTHORIZATION: "Basic dXNlcjpwYXNz"
+    ports:
+      - "8082:8082"
+    restart: always
+    healthcheck:
+      test: curl --fail http://localhost:8081 || exit 1
+      interval: 10s
+      retries: 3
+      start_period: 10s
+      timeout: 5s
+  sample-app-3:
+    depends_on:
+      cryostat:
+        condition: service_healthy
+    image: quay.io/andrewazores/vertx-fib-demo:0.13.0
+    hostname: vertx-fib-demo-3
+    environment:
+      HTTP_PORT: 8083
+      JMX_PORT: 9095
+      USE_AUTH: "true"
+      USE_SSL: "true"
+      CRYOSTAT_AGENT_APP_NAME: "vertx-fib-demo-3"
+      CRYOSTAT_AGENT_WEBCLIENT_SSL_TRUST_ALL: "true"
+      CRYOSTAT_AGENT_WEBCLIENT_SSL_VERIFY_HOSTNAME: "false"
+      CRYOSTAT_AGENT_WEBSERVER_HOST: "sample-app-3"
+      CRYOSTAT_AGENT_WEBSERVER_PORT: "8910"
+      CRYOSTAT_AGENT_CALLBACK: "http://sample-app-3:8912/"
+      CRYOSTAT_AGENT_BASEURI: "http://cryostat:8181/"
+      CRYOSTAT_AGENT_TRUST_ALL: "true"
+      CRYOSTAT_AGENT_AUTHORIZATION: "Basic dXNlcjpwYXNz"
+    ports:
+      - "8083:8083"
     restart: always
     healthcheck:
       test: curl --fail http://localhost:8081 || exit 1

--- a/smoketest/k8s/sample-app-1-deployment.yaml
+++ b/smoketest/k8s/sample-app-1-deployment.yaml
@@ -3,28 +3,28 @@ kind: Deployment
 metadata:
   annotations:
     io.cryostat.discovery: "true"
-    io.cryostat.jmxHost: sample-app
+    io.cryostat.jmxHost: sample-app-1
     io.cryostat.jmxPort: "9093"
   creationTimestamp: null
   labels:
-    io.kompose.service: sample-app
-  name: sample-app
+    io.kompose.service: sample-app-1
+  name: sample-app-1
 spec:
   replicas: 1
   selector:
     matchLabels:
-      io.kompose.service: sample-app
+      io.kompose.service: sample-app-1
   strategy: {}
   template:
     metadata:
       annotations:
         io.cryostat.discovery: "true"
-        io.cryostat.jmxHost: sample-app
+        io.cryostat.jmxHost: sample-app-1
         io.cryostat.jmxPort: "9093"
       creationTimestamp: null
       labels:
         io.kompose.network/compose-default: "true"
-        io.kompose.service: sample-app
+        io.kompose.service: sample-app-1
     spec:
       containers:
         - env:
@@ -35,7 +35,7 @@ spec:
             - name: CRYOSTAT_AGENT_BASEURI
               value: http://cryostat:8181/
             - name: CRYOSTAT_AGENT_CALLBACK
-              value: http://sample-app:8910/
+              value: http://sample-app-1:8910/
             - name: CRYOSTAT_AGENT_TRUST_ALL
               value: "true"
             - name: CRYOSTAT_AGENT_WEBCLIENT_SSL_TRUST_ALL
@@ -43,7 +43,7 @@ spec:
             - name: CRYOSTAT_AGENT_WEBCLIENT_SSL_VERIFY_HOSTNAME
               value: "false"
             - name: CRYOSTAT_AGENT_WEBSERVER_HOST
-              value: sample-app
+              value: sample-app-1
             - name: CRYOSTAT_AGENT_WEBSERVER_PORT
               value: "8910"
             - name: HTTP_PORT
@@ -59,7 +59,7 @@ spec:
             initialDelaySeconds: 10
             periodSeconds: 10
             timeoutSeconds: 5
-          name: sample-app
+          name: sample-app-1
           ports:
             - containerPort: 8081
               hostPort: 8081

--- a/smoketest/k8s/sample-app-1-service.yaml
+++ b/smoketest/k8s/sample-app-1-service.yaml
@@ -3,18 +3,18 @@ kind: Service
 metadata:
   annotations:
     io.cryostat.discovery: "true"
-    io.cryostat.jmxHost: sample-app
+    io.cryostat.jmxHost: sample-app-1
     io.cryostat.jmxPort: "9093"
   creationTimestamp: null
   labels:
-    io.kompose.service: sample-app
-  name: sample-app
+    io.kompose.service: sample-app-1
+  name: sample-app-1
 spec:
   ports:
     - name: "8081"
       port: 8081
       targetPort: 8081
   selector:
-    io.kompose.service: sample-app
+    io.kompose.service: sample-app-1
 status:
   loadBalancer: {}

--- a/smoketest/k8s/sample-app-2-deployment.yaml
+++ b/smoketest/k8s/sample-app-2-deployment.yaml
@@ -1,0 +1,64 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  creationTimestamp: null
+  labels:
+    io.kompose.service: sample-app-2
+  name: sample-app-2
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      io.kompose.service: sample-app-2
+  strategy: {}
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        io.kompose.network/compose-default: "true"
+        io.kompose.service: sample-app-2
+    spec:
+      containers:
+        - env:
+            - name: CRYOSTAT_AGENT_APP_NAME
+              value: vertx-fib-demo-2
+            - name: CRYOSTAT_AGENT_AUTHORIZATION
+              value: Basic dXNlcjpwYXNz
+            - name: CRYOSTAT_AGENT_BASEURI
+              value: http://cryostat:8181/
+            - name: CRYOSTAT_AGENT_CALLBACK
+              value: http://sample-app-2:8911/
+            - name: CRYOSTAT_AGENT_TRUST_ALL
+              value: "true"
+            - name: CRYOSTAT_AGENT_WEBCLIENT_SSL_TRUST_ALL
+              value: "true"
+            - name: CRYOSTAT_AGENT_WEBCLIENT_SSL_VERIFY_HOSTNAME
+              value: "false"
+            - name: CRYOSTAT_AGENT_WEBSERVER_HOST
+              value: sample-app-2
+            - name: CRYOSTAT_AGENT_WEBSERVER_PORT
+              value: "8911"
+            - name: HTTP_PORT
+              value: "8082"
+            - name: JMX_PORT
+              value: "9094"
+            - name: USE_AUTH
+              value: "true"
+          image: quay.io/andrewazores/vertx-fib-demo:0.13.0
+          livenessProbe:
+            exec:
+              command:
+                - curl --fail http://localhost:8081 || exit 1
+            failureThreshold: 3
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 5
+          name: sample-app-2
+          ports:
+            - containerPort: 8082
+              hostPort: 8082
+              protocol: TCP
+          resources: {}
+      hostname: vertx-fib-demo-2
+      restartPolicy: Always
+status: {}

--- a/smoketest/k8s/sample-app-2-service.yaml
+++ b/smoketest/k8s/sample-app-2-service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  creationTimestamp: null
+  labels:
+    io.kompose.service: sample-app-2
+  name: sample-app-2
+spec:
+  ports:
+    - name: "8082"
+      port: 8082
+      targetPort: 8082
+  selector:
+    io.kompose.service: sample-app-2
+status:
+  loadBalancer: {}

--- a/smoketest/k8s/sample-app-3-deployment.yaml
+++ b/smoketest/k8s/sample-app-3-deployment.yaml
@@ -1,0 +1,66 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  creationTimestamp: null
+  labels:
+    io.kompose.service: sample-app-3
+  name: sample-app-3
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      io.kompose.service: sample-app-3
+  strategy: {}
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        io.kompose.network/compose-default: "true"
+        io.kompose.service: sample-app-3
+    spec:
+      containers:
+        - env:
+            - name: CRYOSTAT_AGENT_APP_NAME
+              value: vertx-fib-demo-3
+            - name: CRYOSTAT_AGENT_AUTHORIZATION
+              value: Basic dXNlcjpwYXNz
+            - name: CRYOSTAT_AGENT_BASEURI
+              value: http://cryostat:8181/
+            - name: CRYOSTAT_AGENT_CALLBACK
+              value: http://sample-app-3:8912/
+            - name: CRYOSTAT_AGENT_TRUST_ALL
+              value: "true"
+            - name: CRYOSTAT_AGENT_WEBCLIENT_SSL_TRUST_ALL
+              value: "true"
+            - name: CRYOSTAT_AGENT_WEBCLIENT_SSL_VERIFY_HOSTNAME
+              value: "false"
+            - name: CRYOSTAT_AGENT_WEBSERVER_HOST
+              value: sample-app-3
+            - name: CRYOSTAT_AGENT_WEBSERVER_PORT
+              value: "8910"
+            - name: HTTP_PORT
+              value: "8083"
+            - name: JMX_PORT
+              value: "9095"
+            - name: USE_AUTH
+              value: "true"
+            - name: USE_SSL
+              value: "true"
+          image: quay.io/andrewazores/vertx-fib-demo:0.13.0
+          livenessProbe:
+            exec:
+              command:
+                - curl --fail http://localhost:8081 || exit 1
+            failureThreshold: 3
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 5
+          name: sample-app-3
+          ports:
+            - containerPort: 8083
+              hostPort: 8083
+              protocol: TCP
+          resources: {}
+      hostname: vertx-fib-demo-3
+      restartPolicy: Always
+status: {}

--- a/smoketest/k8s/sample-app-3-service.yaml
+++ b/smoketest/k8s/sample-app-3-service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  creationTimestamp: null
+  labels:
+    io.kompose.service: sample-app-3
+  name: sample-app-3
+spec:
+  ports:
+    - name: "8083"
+      port: 8083
+      targetPort: 8083
+  selector:
+    io.kompose.service: sample-app-3
+status:
+  loadBalancer: {}

--- a/src/main/java/io/cryostat/ExceptionMappers.java
+++ b/src/main/java/io/cryostat/ExceptionMappers.java
@@ -15,6 +15,8 @@
  */
 package io.cryostat;
 
+import org.openjdk.jmc.rjmx.ConnectionException;
+
 import io.netty.handler.codec.http.HttpResponseStatus;
 import jakarta.persistence.NoResultException;
 import org.hibernate.exception.ConstraintViolationException;
@@ -52,5 +54,10 @@ public class ExceptionMappers {
     @ServerExceptionMapper
     public RestResponse<Void> mapIllegalArgumentException(IllegalArgumentException exception) {
         return RestResponse.status(HttpResponseStatus.BAD_REQUEST.code());
+    }
+
+    @ServerExceptionMapper
+    public RestResponse<Void> mapJmxConnectionException(ConnectionException exception) {
+        return RestResponse.status(HttpResponseStatus.BAD_GATEWAY.code());
     }
 }

--- a/src/main/java/io/cryostat/ExceptionMappers.java
+++ b/src/main/java/io/cryostat/ExceptionMappers.java
@@ -17,6 +17,8 @@ package io.cryostat;
 
 import org.openjdk.jmc.rjmx.ConnectionException;
 
+import io.cryostat.targets.TargetConnectionManager;
+
 import io.netty.handler.codec.http.HttpResponseStatus;
 import jakarta.persistence.NoResultException;
 import org.hibernate.exception.ConstraintViolationException;
@@ -58,6 +60,15 @@ public class ExceptionMappers {
 
     @ServerExceptionMapper
     public RestResponse<Void> mapJmxConnectionException(ConnectionException exception) {
+        return RestResponse.status(HttpResponseStatus.BAD_GATEWAY.code());
+    }
+
+    @ServerExceptionMapper
+    public RestResponse<Void> mapFlightRecorderException(
+            org.openjdk.jmc.rjmx.services.jfr.FlightRecorderException exception) {
+        if (TargetConnectionManager.isJmxAuthFailure(exception)) {
+            return RestResponse.status(HttpResponseStatus.FORBIDDEN.code());
+        }
         return RestResponse.status(HttpResponseStatus.BAD_GATEWAY.code());
     }
 }

--- a/src/main/java/io/cryostat/V2Response.java
+++ b/src/main/java/io/cryostat/V2Response.java
@@ -18,10 +18,18 @@ package io.cryostat;
 import java.util.Objects;
 
 import jakarta.annotation.Nullable;
+import jakarta.ws.rs.core.Response;
 
 public record V2Response(Meta meta, Data data) {
-    public static V2Response json(Object payload, String status) {
-        return new V2Response(new Meta("application/json", status), new Data(payload));
+    public static V2Response json(Response.Status status, Object payload) {
+        Data data;
+        if (status.getFamily().equals(Response.Status.Family.CLIENT_ERROR)
+                || status.getFamily().equals(Response.Status.Family.SERVER_ERROR)) {
+            data = new ErrorData(payload);
+        } else {
+            data = new PayloadData(payload);
+        }
+        return new V2Response(new Meta("application/json", status.getReasonPhrase()), data);
     }
 
     // FIXME the type and status should both come from an enum and be non-null
@@ -32,5 +40,29 @@ public record V2Response(Meta meta, Data data) {
         }
     }
 
-    public record Data(@Nullable Object result) {}
+    interface Data {}
+
+    public static class PayloadData implements Data {
+        @Nullable Object result;
+
+        public PayloadData(Object payload) {
+            this.result = payload;
+        }
+
+        public Object getResult() {
+            return result;
+        }
+    }
+
+    public static class ErrorData implements Data {
+        String reason;
+
+        public ErrorData(Object payload) {
+            this.reason = Objects.requireNonNull(payload).toString();
+        }
+
+        public String getReason() {
+            return reason;
+        }
+    }
 }

--- a/src/main/java/io/cryostat/V2Response.java
+++ b/src/main/java/io/cryostat/V2Response.java
@@ -58,7 +58,11 @@ public record V2Response(Meta meta, Data data) {
         String reason;
 
         public ErrorData(Object payload) {
-            this.reason = Objects.requireNonNull(payload).toString();
+            if (payload instanceof Exception) {
+                this.reason = ((Exception) Objects.requireNonNull(payload)).getMessage();
+            } else {
+                this.reason = Objects.requireNonNull(payload).toString();
+            }
         }
 
         public String getReason() {

--- a/src/main/java/io/cryostat/credentials/Credential.java
+++ b/src/main/java/io/cryostat/credentials/Credential.java
@@ -40,6 +40,10 @@ import org.projectnessie.cel.tools.ScriptException;
 @EntityListeners(Credential.Listener.class)
 public class Credential extends PanacheEntity {
 
+    public static final String CREDENTIALS_STORED = "CredentialsStored";
+    public static final String CREDENTIALS_DELETED = "CredentialsDeleted";
+    public static final String CREDENTIALS_UPDATED = "CredentialsUpdated";
+
     @OneToOne(fetch = FetchType.EAGER, cascade = CascadeType.ALL)
     @JoinColumn(name = "matchExpression")
     public MatchExpression matchExpression;
@@ -58,7 +62,6 @@ public class Credential extends PanacheEntity {
 
     @ApplicationScoped
     static class Listener {
-
         @Inject EventBus bus;
         @Inject MatchExpression.TargetMatcher targetMatcher;
 
@@ -67,7 +70,8 @@ public class Credential extends PanacheEntity {
             bus.publish(
                     MessagingServer.class.getName(),
                     new Notification(
-                            "CredentialsStored", Credentials.notificationResult(credential)));
+                            CREDENTIALS_STORED, Credentials.notificationResult(credential)));
+            bus.publish(CREDENTIALS_STORED, credential);
         }
 
         @PostUpdate
@@ -75,7 +79,8 @@ public class Credential extends PanacheEntity {
             bus.publish(
                     MessagingServer.class.getName(),
                     new Notification(
-                            "CredentialsUpdated", Credentials.notificationResult(credential)));
+                            CREDENTIALS_UPDATED, Credentials.notificationResult(credential)));
+            bus.publish(CREDENTIALS_UPDATED, credential);
         }
 
         @PostRemove
@@ -83,7 +88,8 @@ public class Credential extends PanacheEntity {
             bus.publish(
                     MessagingServer.class.getName(),
                     new Notification(
-                            "CredentialsDeleted", Credentials.notificationResult(credential)));
+                            CREDENTIALS_DELETED, Credentials.notificationResult(credential)));
+            bus.publish(CREDENTIALS_DELETED, credential);
         }
     }
 }

--- a/src/main/java/io/cryostat/credentials/Credentials.java
+++ b/src/main/java/io/cryostat/credentials/Credentials.java
@@ -33,12 +33,12 @@ import jakarta.ws.rs.DELETE;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.POST;
 import jakarta.ws.rs.Path;
+import jakarta.ws.rs.core.Response;
 import org.jboss.logging.Logger;
 import org.jboss.resteasy.reactive.RestForm;
 import org.jboss.resteasy.reactive.RestPath;
 import org.jboss.resteasy.reactive.RestResponse;
 import org.jboss.resteasy.reactive.RestResponse.ResponseBuilder;
-import org.jboss.resteasy.reactive.RestResponse.Status;
 import org.projectnessie.cel.tools.ScriptException;
 
 @Path("/api/v2.2/credentials")
@@ -52,6 +52,7 @@ public class Credentials {
     public V2Response list() {
         List<Credential> credentials = Credential.listAll();
         return V2Response.json(
+                Response.Status.OK,
                 credentials.stream()
                         .map(
                                 c -> {
@@ -63,8 +64,7 @@ public class Credentials {
                                     }
                                 })
                         .filter(Objects::nonNull)
-                        .toList(),
-                Status.OK.toString());
+                        .toList());
     }
 
     @GET
@@ -72,7 +72,7 @@ public class Credentials {
     @Path("/{id}")
     public V2Response get(@RestPath long id) throws ScriptException {
         Credential credential = Credential.find("id", id).singleResult();
-        return V2Response.json(safeMatchedResult(credential, targetMatcher), Status.OK.toString());
+        return V2Response.json(Response.Status.OK, safeMatchedResult(credential, targetMatcher));
     }
 
     @Transactional

--- a/src/main/java/io/cryostat/discovery/CustomDiscovery.java
+++ b/src/main/java/io/cryostat/discovery/CustomDiscovery.java
@@ -23,6 +23,7 @@ import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import io.cryostat.V2Response;
 import io.cryostat.targets.JvmIdException;
 import io.cryostat.targets.Target;
 import io.cryostat.targets.Target.Annotations;
@@ -98,7 +99,9 @@ public class CustomDiscovery {
             }
 
             if (dryrun) {
-                return Response.ok().build();
+                return Response.accepted()
+                        .entity(V2Response.json(target, Response.Status.ACCEPTED.toString()))
+                        .build();
             }
 
             target.activeRecordings = new ArrayList<>();
@@ -115,7 +118,9 @@ public class CustomDiscovery {
             node.persist();
             realm.persist();
 
-            return Response.created(URI.create("/api/v3/targets/" + target.id)).build();
+            return Response.created(URI.create("/api/v3/targets/" + target.id))
+                    .entity(V2Response.json(target, Response.Status.CREATED.toString()))
+                    .build();
         } catch (Exception e) {
             if (ExceptionUtils.indexOfType(e, ConstraintViolationException.class) >= 0) {
                 logger.warn("Invalid target definition", e);

--- a/src/main/java/io/cryostat/discovery/CustomDiscovery.java
+++ b/src/main/java/io/cryostat/discovery/CustomDiscovery.java
@@ -39,6 +39,7 @@ import jakarta.ws.rs.Consumes;
 import jakarta.ws.rs.DELETE;
 import jakarta.ws.rs.POST;
 import jakarta.ws.rs.Path;
+import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.hibernate.exception.ConstraintViolationException;
@@ -77,7 +78,7 @@ public class CustomDiscovery {
     @Transactional(rollbackOn = {JvmIdException.class})
     @POST
     @Path("/api/v2/targets")
-    @Consumes("application/json")
+    @Consumes(MediaType.APPLICATION_JSON)
     @RolesAllowed("write")
     public Response create(Target target, @RestQuery boolean dryrun) {
         try {
@@ -128,7 +129,7 @@ public class CustomDiscovery {
     @Transactional
     @POST
     @Path("/api/v2/targets")
-    @Consumes("multipart/form-data")
+    @Consumes({MediaType.MULTIPART_FORM_DATA, MediaType.APPLICATION_FORM_URLENCODED})
     @RolesAllowed("write")
     public Response create(
             @RestForm URI connectUrl, @RestForm String alias, @RestQuery boolean dryrun) {

--- a/src/main/java/io/cryostat/discovery/CustomDiscovery.java
+++ b/src/main/java/io/cryostat/discovery/CustomDiscovery.java
@@ -46,6 +46,7 @@ import jakarta.ws.rs.POST;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.hibernate.exception.ConstraintViolationException;
 import org.jboss.logging.Logger;
@@ -107,16 +108,19 @@ public class CustomDiscovery {
         target.connectUrl = connectUrl;
         target.alias = alias;
 
-        Credential credential = new Credential();
-        credential.matchExpression =
-                new MatchExpression(
-                        String.format("target.connectUrl == \"%s\"", connectUrl.toString()));
-        credential.username = username;
-        credential.password = password;
-        credential.matchExpression.persist();
-        credential.persist();
+        Credential credential = null;
+        if (StringUtils.isNotBlank(username) && StringUtils.isNotBlank(password)) {
+            credential = new Credential();
+            credential.matchExpression =
+                    new MatchExpression(
+                            String.format("target.connectUrl == \"%s\"", connectUrl.toString()));
+            credential.username = username;
+            credential.password = password;
+            credential.matchExpression.persist();
+            credential.persist();
+        }
 
-        return doCreate(target, Optional.of(credential), dryrun, storeCredentials);
+        return doCreate(target, Optional.ofNullable(credential), dryrun, storeCredentials);
     }
 
     @Transactional

--- a/src/main/java/io/cryostat/discovery/CustomDiscovery.java
+++ b/src/main/java/io/cryostat/discovery/CustomDiscovery.java
@@ -201,8 +201,8 @@ public class CustomDiscovery {
         Target target = Target.find("id", id).singleResult();
         DiscoveryNode realm = DiscoveryNode.getRealm(REALM).orElseThrow();
         realm.children.remove(target.discoveryNode);
-        target.delete();
         realm.persist();
+        target.delete();
         return Response.noContent().build();
     }
 

--- a/src/main/java/io/cryostat/discovery/Discovery.java
+++ b/src/main/java/io/cryostat/discovery/Discovery.java
@@ -110,7 +110,7 @@ public class Discovery {
     @Transactional
     @POST
     @Path("/api/v2.2/discovery")
-    @Consumes("application/json")
+    @Consumes(MediaType.APPLICATION_JSON)
     @RolesAllowed("write")
     public Map<String, Object> register(JsonObject body) throws URISyntaxException {
         String id = body.getString("id");
@@ -147,7 +147,7 @@ public class Discovery {
     @Transactional
     @POST
     @Path("/api/v2.2/discovery/{id}")
-    @Consumes("application/json")
+    @Consumes(MediaType.APPLICATION_JSON)
     @PermitAll
     public Map<String, Map<String, String>> publish(
             @RestPath UUID id, @RestQuery String token, List<DiscoveryNode> body) {

--- a/src/main/java/io/cryostat/events/Events.java
+++ b/src/main/java/io/cryostat/events/Events.java
@@ -37,7 +37,6 @@ import org.jboss.logging.Logger;
 import org.jboss.resteasy.reactive.RestPath;
 import org.jboss.resteasy.reactive.RestQuery;
 import org.jboss.resteasy.reactive.RestResponse;
-import org.jboss.resteasy.reactive.RestResponse.Status;
 
 @Path("")
 public class Events {
@@ -65,7 +64,7 @@ public class Events {
     @RolesAllowed("read")
     public V2Response listEventsV2(@RestPath URI connectUrl, @RestQuery String q) throws Exception {
         return V2Response.json(
-                searchEvents(Target.getTargetByConnectUrl(connectUrl), q), Status.OK.toString());
+                Response.Status.OK, searchEvents(Target.getTargetByConnectUrl(connectUrl), q));
     }
 
     @GET

--- a/src/main/java/io/cryostat/expressions/MatchExpressionEvaluator.java
+++ b/src/main/java/io/cryostat/expressions/MatchExpressionEvaluator.java
@@ -37,6 +37,7 @@ import io.quarkus.cache.CaffeineCache;
 import io.quarkus.cache.CompositeCacheKey;
 import io.quarkus.vertx.ConsumeEvent;
 import io.smallrye.common.annotation.Blocking;
+import jakarta.annotation.Nullable;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import jdk.jfr.Category;
@@ -198,13 +199,12 @@ public class MatchExpressionEvaluator {
     private static record SimplifiedTarget(
             String connectUrl,
             String alias,
-            String jvmId,
+            @Nullable String jvmId,
             Map<String, String> labels,
             Target.Annotations annotations) {
         SimplifiedTarget {
             Objects.requireNonNull(connectUrl);
             Objects.requireNonNull(alias);
-            Objects.requireNonNull(jvmId);
             if (labels == null) {
                 labels = Collections.emptyMap();
             }

--- a/src/main/java/io/cryostat/expressions/MatchExpressions.java
+++ b/src/main/java/io/cryostat/expressions/MatchExpressions.java
@@ -32,7 +32,7 @@ import jakarta.ws.rs.GET;
 import jakarta.ws.rs.NotFoundException;
 import jakarta.ws.rs.POST;
 import jakarta.ws.rs.Path;
-import jakarta.ws.rs.core.Response.Status;
+import jakarta.ws.rs.core.Response;
 import org.jboss.logging.Logger;
 import org.jboss.resteasy.reactive.RestPath;
 import org.projectnessie.cel.tools.ScriptException;
@@ -53,7 +53,7 @@ public class MatchExpressions {
         var matched =
                 targetMatcher.match(
                         new MatchExpression(requestData.matchExpression), requestData.targets);
-        return V2Response.json(matched, Status.OK.toString());
+        return V2Response.json(Response.Status.OK, matched);
     }
 
     @GET

--- a/src/main/java/io/cryostat/recordings/Recordings.java
+++ b/src/main/java/io/cryostat/recordings/Recordings.java
@@ -536,12 +536,12 @@ public class Recordings {
             return Response.status(Response.Status.CREATED)
                     .entity(
                             V2Response.json(
-                                    recordingHelper.toExternalForm(recording),
-                                    RestResponse.Status.CREATED.toString()))
+                                    Response.Status.CREATED,
+                                    recordingHelper.toExternalForm(recording)))
                     .build();
         } catch (SnapshotCreationException sce) {
             return Response.status(Response.Status.ACCEPTED)
-                    .entity(V2Response.json(null, RestResponse.Status.ACCEPTED.toString()))
+                    .entity(V2Response.json(Response.Status.ACCEPTED, null))
                     .build();
         }
     }

--- a/src/main/java/io/cryostat/rules/Rules.java
+++ b/src/main/java/io/cryostat/rules/Rules.java
@@ -62,7 +62,7 @@ public class Rules {
     @Transactional
     @POST
     @RolesAllowed("write")
-    @Consumes({MediaType.APPLICATION_JSON})
+    @Consumes(MediaType.APPLICATION_JSON)
     public RestResponse<V2Response> create(Rule rule) {
         // TODO validate the incoming rule
         if (rule == null) {
@@ -83,7 +83,7 @@ public class Rules {
     @PATCH
     @RolesAllowed("write")
     @Path("/{name}")
-    @Consumes("application/json")
+    @Consumes(MediaType.APPLICATION_JSON)
     public RestResponse<V2Response> update(
             @RestPath String name, @RestQuery boolean clean, JsonObject body) {
         Rule rule = Rule.getByName(name);

--- a/src/main/java/io/cryostat/rules/Rules.java
+++ b/src/main/java/io/cryostat/rules/Rules.java
@@ -39,7 +39,6 @@ import org.jboss.resteasy.reactive.RestPath;
 import org.jboss.resteasy.reactive.RestQuery;
 import org.jboss.resteasy.reactive.RestResponse;
 import org.jboss.resteasy.reactive.RestResponse.ResponseBuilder;
-import org.jboss.resteasy.reactive.RestResponse.Status;
 
 @Path("/api/v2/rules")
 public class Rules {
@@ -49,14 +48,14 @@ public class Rules {
     @GET
     @RolesAllowed("read")
     public RestResponse<V2Response> list() {
-        return RestResponse.ok(V2Response.json(Rule.listAll(), Status.OK.getReasonPhrase()));
+        return RestResponse.ok(V2Response.json(Response.Status.OK, Rule.listAll()));
     }
 
     @GET
     @RolesAllowed("read")
     @Path("/{name}")
     public RestResponse<V2Response> get(@RestPath String name) {
-        return RestResponse.ok(V2Response.json(Rule.getByName(name), Status.OK.getReasonPhrase()));
+        return RestResponse.ok(V2Response.json(Response.Status.OK, Rule.getByName(name)));
     }
 
     @Transactional
@@ -75,7 +74,7 @@ public class Rules {
         rule.persist();
         return ResponseBuilder.create(
                         Response.Status.CREATED,
-                        V2Response.json(rule.name, Status.CREATED.toString()))
+                        V2Response.json(Response.Status.CREATED, rule.name))
                 .build();
     }
 
@@ -95,7 +94,7 @@ public class Rules {
         rule.enabled = enabled;
         rule.persist();
 
-        return ResponseBuilder.ok(V2Response.json(rule, Status.OK.toString())).build();
+        return ResponseBuilder.ok(V2Response.json(Response.Status.OK, rule)).build();
     }
 
     @Transactional
@@ -142,7 +141,7 @@ public class Rules {
             bus.send(Rule.RULE_ADDRESS + "?clean", rule);
         }
         rule.delete();
-        return RestResponse.ok(V2Response.json(null, Status.OK.toString()));
+        return RestResponse.ok(V2Response.json(Response.Status.OK, null));
     }
 
     static class RuleExistsException extends ClientErrorException {

--- a/src/main/java/io/cryostat/security/Auth.java
+++ b/src/main/java/io/cryostat/security/Auth.java
@@ -27,6 +27,7 @@ import jakarta.ws.rs.POST;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.Context;
+import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 import org.jboss.logging.Logger;
 
@@ -38,7 +39,7 @@ public class Auth {
     @POST
     @Path("/api/v2.1/logout")
     @PermitAll
-    @Produces("application/json")
+    @Produces(MediaType.APPLICATION_JSON)
     public Response logout(@Context RoutingContext context) {
         HttpAuthenticator authenticator = context.get(HttpAuthenticator.class.getName());
         return authenticator
@@ -62,7 +63,7 @@ public class Auth {
     @POST
     @Path("/api/v2.1/auth")
     @PermitAll
-    @Produces("application/json")
+    @Produces(MediaType.APPLICATION_JSON)
     public Response login(@Context RoutingContext context) {
         HttpAuthenticator authenticator = context.get(HttpAuthenticator.class.getName());
         return authenticator

--- a/src/main/java/io/cryostat/targets/Target.java
+++ b/src/main/java/io/cryostat/targets/Target.java
@@ -233,11 +233,9 @@ public class Target extends PanacheEntity {
                         connectionManager.executeConnectedTask(target, conn -> conn.getJvmId());
             } catch (Exception e) {
                 // TODO tolerate this in the condition that the connection failed because of JMX
-                // auth.
-                // In that instance then persist the entity with a null jvmId, but listen for new
-                // Credentials
-                // and test them against any targets with null jvmIds to see if we can populate
-                // them.
+                // auth. In that instance then persist the entity with a null jvmId, but listen for
+                // new Credentials and test them against any targets with null jvmIds to see if we
+                // can populate them.
                 throw new JvmIdException(e);
             }
         }

--- a/src/main/java/io/cryostat/targets/TargetConnectionManager.java
+++ b/src/main/java/io/cryostat/targets/TargetConnectionManager.java
@@ -188,6 +188,15 @@ public class TargetConnectionManager {
         }
     }
 
+    @Blocking
+    public <T> T executeDirect(
+            Target target, Optional<Credential> credentials, ConnectedTask<T> task)
+            throws Exception {
+        try (var conn = connect(target.connectUrl, credentials)) {
+            return task.execute(conn);
+        }
+    }
+
     /**
      * Mark a connection as still in use by the consumer. Connections expire from cache and are
      * automatically closed after {@link NetworkModule.TARGET_CACHE_TTL}. For long-running

--- a/src/main/java/io/cryostat/util/HttpStatusCodeIdentifier.java
+++ b/src/main/java/io/cryostat/util/HttpStatusCodeIdentifier.java
@@ -15,27 +15,29 @@
  */
 package io.cryostat.util;
 
+import jakarta.ws.rs.core.Response;
+
 public final class HttpStatusCodeIdentifier {
 
     private HttpStatusCodeIdentifier() {}
 
     public static boolean isInformationCode(int code) {
-        return 100 <= code && code < 200;
+        return Response.Status.Family.familyOf(code).equals(Response.Status.Family.INFORMATIONAL);
     }
 
     public static boolean isSuccessCode(int code) {
-        return 200 <= code && code < 300;
+        return Response.Status.Family.familyOf(code).equals(Response.Status.Family.SUCCESSFUL);
     }
 
     public static boolean isRedirectCode(int code) {
-        return 300 <= code && code < 400;
+        return Response.Status.Family.familyOf(code).equals(Response.Status.Family.REDIRECTION);
     }
 
     public static boolean isClientErrorCode(int code) {
-        return 400 <= code && code < 500;
+        return Response.Status.Family.familyOf(code).equals(Response.Status.Family.CLIENT_ERROR);
     }
 
     public static boolean isServerErrorCode(int code) {
-        return 500 <= code && code < 600;
+        return Response.Status.Family.familyOf(code).equals(Response.Status.Family.SERVER_ERROR);
     }
 }

--- a/src/main/java/io/cryostat/ws/MessagingServer.java
+++ b/src/main/java/io/cryostat/ws/MessagingServer.java
@@ -16,15 +16,23 @@
 package io.cryostat.ws;
 
 import java.io.IOException;
+import java.nio.channels.ClosedChannelException;
 import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.CopyOnWriteArraySet;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.quarkus.runtime.ShutdownEvent;
+import io.quarkus.runtime.StartupEvent;
 import io.quarkus.vertx.ConsumeEvent;
 import io.smallrye.common.annotation.Blocking;
 import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.event.Observes;
 import jakarta.inject.Inject;
 import jakarta.websocket.OnClose;
 import jakarta.websocket.OnError;
@@ -32,6 +40,8 @@ import jakarta.websocket.OnMessage;
 import jakarta.websocket.OnOpen;
 import jakarta.websocket.Session;
 import jakarta.websocket.server.ServerEndpoint;
+import org.apache.commons.lang3.exception.ExceptionUtils;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.jboss.logging.Logger;
 
 @ApplicationScoped
@@ -39,8 +49,14 @@ import org.jboss.logging.Logger;
 public class MessagingServer {
 
     @Inject Logger logger;
-    private final Set<Session> sessions = ConcurrentHashMap.newKeySet();
+    private final ExecutorService executor = Executors.newSingleThreadExecutor();
+    private final BlockingQueue<Notification> msgQ;
+    private final Set<Session> sessions = new CopyOnWriteArraySet<>();
     private final ObjectMapper mapper = new ObjectMapper();
+
+    MessagingServer(@ConfigProperty(name = "cryostat.messaging.queue.size") int capacity) {
+        this.msgQ = new ArrayBlockingQueue<>(capacity);
+    }
 
     // TODO implement authentication check
     @OnOpen
@@ -62,42 +78,70 @@ public class MessagingServer {
             logger.errorv("Closing session {0}", session.getId());
             session.close();
         } catch (IOException ioe) {
-            ioe.printStackTrace(System.err);
             logger.error("Unable to close session", ioe);
         }
     }
 
+    void start(@Observes StartupEvent evt) {
+        logger.infov("Starting {0} executor", getClass().getName());
+        executor.execute(
+                () -> {
+                    while (!executor.isShutdown()) {
+                        try {
+                            var notification = msgQ.take();
+                            var map =
+                                    Map.of(
+                                            "meta",
+                                            Map.of("category", notification.category()),
+                                            "message",
+                                            notification.message());
+                            logger.infov("Broadcasting: {0}", map);
+                            sessions.forEach(
+                                    s -> {
+                                        try {
+                                            s.getBasicRemote()
+                                                    .sendText(mapper.writeValueAsString(map));
+                                        } catch (JsonProcessingException e) {
+                                            logger.error("Unable to serialize message to JSON", e);
+                                        } catch (IOException e) {
+                                            // ignored simple ClosedChannelExceptions since this
+                                            // just means the connection has already been closed,
+                                            // either due to an error or the client closing it. This
+                                            // does not actually indicate a problem
+                                            if (!ExceptionUtils.getThrowableList(e).stream()
+                                                    .anyMatch(
+                                                            t ->
+                                                                    t
+                                                                            instanceof
+                                                                            ClosedChannelException)) {
+                                                logger.errorv(
+                                                        "Unable to send message to {0}", s.getId());
+                                                logger.error(e);
+                                            }
+                                        }
+                                    });
+                        } catch (InterruptedException ie) {
+                            logger.warn(ie);
+                            break;
+                        }
+                    }
+                });
+    }
+
+    void shutdown(@Observes ShutdownEvent evt) {
+        logger.infov("Shutting down {0} executor", getClass().getName());
+        executor.shutdown();
+        msgQ.clear();
+    }
+
     @OnMessage
     public void onMessage(Session session, String message) {
-        logger.infov("[{0}] message: {1}", session.getId(), message);
+        logger.infov("{0} message: \"{1}\"", session.getId(), message);
     }
 
     @ConsumeEvent
     @Blocking
     void broadcast(Notification notification) {
-        var map =
-                Map.of(
-                        "meta",
-                        Map.of("category", notification.category()),
-                        "message",
-                        notification.message());
-        logger.infov("Broadcasting: {0}", map);
-        sessions.forEach(
-                s -> {
-                    try {
-                        s.getAsyncRemote()
-                                .sendObject(
-                                        mapper.writeValueAsString(map),
-                                        result -> {
-                                            if (result.getException() != null) {
-                                                logger.warn(
-                                                        "Unable to send message: "
-                                                                + result.getException());
-                                            }
-                                        });
-                    } catch (JsonProcessingException e) {
-                        logger.error("Unable to send message", e);
-                    }
-                });
+        msgQ.add(notification);
     }
 }

--- a/src/main/resources/application-test.properties
+++ b/src/main/resources/application-test.properties
@@ -5,7 +5,7 @@ cryostat.discovery.podman.enabled=true
 cryostat.discovery.docker.enabled=true
 cryostat.auth.disabled=true
 
-quarkus.test.env.JAVA_OPTS_APPEND=-Dquarkus.http.host=0.0.0.0 -Djava.util.logging.manager=org.jboss.logmanager.LogManager -Dcom.sun.management.jmxremote.autodiscovery=true -Dcom.sun.management.jmxremote -Dcom.sun.management.jmxremote.port=9091 -Dcom.sun.management.jmxremote.rmi.port=9091 -Djava.rmi.server.hostname=127.0.0.1 -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.local.only=false
+quarkus.test.env.JAVA_OPTS_APPEND=-Dquarkus.http.host=0.0.0.0 -Djava.util.logging.manager=org.jboss.logmanager.LogManager -Dcom.sun.management.jmxremote -Dcom.sun.management.jmxremote.port=9091 -Dcom.sun.management.jmxremote.rmi.port=9091 -Djava.rmi.server.hostname=127.0.0.1 -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.local.only=false
 
 quarkus.datasource.devservices.enabled=true
 quarkus.datasource.devservices.image-name=quay.io/cryostat/cryostat-db

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -4,6 +4,8 @@ cryostat.discovery.podman.enabled=false
 cryostat.discovery.docker.enabled=false
 quarkus.test.integration-test-profile=test
 
+cryostat.messaging.queue.size=1024
+
 quarkus.http.auth.proactive=false
 quarkus.http.host=0.0.0.0
 quarkus.http.port=8181

--- a/src/test/java/itest/CustomTargetsTest.java
+++ b/src/test/java/itest/CustomTargetsTest.java
@@ -239,14 +239,13 @@ public class CustomTargetsTest extends StandardSelfTest {
         //         storedCredential.numMatchingTargets, Matchers.equalTo(Integer.valueOf(1)));
 
         JsonObject result2 = resultFuture2.get();
-        JsonObject modifiedDiscoveryEvent = result2.getJsonObject("message").getJsonObject("event");
+        JsonObject foundDiscoveryEvent = result2.getJsonObject("message").getJsonObject("event");
+        MatcherAssert.assertThat(foundDiscoveryEvent.getString("kind"), Matchers.equalTo("FOUND"));
         MatcherAssert.assertThat(
-                modifiedDiscoveryEvent.getString("kind"), Matchers.equalTo("FOUND"));
-        MatcherAssert.assertThat(
-                modifiedDiscoveryEvent.getJsonObject("serviceRef").getString("connectUrl"),
+                foundDiscoveryEvent.getJsonObject("serviceRef").getString("connectUrl"),
                 Matchers.equalTo(SELF_JMX_URL));
         MatcherAssert.assertThat(
-                modifiedDiscoveryEvent.getJsonObject("serviceRef").getString("alias"),
+                foundDiscoveryEvent.getJsonObject("serviceRef").getString("alias"),
                 Matchers.equalTo(alias));
 
         HttpResponse<Buffer> listResponse =

--- a/src/test/java/itest/SnapshotTest.java
+++ b/src/test/java/itest/SnapshotTest.java
@@ -15,6 +15,7 @@
  */
 package itest;
 
+import java.net.URI;
 import java.time.Instant;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
@@ -277,7 +278,13 @@ public class SnapshotTest extends StandardSelfTest {
                 Matchers.equalTo("/api/v3/activedownload/" + result.getLong("id")));
         MatcherAssert.assertThat(
                 result.getString("reportUrl"),
-                Matchers.equalTo("/api/v3/targets/1/reports/" + result.getLong("remoteId")));
+                Matchers.equalTo(
+                        URI.create(
+                                        String.format(
+                                                "%s/reports/%d",
+                                                selfCustomTargetLocation,
+                                                result.getLong("remoteId")))
+                                .getPath()));
         MatcherAssert.assertThat(result.getLong("expiry"), Matchers.nullValue());
 
         webClient

--- a/src/test/java/itest/SnapshotTest.java
+++ b/src/test/java/itest/SnapshotTest.java
@@ -149,7 +149,13 @@ public class SnapshotTest extends StandardSelfTest {
         form.add("recordingName", TEST_RECORDING_NAME);
         form.add("duration", "5");
         form.add("events", "template=ALL");
-        webClient.extensions().post(String.format("%s/recordings", v1RequestUrl()), true, form, 5);
+        webClient
+                .extensions()
+                .post(
+                        String.format("%s/recordings", v1RequestUrl()),
+                        true,
+                        form,
+                        REQUEST_TIMEOUT_SECONDS);
 
         // Create a snapshot recording of all events at that time
         webClient
@@ -177,7 +183,7 @@ public class SnapshotTest extends StandardSelfTest {
                 .delete(
                         String.format("%s/recordings/%s", v1RequestUrl(), TEST_RECORDING_NAME),
                         true,
-                        5);
+                        REQUEST_TIMEOUT_SECONDS);
         webClient
                 .extensions()
                 .delete(
@@ -186,7 +192,7 @@ public class SnapshotTest extends StandardSelfTest {
                                 v1RequestUrl(),
                                 snapshotName.get(REQUEST_TIMEOUT_SECONDS, TimeUnit.SECONDS)),
                         true,
-                        5);
+                        REQUEST_TIMEOUT_SECONDS);
     }
 
     @Test
@@ -217,7 +223,13 @@ public class SnapshotTest extends StandardSelfTest {
         form.add("recordingName", TEST_RECORDING_NAME);
         form.add("duration", "5");
         form.add("events", "template=ALL");
-        webClient.extensions().post(String.format("%s/recordings", v1RequestUrl()), true, form, 5);
+        webClient
+                .extensions()
+                .post(
+                        String.format("%s/recordings", v1RequestUrl()),
+                        true,
+                        form,
+                        REQUEST_TIMEOUT_SECONDS);
 
         // Create a snapshot recording of all events at that time
         CompletableFuture<JsonObject> createResponse = new CompletableFuture<>();
@@ -273,7 +285,7 @@ public class SnapshotTest extends StandardSelfTest {
                 .delete(
                         String.format("%s/recordings/%s", v1RequestUrl(), TEST_RECORDING_NAME),
                         true,
-                        5);
+                        REQUEST_TIMEOUT_SECONDS);
         webClient
                 .extensions()
                 .delete(
@@ -282,7 +294,7 @@ public class SnapshotTest extends StandardSelfTest {
                                 v1RequestUrl(),
                                 snapshotName.get(REQUEST_TIMEOUT_SECONDS, TimeUnit.SECONDS)),
                         true,
-                        5);
+                        REQUEST_TIMEOUT_SECONDS);
     }
 
     @Test

--- a/src/test/java/itest/UploadRecordingTest.java
+++ b/src/test/java/itest/UploadRecordingTest.java
@@ -108,7 +108,7 @@ public class UploadRecordingTest extends StandardSelfTest {
                                         "/api/v1/targets/%s/recordings/%s/upload",
                                         getSelfReferenceConnectUrlEncoded(), RECORDING_NAME),
                                 true,
-                                null,
+                                (Buffer) null,
                                 0);
 
         MatcherAssert.assertThat(resp.statusCode(), Matchers.equalTo(200));

--- a/src/test/java/itest/bases/StandardSelfTest.java
+++ b/src/test/java/itest/bases/StandardSelfTest.java
@@ -115,7 +115,7 @@ public abstract class StandardSelfTest {
                         webClient
                                 .delete(path)
                                 .basicAuthentication("user", "pass")
-                                .timeout(5000)
+                                .timeout(TimeUnit.SECONDS.toMillis(REQUEST_TIMEOUT_SECONDS))
                                 .send(
                                         ar -> {
                                             if (ar.failed()) {
@@ -152,7 +152,7 @@ public abstract class StandardSelfTest {
                                 .get("/api/v3/targets")
                                 .basicAuthentication("user", "pass")
                                 .as(BodyCodec.jsonArray())
-                                .timeout(5000)
+                                .timeout(TimeUnit.SECONDS.toMillis(REQUEST_TIMEOUT_SECONDS))
                                 .send(
                                         ar -> {
                                             if (ar.failed()) {
@@ -201,7 +201,7 @@ public abstract class StandardSelfTest {
                         webClient
                                 .getAbs(selfCustomTargetLocation)
                                 .basicAuthentication("user", "pass")
-                                .timeout(5000)
+                                .timeout(TimeUnit.SECONDS.toMillis(REQUEST_TIMEOUT_SECONDS))
                                 .send(
                                         ar -> {
                                             if (ar.failed()) {
@@ -245,7 +245,7 @@ public abstract class StandardSelfTest {
                         webClient
                                 .post("/api/v2/targets")
                                 .basicAuthentication("user", "pass")
-                                .timeout(5000)
+                                .timeout(TimeUnit.SECONDS.toMillis(REQUEST_TIMEOUT_SECONDS))
                                 .sendJson(
                                         self,
                                         ar -> {
@@ -288,7 +288,7 @@ public abstract class StandardSelfTest {
                             .get(path)
                             .basicAuthentication("user", "pass")
                             .as(BodyCodec.jsonObject())
-                            .timeout(5000)
+                            .timeout(TimeUnit.SECONDS.toMillis(REQUEST_TIMEOUT_SECONDS))
                             .send(
                                     ar -> {
                                         if (ar.failed()) {

--- a/src/test/java/itest/bases/StandardSelfTest.java
+++ b/src/test/java/itest/bases/StandardSelfTest.java
@@ -55,8 +55,8 @@ import org.junit.jupiter.api.BeforeAll;
 
 public abstract class StandardSelfTest {
 
-    private static final String SELF_JMX_URL = "service:jmx:rmi:///jndi/rmi://localhost:0/jmxrmi";
-    private static final String SELFTEST_ALIAS = "selftest";
+    public static final String SELF_JMX_URL = "service:jmx:rmi:///jndi/rmi://localhost:0/jmxrmi";
+    public static final String SELFTEST_ALIAS = "selftest";
     private static final ExecutorService WORKER = Executors.newCachedThreadPool();
     public static final Logger logger = Logger.getLogger(StandardSelfTest.class);
     public static final ObjectMapper mapper = new ObjectMapper();
@@ -81,62 +81,36 @@ public abstract class StandardSelfTest {
     }
 
     public static void assertNoRecordings() throws Exception {
-        CompletableFuture<JsonArray> listFuture = new CompletableFuture<>();
-        webClient
-                .get(
-                        String.format(
-                                "/api/v1/targets/%s/recordings",
-                                getSelfReferenceConnectUrlEncoded()))
-                .basicAuthentication("user", "pass")
-                .send(
-                        ar -> {
-                            if (assertRequestStatus(ar, listFuture)) {
-                                listFuture.complete(ar.result().bodyAsJsonArray());
-                            }
-                        });
-        JsonArray listResp = listFuture.get(REQUEST_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+        JsonArray listResp =
+                webClient
+                        .extensions()
+                        .get(
+                                String.format(
+                                        "/api/v1/targets/%s/recordings",
+                                        getSelfReferenceConnectUrlEncoded()),
+                                true,
+                                REQUEST_TIMEOUT_SECONDS)
+                        .bodyAsJsonArray();
         if (!listResp.isEmpty()) {
             throw new ITestCleanupFailedException(
                     String.format("Unexpected recordings:\n%s", listResp.encodePrettily()));
         }
     }
 
-    // @AfterAll
-    public static void deleteSelfCustomTarget() {
-        if (StringUtils.isBlank(selfCustomTargetLocation)) {
+    @AfterAll
+    public static void deleteSelfCustomTarget()
+            throws InterruptedException, ExecutionException, TimeoutException {
+        if (!selfCustomTargetExists()) {
             return;
         }
         logger.infov("Deleting self custom target at {0}", selfCustomTargetLocation);
         String path = URI.create(selfCustomTargetLocation).getPath();
-        CompletableFuture<String> future = new CompletableFuture<>();
-        try {
-            WORKER.submit(
-                    () -> {
-                        webClient
-                                .delete(path)
-                                .basicAuthentication("user", "pass")
-                                .timeout(TimeUnit.SECONDS.toMillis(REQUEST_TIMEOUT_SECONDS))
-                                .send(
-                                        ar -> {
-                                            if (ar.failed()) {
-                                                logger.error(ar.cause());
-                                                future.completeExceptionally(ar.cause());
-                                                return;
-                                            }
-                                            HttpResponse<Buffer> resp = ar.result();
-                                            logger.infov(
-                                                    "DELETE {0} -> HTTP {1} {2}: [{3}]",
-                                                    path,
-                                                    resp.statusCode(),
-                                                    resp.statusMessage(),
-                                                    resp.headers());
-                                            future.complete(null);
-                                        });
-                    });
-            selfCustomTargetLocation = future.get(REQUEST_TIMEOUT_SECONDS, TimeUnit.SECONDS);
-        } catch (Exception e) {
-            logger.error(e);
-        }
+        HttpResponse<Buffer> resp =
+                webClient.extensions().delete(path, true, REQUEST_TIMEOUT_SECONDS);
+        logger.infov(
+                "DELETE {0} -> HTTP {1} {2}: [{3}]",
+                path, resp.statusCode(), resp.statusMessage(), resp.headers());
+        selfCustomTargetLocation = null;
     }
 
     public static void waitForDiscovery(int otherTargetsCount) {
@@ -194,38 +168,21 @@ public abstract class StandardSelfTest {
         if (StringUtils.isBlank(selfCustomTargetLocation)) {
             return false;
         }
-        CompletableFuture<Boolean> future = new CompletableFuture<>();
         try {
-            WORKER.submit(
-                    () -> {
-                        webClient
-                                .getAbs(selfCustomTargetLocation)
-                                .basicAuthentication("user", "pass")
-                                .timeout(TimeUnit.SECONDS.toMillis(REQUEST_TIMEOUT_SECONDS))
-                                .send(
-                                        ar -> {
-                                            if (ar.failed()) {
-                                                logger.error(ar.cause());
-                                                future.completeExceptionally(ar.cause());
-                                                return;
-                                            }
-                                            HttpResponse<Buffer> resp = ar.result();
-                                            logger.infov(
-                                                    "POST /api/v2/targets -> HTTP {0} {1}: [{2}]",
-                                                    resp.statusCode(),
-                                                    resp.statusMessage(),
-                                                    resp.headers());
-                                            future.complete(
-                                                    HttpStatusCodeIdentifier.isSuccessCode(
-                                                            resp.statusCode()));
-                                        });
-                    });
-            boolean result = future.get(REQUEST_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+            HttpResponse<Buffer> resp =
+                    webClient
+                            .extensions()
+                            .get(selfCustomTargetLocation, true, REQUEST_TIMEOUT_SECONDS);
+            logger.infov(
+                    "POST /api/v2/targets -> HTTP {0} {1}: [{2}]",
+                    resp.statusCode(), resp.statusMessage(), resp.headers());
+            boolean result = HttpStatusCodeIdentifier.isSuccessCode(resp.statusCode());
             if (!result) {
                 selfCustomTargetLocation = null;
             }
             return result;
         } catch (Exception e) {
+            selfCustomTargetLocation = null;
             logger.error(e);
             return false;
         }
@@ -236,88 +193,45 @@ public abstract class StandardSelfTest {
             return;
         }
         logger.info("Trying to define self-referential custom target...");
-        CompletableFuture<String> future = new CompletableFuture<>();
+        JsonObject self =
+                new JsonObject(Map.of("connectUrl", SELF_JMX_URL, "alias", SELFTEST_ALIAS));
+        HttpResponse<Buffer> resp;
         try {
-            JsonObject self =
-                    new JsonObject(Map.of("connectUrl", SELF_JMX_URL, "alias", SELFTEST_ALIAS));
-            WORKER.submit(
-                    () -> {
-                        webClient
-                                .post("/api/v2/targets")
-                                .basicAuthentication("user", "pass")
-                                .timeout(TimeUnit.SECONDS.toMillis(REQUEST_TIMEOUT_SECONDS))
-                                .sendJson(
-                                        self,
-                                        ar -> {
-                                            if (ar.failed()) {
-                                                logger.error(ar.cause());
-                                                future.completeExceptionally(ar.cause());
-                                                return;
-                                            }
-                                            HttpResponse<Buffer> resp = ar.result();
-                                            logger.infov(
-                                                    "POST /api/v2/targets -> HTTP {0} {1}: [{2}]",
-                                                    resp.statusCode(),
-                                                    resp.statusMessage(),
-                                                    resp.headers());
-                                            if (HttpStatusCodeIdentifier.isSuccessCode(
-                                                    resp.statusCode())) {
-                                                future.complete(
-                                                        resp.headers().get(HttpHeaders.LOCATION));
-                                            } else {
-                                                future.completeExceptionally(
-                                                        new IllegalStateException(
-                                                                Integer.toString(
-                                                                        resp.statusCode())));
-                                            }
-                                        });
-                    });
-            selfCustomTargetLocation = future.get(REQUEST_TIMEOUT_SECONDS, TimeUnit.SECONDS);
-        } catch (Exception e) {
-            logger.error(e);
+            resp =
+                    webClient
+                            .extensions()
+                            .post(
+                                    "/api/v2/targets",
+                                    true,
+                                    Buffer.buffer(self.encode()),
+                                    REQUEST_TIMEOUT_SECONDS);
+            logger.infov(
+                    "POST /api/v2/targets -> HTTP {0} {1}: [{2}]",
+                    resp.statusCode(), resp.statusMessage(), resp.headers());
+            if (!HttpStatusCodeIdentifier.isSuccessCode(resp.statusCode())) {
+                throw new IllegalStateException(Integer.toString(resp.statusCode()));
+            }
+            selfCustomTargetLocation =
+                    URI.create(resp.headers().get(HttpHeaders.LOCATION)).getPath();
+        } catch (InterruptedException | ExecutionException | TimeoutException e) {
+            throw new IllegalStateException(e);
         }
     }
 
     public static String getSelfReferenceConnectUrl() {
-        tryDefineSelfCustomTarget();
-        CompletableFuture<JsonObject> future = new CompletableFuture<>();
-        WORKER.submit(
-                () -> {
-                    String path = URI.create(selfCustomTargetLocation).getPath();
-                    webClient
-                            .get(path)
-                            .basicAuthentication("user", "pass")
-                            .as(BodyCodec.jsonObject())
-                            .timeout(TimeUnit.SECONDS.toMillis(REQUEST_TIMEOUT_SECONDS))
-                            .send(
-                                    ar -> {
-                                        if (ar.failed()) {
-                                            logger.error(ar.cause());
-                                            future.completeExceptionally(ar.cause());
-                                            return;
-                                        }
-                                        HttpResponse<JsonObject> resp = ar.result();
-                                        JsonObject body = resp.body();
-                                        logger.infov(
-                                                "GET {0} -> HTTP {1} {2}: [{3}] = {4}",
-                                                path,
-                                                resp.statusCode(),
-                                                resp.statusMessage(),
-                                                resp.headers(),
-                                                body);
-                                        if (!HttpStatusCodeIdentifier.isSuccessCode(
-                                                resp.statusCode())) {
-                                            future.completeExceptionally(
-                                                    new IllegalStateException(
-                                                            Integer.toString(resp.statusCode())));
-                                            return;
-                                        }
-                                        future.complete(body);
-                                    });
-                });
         try {
-            JsonObject obj = future.get(REQUEST_TIMEOUT_SECONDS, TimeUnit.SECONDS);
-            return obj.getString("connectUrl");
+            tryDefineSelfCustomTarget();
+            String path = URI.create(selfCustomTargetLocation).getPath();
+            HttpResponse<Buffer> resp =
+                    webClient.extensions().get(path, true, REQUEST_TIMEOUT_SECONDS);
+            JsonObject body = resp.bodyAsJsonObject();
+            logger.infov(
+                    "GET {0} -> HTTP {1} {2}: [{3}] = {4}",
+                    path, resp.statusCode(), resp.statusMessage(), resp.headers(), body);
+            if (!HttpStatusCodeIdentifier.isSuccessCode(resp.statusCode())) {
+                throw new IllegalStateException(Integer.toString(resp.statusCode()));
+            }
+            return body.getString("connectUrl");
         } catch (Exception e) {
             throw new RuntimeException("Could not determine own connectUrl", e);
         }

--- a/src/test/java/itest/util/http/JvmIdWebRequest.java
+++ b/src/test/java/itest/util/http/JvmIdWebRequest.java
@@ -15,93 +15,41 @@
  */
 package itest.util.http;
 
-import java.net.URI;
-import java.util.Base64;
-import java.util.List;
-import java.util.concurrent.CompletableFuture;
+import java.util.Objects;
 import java.util.concurrent.ExecutionException;
-import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
-import com.google.gson.Gson;
-import io.vertx.core.buffer.Buffer;
 import io.vertx.core.json.JsonObject;
-import io.vertx.ext.web.client.HttpRequest;
-import io.vertx.ext.web.client.WebClient;
 import itest.bases.StandardSelfTest;
 import itest.util.Utils;
-import org.apache.commons.lang3.tuple.Pair;
+import itest.util.Utils.TestWebClient;
 
 public class JvmIdWebRequest {
-    private static final Gson gson = new Gson();
+    public static final TestWebClient webClient = Utils.getWebClient();
 
-    public static final int REQUEST_TIMEOUT_SECONDS = 10;
-    public static final WebClient webClient = Utils.getWebClient();
-
-    // shouldn't be percent-encoded i.e.
-    // String.format("service:jmx:rmi:///jndi/rmi://%s:9091/jmxrmi", Podman.POD_NAME)
-    public static String jvmIdRequest(String targetId)
+    public static String jvmIdRequest(long id)
             throws InterruptedException, ExecutionException, TimeoutException {
-        return jvmIdRequest(targetId, null);
+        return webClient
+                .extensions()
+                .get(
+                        String.format("/api/v3/targets/%d", id),
+                        true,
+                        StandardSelfTest.REQUEST_TIMEOUT_SECONDS)
+                .bodyAsJsonObject()
+                .getString("jvmId");
     }
 
-    public static String jvmIdRequest(String targetId, Pair<String, String> credentials)
+    public static String jvmIdRequest(String connectUrl)
             throws InterruptedException, ExecutionException, TimeoutException {
-        CompletableFuture<TargetNodesQueryResponse> resp = new CompletableFuture<>();
-
-        JsonObject query = new JsonObject();
-        query.put(
-                "query",
-                String.format(
-                        "query { targetNodes(filter: { name: \"%s\" }) { target { jvmId } } }",
-                        targetId));
-        HttpRequest<Buffer> buffer = webClient.post("/api/v2.2/graphql");
-        if (credentials != null) {
-            buffer.putHeader(
-                    "X-JMX-Authorization",
-                    "Basic "
-                            + Base64.getUrlEncoder()
-                                    .encodeToString(
-                                            (credentials.getLeft() + ":" + credentials.getRight())
-                                                    .getBytes()));
-        }
-        buffer.sendJson(
-                query,
-                ar -> {
-                    if (StandardSelfTest.assertRequestStatus(ar, resp)) {
-                        resp.complete(
-                                gson.fromJson(
-                                        ar.result().bodyAsString(),
-                                        TargetNodesQueryResponse.class));
-                    }
-                });
-        TargetNodesQueryResponse response = resp.get(REQUEST_TIMEOUT_SECONDS, TimeUnit.SECONDS);
-        return response.data.targetNodes.get(0).target.jvmId;
-    }
-
-    public static String jvmIdRequest(URI serviceUri)
-            throws InterruptedException, ExecutionException, TimeoutException {
-        return jvmIdRequest(serviceUri.toString(), null);
-    }
-
-    public static String jvmIdRequest(URI serviceUri, Pair<String, String> credentials)
-            throws InterruptedException, ExecutionException, TimeoutException {
-        return jvmIdRequest(serviceUri.toString(), credentials);
-    }
-
-    static class TargetNodesQueryResponse {
-        TargetNodes data;
-    }
-
-    static class TargetNodes {
-        List<TargetNode> targetNodes;
-    }
-
-    static class TargetNode {
-        Target target;
-    }
-
-    static class Target {
-        String jvmId;
+        return webClient
+                .extensions()
+                .get("/api/v3/targets", true, StandardSelfTest.REQUEST_TIMEOUT_SECONDS)
+                .bodyAsJsonArray()
+                .stream()
+                .map(o -> (JsonObject) o)
+                .filter(o -> Objects.equals(connectUrl, o.getString("connectUrl")))
+                .findFirst()
+                .map(o -> o.getString("jvmId"))
+                .orElseThrow();
     }
 }


### PR DESCRIPTION
# Welcome to Cryostat3! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat3/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] [Signed all commits using a GPG signature](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#gpg-commit-signature-verification)

**To recreate commits with GPG signature** `git fetch upstream && git rebase --force --gpg-sign upstream/main`
_______________________________________________

Fixes #101
Related to #122
Based on #183
Depends on #183

## Description of the change:
Re-enables the Custom Targets integration test that was ported over earlier. Along with this come some fixes to the initial 3.0 implementation so that the API responses match the pre-existing format, addition of handling of "embedded credentials" supplied with Custom Targets definitions, addition of handling to look up existing credentials from the keyring when opening a target connection, fixes to ensure that WebSocket messages are emitted in a more predictable order for clients to observe, some basic refactoring, and putting back the three instances of `vertx-fib-demo` like the old smoketest has.

## How to manually test:
1. Build PR locally, `./mvnw clean verify ; podman image prune -f` and ensure all tests pass
2. `./smoketest.bash -OXgtb` or whichever combination of flags you like
3. Go to Dashboard > Create Target view, try to create a new custom target. This will need to have a unique but existing/reachable JMX URL, so you can use `service:jmx:rmi:///jndi/rmi://vertx-fib-demo-2:9094/jmxrmi`. In the latest smoketest script, `vertx-fib-demo-n` and `sample-app-n` (`n: [1, 2, 3]`) are basically synonymous - both forms are resolvable hostnames from the perspective of the cryostat3 container. `vertx-fib-demo-2:9094` and `vertx-fib-demo-3:9095` are free to use as custom targets, the other URLs will be automatically discovered by JDP and the samples' Agent instances.
![image](https://github.com/cryostatio/cryostat3/assets/3787464/60c3c1b7-14df-4f3b-b582-80e5547f67ea)

With `service:jmx:rmi:///jndi/rmi://vertx-fib-demo-2:9094/jmxrmi`:
1. Go to target creation view, enter this URL
2. Test connection. It should fail due to missing credentials.
3. Add the credentials `admin:adminpass123` in the form, test the connection again. It should succeed.
4. Replace the credentials with `user:password`, test again. It should still succeed.
5. Replace the credentials with something else, test again. It should fail.
6. Put back `user:password` and create the custom target. This should succeed and some notifications should appear. You will be brought back to the Topology view, which depends on GraphQL (#11), so don't worry about that view being broken for now.
7. Go to Recordings and try to create a new flight recording. This should fail with an HTTP 403.
8. Go to Security and delete the credentials that match the JMX URL. Create new credentials with the same match expression, but this time using the `admin:adminpass123` combination.
9. Go back to Recordings and retry creating a recording. This should succeed.

With `service:jmx:rmi:///jndi/rmi://vertx-fib-demo-3:9095/jmxrmi`:
1. Go to target creation view, enter this URL
2. Test connection. It should fail due to "non-JRMP endpoint" - this is a little misleading but actually indicates the unknown SSL cert required by this test app instance.
3. Creating the target should similarly fail.

With `service:jmx:rmi:///jndi/rmi://cryostat3:9091/jmxrmi`:
1. Go to target creation view, enter this URL
2. Test connection. This should succeed.
3. Creating the target should succeed. Cryostat should succeed at automatically connecting to itself and via this URL you should also see the `onstart` recording that is already present.

Note: *deleting* a Custom Target is only exposed in the UI via the Topology view, so there is no way to undo this graphically yet. You can either tear down and restart the smoketest to get a fresh slate, or you can use curl/HTTPie and delete the custom target directly via the API:

```bash
$ http --auth=user:pass :8181/api/v3/targets
HTTP/1.1 200 OK
Cache-Control: no-cache
Content-Type: application/json;charset=UTF-8
content-encoding: gzip
content-length: 1762

[
    ...
    {
        "agent": false,
        "alias": "service%3Ajmx%3Armi%3A%2F%2F%2Fjndi%2Frmi%3A%2F%2Fvertx-fib-demo-2%3A9094%2Fjmxrmi",
        "annotations": {
            "cryostat": {
                "REALM": "Custom Targets"
            },
            "platform": {}
        },
        "connectUrl": "service:jmx:rmi:///jndi/rmi://vertx-fib-demo-2:9094/jmxrmi",
        "id": 9,
        "jvmId": "hk58o_x3gJT4jK0aLmd5XdBRrdIRKmHb3xKZKixAQDI=",
        "labels": {}
    }
]
```

```bash
$ http --auth=user:pass DELETE :8181/api/v3/targets/9
HTTP/1.1 204 No Content
content-encoding: identity
```