### PR TITLE
ci(db): clean up database container after test run

### DIFF
--- a/.github/workflows/pr-ci.yaml
+++ b/.github/workflows/pr-ci.yaml
@@ -99,7 +99,6 @@ jobs:
       matrix:
         java: [ '17', '21' ]
     env:
-      TESTCONTAINERS_RYUK_DISABLED: true
       cache-name: cache-yarn
     name: Build and test Java ${{ matrix.java }}
     permissions:
@@ -152,7 +151,10 @@ jobs:
         chmod +x $HOME/.bin/docker
         echo "PATH=$HOME/.bin:$PATH" >> "$GITHUB_ENV"
     - name: Set up testcontainers for podman
-      run:  echo ryuk.container.privileged=true > ~/.testcontainers.properties
+      run: |
+        echo ryuk.container.privileged=true > ~/.testcontainers.properties
+        echo docker.client.strategy=org.testcontainers.dockerclient.UnixSocketClientProviderStrategy >> ~/.testcontainers.properties
+        echo testcontainers.reuse.enable=false >> ~/.testcontainers.properties
     - name: Start Podman API
       run: systemctl --user enable --now podman.socket
     - name: Set DOCKER_HOST environment variable

--- a/.github/workflows/push-ci.yaml
+++ b/.github/workflows/push-ci.yaml
@@ -44,7 +44,6 @@ jobs:
         java: [ '17', '21' ]
     env:
       IMAGE_VERSION: ${{ needs.get-pom-properties.outputs.image-version }}
-      TESTCONTAINERS_RYUK_DISABLED: true
       cache-name: cache-yarn
     name: Build and test Java ${{ matrix.java }}
     permissions:
@@ -94,7 +93,10 @@ jobs:
         chmod +x $HOME/.bin/docker
         echo "PATH=$HOME/.bin:$PATH" >> "$GITHUB_ENV"
     - name: Set up testcontainers for podman
-      run:  echo ryuk.container.privileged=true > ~/.testcontainers.properties
+      run: |
+        echo ryuk.container.privileged=true > ~/.testcontainers.properties
+        echo docker.client.strategy=org.testcontainers.dockerclient.UnixSocketClientProviderStrategy >> ~/.testcontainers.properties
+        echo testcontainers.reuse.enable=false >> ~/.testcontainers.properties
     - name: Start Podman API
       run: systemctl --user enable --now podman.socket
     - name: Set DOCKER_HOST environment variable

--- a/README.md
+++ b/README.md
@@ -120,9 +120,9 @@ $ export LD_PRELOAD=$HOME/bin/lib/libuserhosts.so
 
 You can verify that this setup works by running `smoketest.bash`, and then in another terminal:
 ```bash
-$ LD_PRELOAD=$HOME/bin/libuserhosts.so ping cryostat3
-$ LD_PRELOAD=$HOME/bin/libuserhosts.so curl http://cryostat3:8181
-$ LD_PRELOAD=$HOME/bin/libuserhosts.so firefox http://cryostat3:8181
+$ LD_PRELOAD=$HOME/bin/libuserhosts.so ping auth
+$ LD_PRELOAD=$HOME/bin/libuserhosts.so curl http://auth:8080
+$ LD_PRELOAD=$HOME/bin/libuserhosts.so firefox http://auth:8080
 ```
 
 ### Smoketesting in K8s

--- a/README.md
+++ b/README.md
@@ -90,7 +90,13 @@ $ systemctl --user enable --now podman.socket
 `$HOME/.bashrc` (or equivalent shell configuration)
 ```bash
 export DOCKER_HOST=unix:///run/user/$(id -u)/podman/podman.sock
-export TESTCONTAINERS_RYUK_DISABLED=true
+```
+
+`$HOME/.testcontainers.properties`
+```properties
+ryuk.container.privileged=true
+docker.client.strategy=org.testcontainers.dockerclient.UnixSocketClientProviderStrategy
+testcontainers.reuse.enable=false
 ```
 
 Build the container image and run smoketests. This will spin up the cryostat container and its required services.


### PR DESCRIPTION
# Welcome to Cryostat3! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat3/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] [Signed all commits using a GPG signature](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#gpg-commit-signature-verification)

**To recreate commits with GPG signature** `git fetch upstream && git rebase --force --gpg-sign upstream/main`
_______________________________________________

Fixes: #221

## Description of the change:
Update configuration to allow `ryuk` container to run, which is responsible for cleaning up leftover containers (like cryostat-db or other postgres) after test runs.

## How to manually test:
1. Make the environment setup changes as listed in the updated `README`
2. `./mvnw clean verify ; podman image prune -f ; podman ps -a`. There may be some containers running at this point:
```
CONTAINER ID  IMAGE                                COMMAND               CREATED             STATUS             PORTS                    NAMES
56b3e0c3d6b6  docker.io/testcontainers/ryuk:0.5.1  /bin/ryuk             About a minute ago  Up About a minute  0.0.0.0:38897->8080/tcp  testcontainers-ryuk-f1b8be74-163c-43aa-954a-22f4d64950db
4cbf23b40104  quay.io/cryostat/cryostat-db:latest  postgres -c fsync...  About a minute ago  Up About a minute  0.0.0.0:36511->5432/tcp  condescending_sutherland
8a61aaadfef1  docker.io/testcontainers/ryuk:0.5.1  /bin/ryuk             55 seconds ago      Up 55 seconds      0.0.0.0:36247->8080/tcp  testcontainers-ryuk-3ba85f20-bfe2-40df-813c-72e7407b8ff0
```
Wait a few seconds, then check `podman ps -a` again. After a short time, no containers should be left running.
