### PR TITLE
test(smoketest): auth proxy is optional

### DIFF
--- a/smoketest/compose/auth_proxy.yml
+++ b/smoketest/compose/auth_proxy.yml
@@ -1,12 +1,20 @@
 version: "3"
 services:
   cryostat:
+    expose:
+      - "${CRYOSTAT_HTTP_PORT}"
     environment:
       QUARKUS_HTTP_PROXY_PROXY_ADDRESS_FORWARDING: 'true'
       QUARKUS_HTTP_PROXY_ALLOW_X_FORWARDED: 'true'
       QUARKUS_HTTP_PROXY_ENABLE_FORWARDED_HOST: 'true'
       QUARKUS_HTTP_PROXY_ENABLE_FORWARDED_PREFIX: 'true'
       QUARKUS_HTTP_PROXY_TRUSTED_PROXIES: localhost:8080,auth:8080
+    healthcheck:
+      test: curl --fail http://cryostat:8181/health/liveness || exit 1
+      interval: 10s
+      retries: 3
+      start_period: 30s
+      timeout: 5s
   auth:
     # the proxy does not actually depend on cryostat being up, but we use this
     # to ensure that when the smoketest tries to open the auth login page in a

--- a/smoketest/compose/cryostat.yml
+++ b/smoketest/compose/cryostat.yml
@@ -18,8 +18,6 @@ services:
       - label:disable
     hostname: cryostat3
     user: "1000"
-    expose:
-      - "8181"
     labels:
       kompose.service.expose: "cryostat3"
       io.cryostat.discovery: "true"
@@ -28,12 +26,13 @@ services:
       io.cryostat.jmxUrl: "service:jmx:rmi:///jndi/rmi://localhost:0/jmxrmi"
     environment:
       QUARKUS_HTTP_HOST: "cryostat"
+      QUARKUS_HTTP_PORT: ${CRYOSTAT_HTTP_PORT}
       CRYOSTAT_DISCOVERY_PODMAN_ENABLED: "true"
       CRYOSTAT_DISCOVERY_JDP_ENABLED: "true"
       JAVA_OPTS_APPEND: "-XX:+FlightRecorder -XX:StartFlightRecording=name=onstart,settings=default,disk=true,maxage=5m -Dcom.sun.management.jmxremote.autodiscovery=true -Dcom.sun.management.jmxremote -Dcom.sun.management.jmxremote.port=9091 -Dcom.sun.management.jmxremote.rmi.port=9091 -Djava.rmi.server.hostname=127.0.0.1 -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.local.only=false"
     restart: unless-stopped
     healthcheck:
-      test: curl --fail http://cryostat:8181/health/liveness || exit 1
+      test: curl --fail http://cryostat:${CRYOSTAT_HTTP_PORT}/health/liveness || exit 1
       interval: 10s
       retries: 3
       start_period: 30s

--- a/smoketest/compose/no_proxy.yml
+++ b/smoketest/compose/no_proxy.yml
@@ -1,0 +1,8 @@
+version: "3"
+services:
+  cryostat:
+    hostname: cryostat3
+    ports:
+      - ${CRYOSTAT_HTTP_PORT}:${CRYOSTAT_HTTP_PORT}
+    expose:
+      - ${CRYOSTAT_HTTP_PORT}

--- a/smoketest/compose/sample-apps.yml
+++ b/smoketest/compose/sample-apps.yml
@@ -2,7 +2,7 @@ version: "3"
 services:
   sample-app-1:
     depends_on:
-      auth:
+      cryostat:
         condition: service_healthy
     image: ${VERTX_FIB_DEMO_IMAGE:-quay.io/andrewazores/vertx-fib-demo:0.13.0}
     hostname: vertx-fib-demo-1
@@ -15,7 +15,7 @@ services:
       CRYOSTAT_AGENT_WEBSERVER_HOST: "sample-app-1"
       CRYOSTAT_AGENT_WEBSERVER_PORT: "8910"
       CRYOSTAT_AGENT_CALLBACK: "http://sample-app-1:8910/"
-      CRYOSTAT_AGENT_BASEURI: "http://auth:8080/"
+      CRYOSTAT_AGENT_BASEURI: "http://cryostat:${CRYOSTAT_HTTP_PORT}/"
       CRYOSTAT_AGENT_TRUST_ALL: "true"
       CRYOSTAT_AGENT_AUTHORIZATION: Basic dXNlcjpwYXNz
     ports:
@@ -33,7 +33,7 @@ services:
       timeout: 5s
   sample-app-2:
     depends_on:
-      auth:
+      cryostat:
         condition: service_healthy
     image: ${VERTX_FIB_DEMO_IMAGE:-quay.io/andrewazores/vertx-fib-demo:0.13.0}
     hostname: vertx-fib-demo-2
@@ -47,7 +47,7 @@ services:
       CRYOSTAT_AGENT_WEBSERVER_HOST: "sample-app-2"
       CRYOSTAT_AGENT_WEBSERVER_PORT: "8911"
       CRYOSTAT_AGENT_CALLBACK: "http://sample-app-2:8911/"
-      CRYOSTAT_AGENT_BASEURI: "http://auth:8080/"
+      CRYOSTAT_AGENT_BASEURI: "http://cryostat:${CRYOSTAT_HTTP_PORT}/"
       CRYOSTAT_AGENT_TRUST_ALL: "true"
       CRYOSTAT_AGENT_AUTHORIZATION: "Basic dXNlcjpwYXNz"
     ports:
@@ -61,7 +61,7 @@ services:
       timeout: 5s
   sample-app-3:
     depends_on:
-      auth:
+      cryostat:
         condition: service_healthy
     image: ${VERTX_FIB_DEMO_IMAGE:-quay.io/andrewazores/vertx-fib-demo:0.13.0}
     hostname: vertx-fib-demo-3
@@ -76,7 +76,7 @@ services:
       CRYOSTAT_AGENT_WEBSERVER_HOST: "sample-app-3"
       CRYOSTAT_AGENT_WEBSERVER_PORT: "8910"
       CRYOSTAT_AGENT_CALLBACK: "http://sample-app-3:8912/"
-      CRYOSTAT_AGENT_BASEURI: "http://auth:8080/"
+      CRYOSTAT_AGENT_BASEURI: "http://cryostat:${CRYOSTAT_HTTP_PORT}/"
       CRYOSTAT_AGENT_TRUST_ALL: "true"
       CRYOSTAT_AGENT_AUTHORIZATION: "Basic dXNlcjpwYXNz"
     ports:
@@ -104,7 +104,7 @@ services:
       CRYOSTAT_AGENT_WEBSERVER_HOST: quarkus-test-agent
       CRYOSTAT_AGENT_WEBSERVER_PORT: 9977
       CRYOSTAT_AGENT_CALLBACK: http://quarkus-test-agent:9977/
-      CRYOSTAT_AGENT_BASEURI: http://auth:8080/
+      CRYOSTAT_AGENT_BASEURI: http://cryostat:${CRYOSTAT_HTTP_PORT}/
       CRYOSTAT_AGENT_BASEURI_RANGE: public
       CRYOSTAT_AGENT_SSL_TRUST_ALL: "true"
       CRYOSTAT_AGENT_SSL_VERIFY_HOSTNAME: "false"


### PR DESCRIPTION
# Welcome to Cryostat3! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat3/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] [Signed all commits using a GPG signature](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#gpg-commit-signature-verification)

**To recreate commits with GPG signature** `git fetch upstream && git rebase --force --gpg-sign upstream/main`
_______________________________________________

Related to #208
Related to #64

## Description of the change:
This adds a `-p` switch to `smoketest.bash` for disabling the `oauth2-proxy` configuration.

## Motivation for the change:
Developers can now choose whether to have Cryostat deployed directly with no authentication (add `-p`) or deployed with the `oauth2-proxy` providing `Basic` authentication (without `-p`). In either case, the exposed port is now `8080` rather than `8181`. 

## How to manually test:
1. `bash smoketest.bash -Xgt` to run the smoketest with the `oauth2-proxy` enabled. This should look the same as running it on current `main`. `podman ps` to inspect the running containers - there should be an auth proxy. Open a private browsing window and go to `http://localhost:8080`. You should see an auth prompt - log in with `user:pass`. The private browsing window is key here to ensure your browser doesn't pass cached credentials to the auth proxy so that you skip right past it. Sample applications should be available in the target selection dropdown and the application should work as usual.
2. `ctrl-c` to tear down that previous smoketest. Start again with `bash smoketest.bash -Xgtp` this time to disable the auth proxy. `podman ps` to inspect and verify it is not running. Open another private browsing window and again go to `http://localhost:8080`. You should go directly into the Cryostat UI without authentication. Sample applications should be available in the target selection dropdown and the application should work as usual.