### PR TITLE
feat(recordings): object storage URL may be different interally vs externally

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,6 @@
 
     <org.apache.commons.codec.version>1.16.0</org.apache.commons.codec.version>
     <org.apache.commons.io.version>2.13.0</org.apache.commons.io.version>
-    <org.apache.httpcomponents.version>4.5.14</org.apache.httpcomponents.version>
     <org.apache.httpcomponents.version>5.2.1</org.apache.httpcomponents.version>
     <org.apache.commons.lang3.version>3.13.0</org.apache.commons.lang3.version>
     <org.apache.commons.validator.version>1.7</org.apache.commons.validator.version>

--- a/smoketest.bash
+++ b/smoketest.bash
@@ -25,17 +25,17 @@ display_usage() {
     echo -e "\t-h\t\t\t\t\t\tprint this Help text."
     echo -e "\t-O\t\t\t\t\t\tOffline mode, do not attempt to pull container images."
     echo -e "\t-p\t\t\t\t\t\tDisable auth Proxy."
-    echo -e "\t-s [minio|seaweed|cloudserver|localstack]\tS3 implementation to spin up (default \"minio\")."
+    echo -e "\t-s [seaweed|minio|cloudserver|localstack]\tS3 implementation to spin up (default \"seaweed\")."
     echo -e "\t-g\t\t\t\t\t\tinclude Grafana dashboard and jfr-datasource in deployment."
     echo -e "\t-r\t\t\t\t\t\tconfigure a cryostat-Reports sidecar instance"
     echo -e "\t-t\t\t\t\t\t\tinclude sample applications for Testing."
     echo -e "\t-V\t\t\t\t\t\tdo not discard data storage Volumes on exit."
     echo -e "\t-X\t\t\t\t\t\tdeploy additional development aid tools."
     echo -e "\t-c [podman|docker]\t\t\t\tUse Podman or Docker Container Engine (default \"podman\")."
-    echo -e "\t-b\t\t\t\t\t\tOpen a Browser tab for each running service's first mapped port (ex. Cryostat web client, Minio console)"
+    echo -e "\t-b\t\t\t\t\t\tOpen a Browser tab for each running service's first mapped port (ex. auth proxy login, database viewer)"
 }
 
-s3=minio
+s3=seaweed
 ce=podman
 while getopts "hs:prgtOVXcb" opt; do
     case $opt in

--- a/smoketest/compose/auth_proxy_alpha_config.yaml
+++ b/smoketest/compose/auth_proxy_alpha_config.yaml
@@ -9,6 +9,12 @@ upstreamConfig:
     - id: grafana
       path: /grafana/
       uri: http://grafana:3000
+    - id: storage
+      path: ^/storage/(.*)$
+      rewriteTarget: /$1
+      uri: http://s3:${STORAGE_PORT}
+      passHostHeader: false
+      proxyWebSockets: false
 providers:
   - id: dummy
     name: Unused - Sign In Below

--- a/smoketest/compose/s3-cloudserver.yml
+++ b/smoketest/compose/s3-cloudserver.yml
@@ -4,6 +4,7 @@ services:
     environment:
       STORAGE_BUCKETS_ARCHIVES_NAME: archivedrecordings
       QUARKUS_S3_ENDPOINT_OVERRIDE: http://s3:8000
+      STORAGE_EXT_URL: http://localhost:8080/storage/
       QUARKUS_S3_PATH_STYLE_ACCESS: "true" # needed since compose setup does not support DNS subdomain resolution
       QUARKUS_S3_AWS_REGION: us-east-1
       QUARKUS_S3_AWS_CREDENTIALS_TYPE: static
@@ -14,8 +15,6 @@ services:
   s3:
     image: ${CLOUDSERVER_IMAGE:-docker.io/zenko/cloudserver:latest}
     hostname: s3
-    ports:
-      - "8000:8000"
     expose:
       - "8000"
     environment:

--- a/smoketest/compose/s3-localstack.yml
+++ b/smoketest/compose/s3-localstack.yml
@@ -4,6 +4,7 @@ services:
     environment:
       STORAGE_BUCKETS_ARCHIVES_NAME: archivedrecordings
       QUARKUS_S3_ENDPOINT_OVERRIDE: http://s3:4566
