### PR TITLE
fix(rules): rule application occurs within DB transaction to ensure cursor is not closed prematurely

### DIFF
--- a/src/main/java/io/cryostat/rules/RuleService.java
+++ b/src/main/java/io/cryostat/rules/RuleService.java
@@ -189,7 +189,8 @@ public class RuleService {
         return optionsBuilder.build();
     }
 
-    private void applyRuleToMatchingTargets(Rule rule) {
+    @Transactional
+    void applyRuleToMatchingTargets(Rule rule) {
         try (Stream<Target> targets = Target.streamAll()) {
             targets.filter(
                             target -> {

--- a/src/main/java/io/cryostat/rules/ScheduledArchiveJob.java
+++ b/src/main/java/io/cryostat/rules/ScheduledArchiveJob.java
@@ -27,6 +27,7 @@ import io.cryostat.recordings.RecordingHelper;
 import io.cryostat.targets.Target;
 
 import jakarta.inject.Inject;
+import jakarta.transaction.Transactional;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.jboss.logging.Logger;
 import org.quartz.Job;
@@ -66,8 +67,8 @@ class ScheduledArchiveJob implements Job {
         }
     }
 
-    private void initPreviousRecordings(
-            Target target, Rule rule, Queue<String> previousRecordings) {
+    @Transactional
+    void initPreviousRecordings(Target target, Rule rule, Queue<String> previousRecordings) {
         recordingHelper.listArchivedRecordingObjects().parallelStream()
                 .forEach(
                         item -> {
@@ -87,13 +88,15 @@ class ScheduledArchiveJob implements Job {
                         });
     }
 
-    private void performArchival(ActiveRecording recording, Queue<String> previousRecordings)
+    @Transactional
+    void performArchival(ActiveRecording recording, Queue<String> previousRecordings)
             throws Exception {
         String filename = recordingHelper.saveRecording(recording);
         previousRecordings.add(filename);
     }
 
-    private void pruneArchive(Target target, Queue<String> previousRecordings, String filename)
+    @Transactional
+    void pruneArchive(Target target, Queue<String> previousRecordings, String filename)
             throws Exception {
         recordingHelper.deleteArchivedRecording(target.jvmId, filename);
         previousRecordings.remove(filename);


### PR DESCRIPTION
# Welcome to Cryostat3! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat3/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] [Signed all commits using a GPG signature](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#gpg-commit-signature-verification)

**To recreate commits with GPG signature** `git fetch upstream && git rebase --force --gpg-sign upstream/main`
_______________________________________________

Fixes: #245

## Description of the change:
Annotate method with `@Transactional` to ensure the database cursor/connection is not prematurely closed.

## Motivation for the change:
See #245

## How to manually test:
See #245
Also try:
```json
{
  "name": "test",
  "description": "",
  "matchExpression": "!target.connectUrl.startsWith('http')",
  "eventSpecifier": "template=Profiling,type=TARGET",
  "archivalPeriodSeconds": 15,
  "initialDelaySeconds": 0,
  "preservedArchives": 3,
  "maxAgeSeconds": 0,
  "maxSizeBytes": 10485760,
  "enabled": false,
  "recordingName": "auto_test"
}
```
Upload this rule definition and enable it. Recordings should be started within a few seconds, and then every 15 seconds afterward should be archived, and once there are 3 copies of each, the oldest copies should start rolling over and getting deleted.
