### PR TITLE
test(smoketest): allow overriding container images by env var

### DIFF
--- a/smoketest.bash
+++ b/smoketest.bash
@@ -214,7 +214,7 @@ if [ "${PULL_IMAGES}" = "true" ]; then
     for file in "${FILES[@]}" ; do
         images="$(yq '.services.*.image' "${file}" | grep -v null)"
         for img in ${images}; do
-          IMAGES+=("${img}")
+          IMAGES+=("$(eval echo "${img}")")
         done
     done
     ${ce} pull "${IMAGES[@]}" || true

--- a/smoketest/compose/auth_proxy.yml
+++ b/smoketest/compose/auth_proxy.yml
@@ -20,7 +20,7 @@ services:
         limits:
           cpus: '0.1'
           memory: 32m
-    image: quay.io/oauth2-proxy/oauth2-proxy:latest
+    image: ${OAUTH2_PROXY_IMAGE:-quay.io/oauth2-proxy/oauth2-proxy:latest}
     command: --alpha-config=/tmp/auth_proxy_alpha_config.yaml
     volumes:
       - auth_proxy_cfg:/tmp

--- a/smoketest/compose/cryostat-grafana.yml
+++ b/smoketest/compose/cryostat-grafana.yml
@@ -5,7 +5,7 @@ services:
       - GRAFANA_DASHBOARD_EXT_URL=http://localhost:3000
       - GRAFANA_DASHBOARD_URL=http://grafana:3000
   grafana:
-    image: quay.io/cryostat/cryostat-grafana-dashboard:latest
+    image: ${GRAFANA_DASHBOARD_IMAGE:-quay.io/cryostat/cryostat-grafana-dashboard:latest}
     hostname: grafana
     restart: unless-stopped
     deploy:

--- a/smoketest/compose/cryostat.yml
+++ b/smoketest/compose/cryostat.yml
@@ -11,7 +11,7 @@ services:
         limits:
           cpus: '2'
           memory: 512m
-    image: quay.io/cryostat/cryostat:3.0.0-snapshot
+    image: ${CRYOSTAT_IMAGE:-quay.io/cryostat/cryostat:3.0.0-snapshot}
     volumes:
       - ${XDG_RUNTIME_DIR}/podman/podman.sock:/run/user/1000/podman/podman.sock:Z
     security_opt:

--- a/smoketest/compose/cryostat_docker.yml
+++ b/smoketest/compose/cryostat_docker.yml
@@ -11,7 +11,7 @@ services:
         limits:
           cpus: '2'
           memory: 512m
-    image: quay.io/cryostat/cryostat:3.0.0-snapshot
+    image: ${CRYOSTAT_IMAGE:-quay.io/cryostat/cryostat:3.0.0-snapshot}
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock:Z
     security_opt:

--- a/smoketest/compose/cryostat_k8s.yml
+++ b/smoketest/compose/cryostat_k8s.yml
@@ -6,7 +6,7 @@ services:
         condition: service_healthy
       s3:
         condition: service_healthy
-    image: quay.io/cryostat/cryostat:3.0.0-snapshot
+    image: ${CRYOSTAT_IMAGE:-quay.io/cryostat/cryostat:3.0.0-snapshot}
     hostname: cryostat3
     expose:
       - "9091"

--- a/smoketest/compose/db-viewer.yml
+++ b/smoketest/compose/db-viewer.yml
@@ -4,7 +4,7 @@ services:
     depends_on:
       db:
         condition: service_healthy
-    image: docker.io/dpage/pgadmin4:7
+    image: ${DB_VIEWER_IMAGE:-docker.io/dpage/pgadmin4:7}
     hostname: db-viewer
     ports:
       - "8989:8989"

--- a/smoketest/compose/db.yml
+++ b/smoketest/compose/db.yml
@@ -7,7 +7,7 @@ services:
       QUARKUS_DATASOURCE_PASSWORD: cryostat3
       QUARKUS_DATASOURCE_JDBC_URL: jdbc:postgresql://db:5432/cryostat3
   db:
-    image: quay.io/cryostat/cryostat-db:latest
+    image: ${CRYOSTAT_DB_IMAGE:-quay.io/cryostat/cryostat-db:latest}
     hostname: db
     expose:
       - "5432"

--- a/smoketest/compose/db_k8s.yml
+++ b/smoketest/compose/db_k8s.yml
@@ -8,7 +8,7 @@ services:
       QUARKUS_DATASOURCE_PASSWORD: cryostat3
       QUARKUS_DATASOURCE_JDBC_URL: jdbc:postgresql://db:5432/cryostat3
   db:
-    image: quay.io/cryostat/cryostat-db:latest
+    image: ${CRYOSTAT_DB_IMAGE:-quay.io/cryostat/cryostat-db:latest}
     hostname: db
     expose:
       - "5432"

--- a/smoketest/compose/jfr-datasource.yml
+++ b/smoketest/compose/jfr-datasource.yml
@@ -4,7 +4,7 @@ services:
     environment:
       - GRAFANA_DATASOURCE_URL=http://jfr-datasource:8080
   jfr-datasource:
-    image: quay.io/cryostat/jfr-datasource:latest
+    image: ${JFR_DATASOURCE_IMAGE:-quay.io/cryostat/jfr-datasource:latest}
     hostname: jfr-datasource
     restart: unless-stopped
     deploy:

--- a/smoketest/compose/s3-cloudserver.yml
+++ b/smoketest/compose/s3-cloudserver.yml
@@ -12,7 +12,7 @@ services:
       AWS_ACCESS_KEY_ID: accessKey1
       AWS_SECRET_ACCESS_KEY: verySecretKey1
   s3:
-    image: docker.io/zenko/cloudserver:latest
+    image: ${CLOUDSERVER_IMAGE:-docker.io/zenko/cloudserver:latest}
     hostname: s3
     expose:
       - "8000"

--- a/smoketest/compose/s3-localstack.yml
+++ b/smoketest/compose/s3-localstack.yml
@@ -12,7 +12,7 @@ services:
       AWS_ACCESS_KEY_ID: unused
       AWS_SECRET_ACCESS_KEY: unused
   s3:
-    image: docker.io/localstack/localstack:latest
+    image: ${LOCALSTACK_IMAGE:-docker.io/localstack/localstack:latest}
     hostname: s3
     expose:
       - "4566"

--- a/smoketest/compose/s3-minio.yml
+++ b/smoketest/compose/s3-minio.yml
@@ -12,7 +12,7 @@ services:
       AWS_ACCESS_KEY_ID: minioroot
       AWS_SECRET_ACCESS_KEY: minioroot
   s3:
-    image: docker.io/minio/minio:latest
+    image: ${MINIO_IMAGE:-docker.io/minio/minio:latest}
     hostname: s3
     ports:
       - "9001:9001"

--- a/smoketest/compose/s3-seaweed.yml
+++ b/smoketest/compose/s3-seaweed.yml
@@ -12,7 +12,7 @@ services:
       AWS_ACCESS_KEY_ID: unused
       AWS_SECRET_ACCESS_KEY: unused
   s3:
-    image: docker.io/chrislusf/seaweedfs:latest
+    image: ${SEAWEEDFS_IMAGE:-docker.io/chrislusf/seaweedfs:latest}
     command: server -s3
     hostname: s3
     expose:

--- a/smoketest/compose/sample-apps.yml
+++ b/smoketest/compose/sample-apps.yml
@@ -4,7 +4,7 @@ services:
     depends_on:
       auth:
         condition: service_healthy
-    image: quay.io/andrewazores/vertx-fib-demo:0.13.0
+    image: ${VERTX_FIB_DEMO_IMAGE:-quay.io/andrewazores/vertx-fib-demo:0.13.0}
     hostname: vertx-fib-demo-1
     environment:
       HTTP_PORT: 8081
@@ -35,7 +35,7 @@ services:
     depends_on:
       auth:
         condition: service_healthy
-    image: quay.io/andrewazores/vertx-fib-demo:0.13.0
+    image: ${VERTX_FIB_DEMO_IMAGE:-quay.io/andrewazores/vertx-fib-demo:0.13.0}
     hostname: vertx-fib-demo-2
     environment:
       HTTP_PORT: 8082
@@ -63,7 +63,7 @@ services:
     depends_on:
       auth:
         condition: service_healthy
-    image: quay.io/andrewazores/vertx-fib-demo:0.13.0
+    image: ${VERTX_FIB_DEMO_IMAGE:-quay.io/andrewazores/vertx-fib-demo:0.13.0}
     hostname: vertx-fib-demo-3
     environment:
       HTTP_PORT: 8083
@@ -89,7 +89,7 @@ services:
       start_period: 30s
       timeout: 5s
   quarkus-test-agent:
-    image: quay.io/andrewazores/quarkus-test:latest
+    image: ${QUARKUS_TEST_IMAGE:-quay.io/andrewazores/quarkus-test:latest}
     # do not add a depends_on:cryostat/depends_on:auth here, so that we can test that the agent is tolerant of that state
     hostname: quarkus-test-agent
     ports:


### PR DESCRIPTION
# Welcome to Cryostat3! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat3/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] [Signed all commits using a GPG signature](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#gpg-commit-signature-verification)

**To recreate commits with GPG signature** `git fetch upstream && git rebase --force --gpg-sign upstream/main`
_______________________________________________

Related to #64

## Description of the change:
Allows override of smoketest container images using env vars.

## Motivation for the change:
Useful for spinning up tests using different versions of various containers to test integration, ex. `/build_test` images.

## How to manually test:
1. `./mvnw clean package ; podman tag quay.io/cryostat/cryostat:3.0.0-snapshot quay.io/$myusername/cryostat:test-1 ; podman push quay.io/$myusername/cryostat:test-1` - make sure you replace `$myusername`, and that your `quay.io` repository is public
2. `CRYOSTAT_IMAGE=quay.io/$myusername/cryostat:test-1 bash smoketest.bash -O`
3. `podman ps -a` - the smoketest should be running your `test-1` container.