+      STORAGE_EXT_URL: http://localhost:8080/storage/
       QUARKUS_S3_PATH_STYLE_ACCESS: "true" # needed since compose setup does not support DNS subdomain resolution
       QUARKUS_S3_AWS_REGION: us-east-1
       QUARKUS_S3_AWS_CREDENTIALS_TYPE: static
@@ -14,8 +15,6 @@ services:
   s3:
     image: ${LOCALSTACK_IMAGE:-docker.io/localstack/localstack:latest}
     hostname: s3
-    ports:
-      - "4566:4566"
     expose:
       - "4566"
     environment:

--- a/smoketest/compose/s3-minio.yml
+++ b/smoketest/compose/s3-minio.yml
@@ -4,6 +4,7 @@ services:
     environment:
       STORAGE_BUCKETS_ARCHIVES_NAME: archivedrecordings
       QUARKUS_S3_ENDPOINT_OVERRIDE: http://s3:9000
+      STORAGE_EXT_URL: http://localhost:8080/storage/
       QUARKUS_S3_PATH_STYLE_ACCESS: "true" # needed since compose setup does not support DNS subdomain resolution
       QUARKUS_S3_AWS_REGION: us-east-1
       QUARKUS_S3_AWS_CREDENTIALS_TYPE: static
@@ -14,12 +15,8 @@ services:
   s3:
     image: ${MINIO_IMAGE:-docker.io/minio/minio:latest}
     hostname: s3
-    ports:
-      - "9001:9001"
-      - "9000:9000"
     expose:
       - "9000"
-      - "9001"
     command: server /data --console-address ":9001"
     environment:
       MINIO_ROOT_USER: minioroot

--- a/smoketest/compose/s3-seaweed.yml
+++ b/smoketest/compose/s3-seaweed.yml
@@ -8,18 +8,20 @@ services:
       QUARKUS_S3_PATH_STYLE_ACCESS: "true" # needed since compose setup does not support DNS subdomain resolution
       QUARKUS_S3_AWS_REGION: us-east-1
       QUARKUS_S3_AWS_CREDENTIALS_TYPE: static
-      QUARKUS_S3_AWS_CREDENTIALS_STATIC_PROVIDER_ACCESS_KEY_ID: unused
-      QUARKUS_S3_AWS_CREDENTIALS_STATIC_PROVIDER_SECRET_ACCESS_KEY: unused
-      AWS_ACCESS_KEY_ID: unused
-      AWS_SECRET_ACCESS_KEY: unused
+      QUARKUS_S3_AWS_CREDENTIALS_STATIC_PROVIDER_ACCESS_KEY_ID: access_key
+      QUARKUS_S3_AWS_CREDENTIALS_STATIC_PROVIDER_SECRET_ACCESS_KEY: secret_key
+      AWS_ACCESS_KEY_ID: access_key
+      AWS_SECRET_ACCESS_KEY: secret_key
   s3:
     image: ${SEAWEEDFS_IMAGE:-docker.io/chrislusf/seaweedfs:latest}
     hostname: s3
-    command: server -dir=/data -s3
+    command: server -dir=/data -s3 -s3.config=/opt/seaweed_cfg.json
     environment:
+      IP_BIND: 0.0.0.0
       WEED_V: '4' # glog logging level
     volumes:
       - seaweed_data:/data
+      - seaweed_cfg:/opt
     expose:
       - "8333"
     labels:
@@ -40,3 +42,5 @@ services:
 volumes:
   seaweed_data:
     driver: local
+  seaweed_cfg:
+    external: true

--- a/smoketest/compose/s3-seaweed.yml
+++ b/smoketest/compose/s3-seaweed.yml
@@ -16,6 +16,8 @@ services:
     image: ${SEAWEEDFS_IMAGE:-docker.io/chrislusf/seaweedfs:latest}
     hostname: s3
     command: server -dir=/data -s3
+    environment:
+      WEED_V: '4'
     volumes:
       - seaweed_data:/data
     expose:

