### PR TITLE
test(smoketest): expose storage API ports externally

### DIFF
--- a/smoketest/compose/s3-cloudserver.yml
+++ b/smoketest/compose/s3-cloudserver.yml
@@ -14,6 +14,8 @@ services:
   s3:
     image: ${CLOUDSERVER_IMAGE:-docker.io/zenko/cloudserver:latest}
     hostname: s3
+    ports:
+      - "8000:8000"
     expose:
       - "8000"
     environment:

--- a/smoketest/compose/s3-localstack.yml
+++ b/smoketest/compose/s3-localstack.yml
@@ -14,9 +14,10 @@ services:
   s3:
     image: ${LOCALSTACK_IMAGE:-docker.io/localstack/localstack:latest}
     hostname: s3
+    ports:
+      - "4566:4566"
     expose:
       - "4566"
-      - "4577"
     environment:
       SERVICES: s3
       START_WEB: 1

--- a/smoketest/compose/s3-minio.yml
+++ b/smoketest/compose/s3-minio.yml
@@ -16,6 +16,7 @@ services:
     hostname: s3
     ports:
       - "9001:9001"
+      - "9000:9000"
     expose:
       - "9000"
       - "9001"

--- a/smoketest/compose/s3-seaweed.yml
+++ b/smoketest/compose/s3-seaweed.yml
@@ -15,6 +15,8 @@ services:
     image: ${SEAWEEDFS_IMAGE:-docker.io/chrislusf/seaweedfs:latest}
     command: server -s3
     hostname: s3
+    ports:
+      - "8333:8333"
     expose:
       - "8333"
     labels:


### PR DESCRIPTION
# Welcome to Cryostat3! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat3/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] [Signed all commits using a GPG signature](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#gpg-commit-signature-verification)

**To recreate commits with GPG signature** `git fetch upstream && git rebase --force --gpg-sign upstream/main`
_______________________________________________

Related to https://github.com/cryostatio/cryostat-web/pull/1206

## Description of the change:
Opens the smoketest compose ports to requests from the host.

## Motivation for the change:
This is required for host requests (ex. browser client on the host) to be able to make requests to the object storage (S3) container, which would be the case when the client tries to download a recording for example.

## How to manually test:
1. Build cryostat3 with https://github.com/cryostatio/cryostat-web/pull/1206
2. `./smoketest.bash -O`, open `localhost:8080` in a browser
3. Go to Recordings, select `localhost:0` target, then try to download an active recording.
4. Archive an active recording, go to Archives > All Archives, and try to download an archived recording.
