### PR TITLE
test(smoketest): place Grafana dashboard behind oauth proxy

### DIFF
--- a/smoketest.bash
+++ b/smoketest.bash
@@ -78,13 +78,17 @@ while getopts "hs:prgtOVXcb" opt; do
             ;;
     esac
 done
-export CRYOSTAT_HTTP_PORT
+
 if [ "${USE_PROXY}" = "true" ]; then
     FILES+=("${DIR}/smoketest/compose/auth_proxy.yml")
     CRYOSTAT_HTTP_PORT=8181
+    GRAFANA_DASHBOARD_EXT_URL=http://localhost:8080/grafana/
 else
     FILES+=("${DIR}/smoketest/compose/no_proxy.yml")
+    GRAFANA_DASHBOARD_EXT_URL=http://grafana:3000/
 fi
+export CRYOSTAT_HTTP_PORT
+export GRAFANA_DASHBOARD_EXT_URL
 
 s3Manifest="${DIR}/smoketest/compose/s3-${s3}.yml"
 

--- a/smoketest.bash
+++ b/smoketest.bash
@@ -18,6 +18,7 @@ OPEN_TABS=${OPEN_TABS:-false}
 
 CRYOSTAT_HTTP_PORT=8080
 USE_PROXY=${USE_PROXY:-true}
+DEPLOY_GRAFANA=false
 
 display_usage() {
     echo "Usage:"
@@ -50,6 +51,7 @@ while getopts "hs:prgtOVXcb" opt; do
             ;;
         g)
             FILES+=("${DIR}/smoketest/compose/cryostat-grafana.yml" "${DIR}/smoketest/compose/jfr-datasource.yml")
+            DEPLOY_GRAFANA=true
             ;;
         t)
             FILES+=("${DIR}/smoketest/compose/sample-apps.yml")
@@ -85,6 +87,9 @@ if [ "${USE_PROXY}" = "true" ]; then
     GRAFANA_DASHBOARD_EXT_URL=http://localhost:8080/grafana/
 else
     FILES+=("${DIR}/smoketest/compose/no_proxy.yml")
+    if [ "${DEPLOY_GRAFANA}" = "true" ]; then
+      FILES+=("${DIR}/smoketest/compose/grafana_no_proxy.yml")
+    fi
     GRAFANA_DASHBOARD_EXT_URL=http://grafana:3000/
 fi
 export CRYOSTAT_HTTP_PORT

--- a/smoketest/compose/auth_proxy_alpha_config.yaml
+++ b/smoketest/compose/auth_proxy_alpha_config.yaml
@@ -6,6 +6,9 @@ upstreamConfig:
     - id: cryostat
       path: /
       uri: http://cryostat:8181
+    - id: grafana
+      path: /grafana/
+      uri: http://grafana:3000
 providers:
   - id: dummy
     name: Unused - Sign In Below

--- a/smoketest/compose/cryostat-grafana.yml
+++ b/smoketest/compose/cryostat-grafana.yml
@@ -2,7 +2,7 @@ version: "3"
 services:
   cryostat:
     environment:
-      - GRAFANA_DASHBOARD_EXT_URL=http://localhost:3000
+      - GRAFANA_DASHBOARD_EXT_URL=${GRAFANA_DASHBOARD_EXT_URL:-http://localhost:3000/}
       - GRAFANA_DASHBOARD_URL=http://grafana:3000
   grafana:
     image: ${GRAFANA_DASHBOARD_IMAGE:-quay.io/cryostat/cryostat-grafana-dashboard:latest}
@@ -16,9 +16,10 @@ services:
     environment:
       - GF_INSTALL_PLUGINS=grafana-simple-json-datasource
       - GF_AUTH_ANONYMOUS_ENABLED=true
+      - GF_SERVER_DOMAIN=localhost
+      - GF_SERVER_ROOT_URL=http://localhost:8080/grafana/
+      - GF_SERVER_SERVE_FROM_SUB_PATH=true
       - JFR_DATASOURCE_URL=http://jfr-datasource:8080
-    ports:
-      - "3000:3000"
     expose:
       - "3000"
     healthcheck:

--- a/smoketest/compose/grafana_no_proxy.yml
+++ b/smoketest/compose/grafana_no_proxy.yml
@@ -1,0 +1,13 @@
+version: "3"
+services:
+  cryostat:
+    environment:
+      - GRAFANA_DASHBOARD_EXT_URL=${GRAFANA_DASHBOARD_EXT_URL:-http://localhost:3000/}
+      - GRAFANA_DASHBOARD_URL=http://grafana:3000
+  grafana:
+    ports:
+      - '3000:3000'
+    environment:
+      - GF_SERVER_DOMAIN=
+      - GF_SERVER_ROOT_URL=
+      - GF_SERVER_SERVE_FROM_SUB_PATH=false


### PR DESCRIPTION
# Welcome to Cryostat3! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat3/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] [Signed all commits using a GPG signature](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#gpg-commit-signature-verification)

**To recreate commits with GPG signature** `git fetch upstream && git rebase --force --gpg-sign upstream/main`
_______________________________________________

Related to #208
Related to #64

## Description of the change:
Places the Grafana dashboard container behind the OAuth proxy the same way that the Cryostat server is. The Grafana dashboard is hosted at the subpath `/grafana/`, and the container is configured to know about this subpath. The Cryostat server is configured to direct clients to that path when the "View in Grafana..." UI control is clicked.

## Motivation for the change:
This allows both the Cryostat server and Grafana server to be deployed with no direct authentication or authorization of their own. Instead, both are only reachable by going through the proxy, which handles all user authentication and authorization before traffic can reach these containers.

## How to manually test:
1. `./smoketest.bash -g` to deploy the smoketest with Grafana. Also try with other flags, ex. `-Xg`, `-Xgt`, etc. Try with `-gp` to deploy Grafana without the Proxy.
2. In all cases, the "View in Grafana..." feature in the Cryostat UI should work as expected. If `-p` was passed, your browser should open a `http://grafana:3000` tab for the Grafana dashboard. Otherwise, the tab should open to `http://auth:8080/grafana/`.
3. With `-gp`, go to `http://localhost:3000` manually in a new private/incognito window. This should bring you directly to the Grafana dashboard.
4. With `-g`, go to `http://localhost:8080/grafana/` manually in a new private/incognito window. This should bring you to the OAuth login page, just like `http://localhost:8080` does when you try to open the Cryostat UI. After logging in with `user:pass` you should be directed to the Grafana dashboard.