--- a/smoketest/compose/s3-seaweed.yml
+++ b/smoketest/compose/s3-seaweed.yml
@@ -4,6 +4,7 @@ services:
     environment:
       STORAGE_BUCKETS_ARCHIVES_NAME: archivedrecordings
       QUARKUS_S3_ENDPOINT_OVERRIDE: http://s3:8333
+      STORAGE_EXT_URL: http://localhost:8080/storage/
       QUARKUS_S3_PATH_STYLE_ACCESS: "true" # needed since compose setup does not support DNS subdomain resolution
       QUARKUS_S3_AWS_REGION: us-east-1
       QUARKUS_S3_AWS_CREDENTIALS_TYPE: static
@@ -15,8 +16,6 @@ services:
     image: ${SEAWEEDFS_IMAGE:-docker.io/chrislusf/seaweedfs:latest}
     command: server -s3
     hostname: s3
-    ports:
-      - "8333:8333"
     expose:
       - "8333"
     labels:

--- a/smoketest/compose/s3-seaweed.yml
+++ b/smoketest/compose/s3-seaweed.yml
@@ -14,8 +14,10 @@ services:
       AWS_SECRET_ACCESS_KEY: unused
   s3:
     image: ${SEAWEEDFS_IMAGE:-docker.io/chrislusf/seaweedfs:latest}
-    command: server -s3
     hostname: s3
+    command: server -dir=/data -s3
+    volumes:
+      - seaweed_data:/data
     expose:
       - "8333"
     labels:
@@ -32,3 +34,7 @@ services:
       retries: 3
       start_period: 30s
       timeout: 5s
+
+volumes:
+  seaweed_data:
+    driver: local

--- a/smoketest/compose/s3-seaweed.yml
+++ b/smoketest/compose/s3-seaweed.yml
@@ -17,7 +17,7 @@ services:
     hostname: s3
     command: server -dir=/data -s3
     environment:
-      WEED_V: '4'
+      WEED_V: '4' # glog logging level
     volumes:
       - seaweed_data:/data
     expose:

--- a/smoketest/compose/s3_no_proxy.yml
+++ b/smoketest/compose/s3_no_proxy.yml
@@ -1,0 +1,8 @@
+version: "3"
+services:
+  s3:
+    ports:
+      - "${STORAGE_PORT}:${STORAGE_PORT}"
+  cryostat:
+    environment:
+      STORAGE_EXT_URL: ''

--- a/smoketest/compose/seaweed_cfg.json
+++ b/smoketest/compose/seaweed_cfg.json
@@ -1,0 +1,28 @@
+{
+  "identities": [
+    {
+      "name": "anonymous",
+      "actions": [
+        "Read"
+      ]
+    },
+    {
+      "name": "cryostat",
+      "credentials": [
+        {
+          "accessKey": "access_key",
+          "secretKey": "secret_key"
+        }
+      ],
+      "actions": [
+        "Admin",
+        "Read",
+        "ReadAcp",
+        "List",
+        "Tagging",
+        "Write",
+        "WriteAcp"
+      ]
+    }
+  ]
+}

--- a/src/main/java/io/cryostat/ConfigProperties.java
+++ b/src/main/java/io/cryostat/ConfigProperties.java
@@ -33,4 +33,6 @@ public class ConfigProperties {
     public static final String GRAFANA_DASHBOARD_URL = "grafana-dashboard.url";
     public static final String GRAFANA_DASHBOARD_EXT_URL = "grafana-dashboard-ext.url";
     public static final String GRAFANA_DATASOURCE_URL = "grafana-datasource.url";
+
+    public static final String STORAGE_EXT_URL = "storage-ext.url";
 }

--- a/src/main/java/io/cryostat/recordings/Recordings.java
+++ b/src/main/java/io/cryostat/recordings/Recordings.java
@@ -965,11 +965,13 @@ public class Recordings {
         if (recording == null) {
             throw new NotFoundException();
         }
+        String savename = recording.name;
         String filename =
                 recordingHelper.saveRecording(
-                        recording, Instant.now().plusSeconds(60)); // TODO make expiry configurable
+                        recording,
+                        savename,
+                        Instant.now().plusSeconds(60)); // TODO make expiry configurable
         String encodedKey = recordingHelper.encodedKey(recording.target.jvmId, filename);
