### PR TITLE
fix(discovery): check container discovery domain socket readability before start

### DIFF
--- a/smoketest/compose/cryostat.yml
+++ b/smoketest/compose/cryostat.yml
@@ -28,8 +28,9 @@ services:
       QUARKUS_HTTP_HOST: "cryostat"
       QUARKUS_HTTP_PORT: ${CRYOSTAT_HTTP_PORT}
       QUARKUS_HIBERNATE_ORM_LOG_SQL: "true"
-      CRYOSTAT_DISCOVERY_PODMAN_ENABLED: "true"
       CRYOSTAT_DISCOVERY_JDP_ENABLED: "true"
+      CRYOSTAT_DISCOVERY_PODMAN_ENABLED: "true"
+      CRYOSTAT_DISCOVERY_DOCKER_ENABLED: "true"
       JAVA_OPTS_APPEND: "-XX:+FlightRecorder -XX:StartFlightRecording=name=onstart,settings=default,disk=true,maxage=5m -XX:StartFlightRecording=name=startup,settings=profile,disk=true,duration=30s -Dcom.sun.management.jmxremote.autodiscovery=true -Dcom.sun.management.jmxremote -Dcom.sun.management.jmxremote.port=9091 -Dcom.sun.management.jmxremote.rmi.port=9091 -Djava.rmi.server.hostname=127.0.0.1 -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.local.only=false"
     restart: unless-stopped
     healthcheck:

--- a/src/main/java/io/cryostat/ConfigProperties.java
+++ b/src/main/java/io/cryostat/ConfigProperties.java
@@ -20,6 +20,10 @@ public class ConfigProperties {
     public static final String AWS_OBJECT_EXPIRATION_LABELS =
             "storage.buckets.archives.expiration-label";
 
+    public static final String CONTAINERS_POLL_PERIOD = "cryostat.discovery.containers.poll-period";
+    public static final String CONTAINERS_REQUEST_TIMEOUT =
+            "cryostat.discovery.containers.request-timeout";
+
     public static final String CONNECTIONS_MAX_OPEN = "cryostat.connections.max-open";
     public static final String CONNECTIONS_TTL = "cryostat.connections.ttl";
     public static final String CONNECTIONS_FAILED_BACKOFF = "cryostat.connections.failed-backoff";

--- a/src/main/java/io/cryostat/discovery/ContainerDiscovery.java
+++ b/src/main/java/io/cryostat/discovery/ContainerDiscovery.java
@@ -150,7 +150,7 @@ public abstract class ContainerDiscovery {
         }
 
         Path socketPath = Path.of(getSocket().path());
-        if (!(fs.isRegularFile(socketPath) && fs.isReadable(socketPath))) {
+        if (!(fs.exists(socketPath) && fs.isReadable(socketPath))) {
             logger.errorv(
                     "{0} enabled but socket {1} is not accessible!",
                     getClass().getName(), socketPath);

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,5 +1,7 @@
 quarkus.naming.enable-jndi=true
 cryostat.discovery.jdp.enabled=false
+cryostat.discovery.containers.poll-period=10s
+cryostat.discovery.containers.request-timeout=2s
 cryostat.discovery.podman.enabled=false
 cryostat.discovery.docker.enabled=false
 quarkus.test.integration-test-profile=test


### PR DESCRIPTION
# Welcome to Cryostat3! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat3/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] [Signed all commits using a GPG signature](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#gpg-commit-signature-verification)

**To recreate commits with GPG signature** `git fetch upstream && git rebase --force --gpg-sign upstream/main`
_______________________________________________

Fixes: #250

## How to manually test:
1. `./mvnw clean verify ; podman image prune -f`
2. `./smoketest.bash -O` and look for messages like `ERROR: io.cryostat.discovery.DockerDiscovery_Subclass enabled but socket /var/run/docker.sock is not accessible!` shortly after startup. The repeated log messages like in #250 should no longer appear. May be easier via `podman logs compose_cryostat_1` rather than the interleaved smoketest logs from all services.

```
Jan 22, 2024 3:37:08 PM io.cryostat.discovery.ContainerDiscovery onStart
ERROR: io.cryostat.discovery.DockerDiscovery_Subclass enabled but socket /var/run/docker.sock is not accessible!
Jan 22, 2024 3:37:08 PM io.cryostat.discovery.ContainerDiscovery onStart
INFO: io.cryostat.discovery.PodmanDiscovery_Subclass started
```