-        String savename = recording.name;
         if (!savename.endsWith(".jfr")) {
             savename += ".jfr";
         }

--- a/src/main/java/io/cryostat/recordings/Recordings.java
+++ b/src/main/java/io/cryostat/recordings/Recordings.java
@@ -1023,7 +1023,9 @@ public class Recordings {
             response =
                     response.header(
                             HttpHeaders.CONTENT_DISPOSITION,
-                            String.format("attachment; filename=\"%s\"", f));
+                            String.format(
+                                    "attachment; filename=\"%s\"",
+                                    new String(base64Url.decode(f), StandardCharsets.UTF_8)));
         }
         return response.location(uri).build();
     }

--- a/src/main/java/io/cryostat/recordings/Recordings.java
+++ b/src/main/java/io/cryostat/recordings/Recordings.java
@@ -995,14 +995,19 @@ public class Recordings {
         PresignedGetObjectRequest presignedRequest = presigner.presignGetObject(presignRequest);
         URI uri = presignedRequest.url().toURI();
         if (externalStorageUrl.isPresent()) {
-            URI extUri = new URI(externalStorageUrl.get());
-            uri =
-                    new URI(
-                            extUri.getScheme(),
-                            extUri.getAuthority(),
-                            URI.create(extUri.getPath()).resolve(uri.getPath()).getPath(),
-                            uri.getQuery(),
-                            uri.getFragment());
+            String extUrl = externalStorageUrl.get();
+            if (StringUtils.isNotBlank(extUrl)) {
+                URI extUri = new URI(extUrl);
+                uri =
+                        new URI(
+                                extUri.getScheme(),
+                                extUri.getAuthority(),
+                                URI.create(String.format("%s/%s", extUri.getPath(), uri.getPath()))
+                                        .normalize()
+                                        .getPath(),
+                                uri.getQuery(),
+                                uri.getFragment());
+            }
         }
         return Response.status(RestResponse.Status.PERMANENT_REDIRECT).location(uri).build();
     }

--- a/src/main/java/io/cryostat/recordings/Recordings.java
+++ b/src/main/java/io/cryostat/recordings/Recordings.java
@@ -969,17 +969,21 @@ public class Recordings {
                 recordingHelper.saveRecording(
                         recording, Instant.now().plusSeconds(60)); // TODO make expiry configurable
         String encodedKey = recordingHelper.encodedKey(recording.target.jvmId, filename);
+        String savename = recording.name;
+        if (!savename.endsWith(".jfr")) {
+            savename += ".jfr";
+        }
         return Response.status(RestResponse.Status.PERMANENT_REDIRECT)
                 .header(
                         HttpHeaders.CONTENT_DISPOSITION,
-                        String.format("attachment; filename=\"%s.jfr\"", recording.name))
+                        String.format("attachment; filename=\"%s\"", savename))
                 .location(
                         URI.create(
                                 String.format(
                                         "/api/v3/download/%s?f=%s",
                                         encodedKey,
                                         base64Url.encodeAsString(
-                                                recording.name.getBytes(StandardCharsets.UTF_8)))))
+                                                savename.getBytes(StandardCharsets.UTF_8)))))
                 .build();
     }
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -46,6 +46,7 @@ quarkus.http.filter.static.matches=/static/.+
 quarkus.http.filter.static.methods=GET
 quarkus.http.filter.static.order=1
 
+storage-ext.url=
 storage.buckets.archives.name=archivedrecordings
 storage.buckets.archives.expiration-label=expiration
 


### PR DESCRIPTION
# Welcome to Cryostat3! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat3/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] [Signed all commits using a GPG signature](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#gpg-commit-signature-verification)

**To recreate commits with GPG signature** `git fetch upstream && git rebase --force --gpg-sign upstream/main`
_______________________________________________

Based on #235
Related to #2

## Description of the change:
Adds optional configuration `storage-ext.url`, similar to existing `grafana-dashboard-ext.url`.

## Motivation for the change:
Cryostat uses this URL to determine the externally-facing URL where the object storage provider (S3 instance) can be reached by requesting clients, since Cryostat is likely to use an internal URL to communicate with the storage provider, but should tell clients how to download files from the object store using an externally routable URL.

## How to manually test:
1. `./mvnw clean package ; podman image prune -f`
2. `./smoketest.bash -O`
3. `http -v --follow --auth=user:pass :8080/api/v3/activedownload/1` to attempt downloading an active recording - see examples below.
4. This can also be done by opening `localhost:8080` in a browser, logging in with `user:pass`, going to Recordings, selecting Cryostat as the target, and attempting to download the `onstart` recording. Open browser devtools network tab to view and verify request paths.
5. Verify that the URL the client is redirected to looks like `http://localhost:8080/storage/$somepath`, where `somepath` is an S3 presigned URL. The `localhost:8080/storage` prefix is the important part, indicating that the request is being routed through the auth proxy.

## Current difficulties:
~~1. S3 instances produce the presigned request URL using various parameters like the request URL and headers, which become encoded as part of the signature of the short-lived token for the resource. This is very similar to what we have implemented directly in 2.x. This means that using an internal URL for Cryostat to talk to S3, and an external URL for clients to talk to S3, does not meet the signature validation requirements and S3 rejects the client's request.
2. Configuring Cryostat to talk to S3 via the external route would likely resolve the point above since then the request parameters can be the same, however in practice this would mean that Cryostat would need to go through the authentication proxy as well (the same as an external client does). This gets pretty messy since it's an additional set of credentials and authorization that need to be set up just for this reason. This might not be too bad in a real Kubernetes deployment since Cryostat should be able to use its own serviceaccount token to talk through the proxy. Maybe we can use `--skip-auth-regex` on the storage path so that the proxy only acts a gateway in front of S3 and does not perform authz duties? This means that the S3 provider *must* have its own authz for anything other than presigned URLs, but since our primary deployment target scenario is to use MinIO this should be okay since that does have its own robust authz mechanism that we can configure separately.~~
Switching from Minio to SeaweedFS seems to have resolved the above. Seaweed tolerates the internal vs external URL, once it is configured with user basic auth to enable presigned downloads at all.

1. Switching from Minio to SeaweedFS, it seems Seaweed is not properly respecting the `Content-Disposition` header set when redirecting clients to download active recordings. The new flow for this action in Cryostat 3 is that Cryostat actually pipes the JFR data out of the target JVM and uploads it to S3, rather than sending it back out to the client directly. Then Cryostat sends the client back a redirect response telling it to go get the file itself from S3 using a presigned URL, and a `Content-Disposition` header that should inform the client (browser) what filename to use when saving this file, overriding the filename as it is found on the server. With Minio this works as expected, but with Seaweed the saved file retains the filename it has on the server. This ends up looking the same as any other archived recording file, which is not so bad, but the bugged behaviour is that this does not match the filename of the accompanying `.metadata.json` file produced by the web-client. **Potential fix**: don't generate the `.metadata.json` on the client, actually supply that straight from the server and just have the client download it. The filenames may end up looking like archived recording filenames, which I think is actually OK, and at least the JFR and metadata JSON files will have matching names.

With Seaweed:
```bash
$ http -v --follow --auth=user:pass :8080/api/v3/activedownload/1
GET /api/v3/activedownload/1 HTTP/1.1
Accept: */*
Accept-Encoding: gzip, deflate, br
Authorization: Basic dXNlcjpwYXNz
Connection: keep-alive
Host: localhost:8080
User-Agent: HTTPie/3.2.2



HTTP/1.1 308 Permanent Redirect
Cache-Control: no-cache
Content-Disposition: attachment; filename="onstart.jfr"
Content-Length: 0
Date: Fri, 12 Jan 2024 18:37:23 GMT
Gap-Auth: user
Location: http://localhost:8080/api/v3/download/THB0RWlxN2U0cHE5eE1WRlJzZDYwSGp3OEdoaG53c24wa2xKa2ZuclFWOD0vY29tcG9zZS1jcnlvc3RhdC0xX29uc3RhcnRfMjAyNDAxMTJUMTgzNzIyWi5qZnI?f=b25zdGFydC5qZnI



GET /api/v3/download/THB0RWlxN2U0cHE5eE1WRlJzZDYwSGp3OEdoaG53c24wa2xKa2ZuclFWOD0vY29tcG9zZS1jcnlvc3RhdC0xX29uc3RhcnRfMjAyNDAxMTJUMTgzNzIyWi5qZnI?f=b25zdGFydC5qZnI HTTP/1.1
Accept: */*
Accept-Encoding: gzip, deflate, br
Authorization: Basic dXNlcjpwYXNz
Connection: keep-alive
Host: localhost:8080
User-Agent: HTTPie/3.2.2



HTTP/1.1 308 Permanent Redirect
Cache-Control: no-cache
Content-Disposition: attachment; filename="onstart.jfr"
Content-Length: 0
Date: Fri, 12 Jan 2024 18:37:23 GMT
Gap-Auth: user
Location: http://localhost:8080/storage/archivedrecordings/LptEiq7e4pq9xMVFRsd60Hjw8Ghhnwsn0klJkfnrQV8=/compose-cryostat-1_onstart_20240112T183722Z.jfr?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Date=20240112T183723Z&X-Amz-SignedHeaders=host&X-Amz-Expires=60&X-Amz-Credential=access_key/20240112/us-east-1/s3/aws4_request&X-Amz-Signature=d53ab9c8a79820c79822f66a33041ebf4afd064aa489f0131a643990a8f62b3d



GET /storage/archivedrecordings/LptEiq7e4pq9xMVFRsd60Hjw8Ghhnwsn0klJkfnrQV8=/compose-cryostat-1_onstart_20240112T183722Z.jfr?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Date=20240112T183723Z&X-Amz-SignedHeaders=host&X-Amz-Expires=60&X-Amz-Credential=access_key/20240112/us-east-1/s3/aws4_request&X-Amz-Signature=d53ab9c8a79820c79822f66a33041ebf4afd064aa489f0131a643990a8f62b3d HTTP/1.1
Accept: */*
Accept-Encoding: gzip, deflate, br
Authorization: Basic dXNlcjpwYXNz
Connection: keep-alive
Host: localhost:8080
User-Agent: HTTPie/3.2.2



HTTP/1.1 200 OK
Accept-Ranges: bytes
Access-Control-Expose-Headers: Content-Disposition
Content-Disposition: inline; filename="compose-cryostat-1_onstart_20240112T183722Z.jfr"
Content-Length: 1754515
Content-Type: binary/octet-stream
Date: Fri, 12 Jan 2024 18:37:23 GMT
Etag: "e8c91341182321ce9dbd2940df43e2de"
Gap-Auth: user
Last-Modified: Fri, 12 Jan 2024 18:37:23 GMT
Server: SeaweedFS Filer 30GB 3.61
X-Amz-Tagging-Anztswq: THB0RWlxN2U0cHE5eE1WRlJzZDYwSGp3OEdoaG53c24wa2xKa2ZuclFWOD0
X-Amz-Tagging-Count: 3
X-Amz-Tagging-Y29ubmvjdfvyba: c2VydmljZTpqbXg6cm1pOi8vL2puZGkvcm1pOi8vbG9jYWxob3N0OjAvam14cm1p
X-Amz-Tagging-Zxhwaxjhdglvbg: MjAyNC0wMS0xMlQxODozODoyMi42NDM4MDEzOTZa



+-----------------------------------------+
| NOTE: binary data not shown in terminal |
+-----------------------------------------+
```

With Minio:

```bash
$ http -v --follow --auth=user:pass :8080/api/v3/activedownload/1
GET /api/v3/activedownload/1 HTTP/1.1
Accept: */*
Accept-Encoding: gzip, deflate, br
Authorization: Basic dXNlcjpwYXNz
Connection: keep-alive
Host: localhost:8080
User-Agent: HTTPie/3.2.2



HTTP/1.1 308 Permanent Redirect
Cache-Control: no-cache
Content-Disposition: attachment; filename="onstart.jfr"
Content-Length: 0
Date: Fri, 12 Jan 2024 18:38:35 GMT
Gap-Auth: user
Location: http://localhost:8080/api/v3/download/QWFMYzJTVDRjYTBrTnUwUjNZRGpQR0xyZmtXcGdXSkduQnVONXZ5RGxXST0vY29tcG9zZS1jcnlvc3RhdC0xX29uc3RhcnRfMjAyNDAxMTJUMTgzODM1Wi5qZnI?f=b25zdGFydC5qZnI



GET /api/v3/download/QWFMYzJTVDRjYTBrTnUwUjNZRGpQR0xyZmtXcGdXSkduQnVONXZ5RGxXST0vY29tcG9zZS1jcnlvc3RhdC0xX29uc3RhcnRfMjAyNDAxMTJUMTgzODM1Wi5qZnI?f=b25zdGFydC5qZnI HTTP/1.1
Accept: */*
Accept-Encoding: gzip, deflate, br
Authorization: Basic dXNlcjpwYXNz
Connection: keep-alive
Host: localhost:8080
User-Agent: HTTPie/3.2.2



HTTP/1.1 308 Permanent Redirect
Cache-Control: no-cache
Content-Disposition: attachment; filename="onstart.jfr"
Content-Length: 0
Date: Fri, 12 Jan 2024 18:38:35 GMT
Gap-Auth: user
Location: http://localhost:8080/storage/archivedrecordings/AaLc2ST4ca0kNu0R3YDjPGLrfkWpgWJGnBuN5vyDlWI=/compose-cryostat-1_onstart_20240112T183835Z.jfr?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Date=20240112T183835Z&X-Amz-SignedHeaders=host&X-Amz-Expires=60&X-Amz-Credential=minioroot/20240112/us-east-1/s3/aws4_request&X-Amz-Signature=2d15450d129d3c270fe40011d142415ae41c2b2ee4289b3281ecb1336c7c1c21



GET /storage/archivedrecordings/AaLc2ST4ca0kNu0R3YDjPGLrfkWpgWJGnBuN5vyDlWI=/compose-cryostat-1_onstart_20240112T183835Z.jfr?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Date=20240112T183835Z&X-Amz-SignedHeaders=host&X-Amz-Expires=60&X-Amz-Credential=minioroot/20240112/us-east-1/s3/aws4_request&X-Amz-Signature=2d15450d129d3c270fe40011d142415ae41c2b2ee4289b3281ecb1336c7c1c21 HTTP/1.1
Accept: */*
Accept-Encoding: gzip, deflate, br
Authorization: Basic dXNlcjpwYXNz
Connection: keep-alive
Host: localhost:8080
User-Agent: HTTPie/3.2.2



HTTP/1.1 200 OK
Accept-Ranges: bytes
Content-Length: 1628312
Content-Type: binary/octet-stream
Date: Fri, 12 Jan 2024 18:38:35 GMT
Etag: "320062a5bb9151ac47dd8c16d9aaf98e-1"
Expires: Fri, 12 Jan 2024 18:39:35 GMT
Gap-Auth: user
Last-Modified: Fri, 12 Jan 2024 18:38:35 GMT
Server: MinIO
Strict-Transport-Security: max-age=31536000; includeSubDomains
Vary: Origin
Vary: Accept-Encoding
X-Amz-Id-2: dd9025bab4ad464b049177c95eb6ebf374d3b3fd1af9251148b658df7ac2e3e8
X-Amz-Request-Id: 17A9AD83BC0440D5
X-Amz-Tagging-Count: 3
X-Content-Type-Options: nosniff
X-Xss-Protection: 1; mode=block



+-----------------------------------------+
| NOTE: binary data not shown in terminal |
+-----------------------------------------+
```

Note how in the Minio case, there is an initial `Content-Disposition` on the first redirect, the same on the second redirect, and none in the final response. Whereas in the Seaweed case, the first two redirect responses have the same header (since these come from Cryostat), and the final response from Seaweed also contains the `Content-Disposition` header but with different contents. This is what causes the bug. I have patched some of the behaviour for this header as set in the two Cryostat redirect responses, as well as tried specifying that header's value in the object metadata when Cryostat uploads it to Seaweed, but to no avail. I've burned a few hours trying to work around this but keep triggering the presigned URL signature validation failure whenever I try something else, so this might just have to do for now.