### PR TITLE
perf(startup): enable startup profiling recording

### DIFF
--- a/smoketest/compose/cryostat.yml
+++ b/smoketest/compose/cryostat.yml
@@ -30,7 +30,7 @@ services:
       QUARKUS_HIBERNATE_ORM_LOG_SQL: "true"
       CRYOSTAT_DISCOVERY_PODMAN_ENABLED: "true"
       CRYOSTAT_DISCOVERY_JDP_ENABLED: "true"
-      JAVA_OPTS_APPEND: "-XX:+FlightRecorder -XX:StartFlightRecording=name=onstart,settings=default,disk=true,maxage=5m -Dcom.sun.management.jmxremote.autodiscovery=true -Dcom.sun.management.jmxremote -Dcom.sun.management.jmxremote.port=9091 -Dcom.sun.management.jmxremote.rmi.port=9091 -Djava.rmi.server.hostname=127.0.0.1 -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.local.only=false"
+      JAVA_OPTS_APPEND: "-XX:+FlightRecorder -XX:StartFlightRecording=name=onstart,settings=default,disk=true,maxage=5m -XX:StartFlightRecording=name=startup,settings=profile,disk=true,duration=30s -Dcom.sun.management.jmxremote.autodiscovery=true -Dcom.sun.management.jmxremote -Dcom.sun.management.jmxremote.port=9091 -Dcom.sun.management.jmxremote.rmi.port=9091 -Djava.rmi.server.hostname=127.0.0.1 -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.local.only=false"
     restart: unless-stopped
     healthcheck:
       test: curl --fail http://cryostat:${CRYOSTAT_HTTP_PORT}/health/liveness || exit 1


### PR DESCRIPTION
# Welcome to Cryostat3! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat3/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] [Signed all commits using a GPG signature](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#gpg-commit-signature-verification)

**To recreate commits with GPG signature** `git fetch upstream && git rebase --force --gpg-sign upstream/main`
_______________________________________________

Related to #28

## Description of the change:
Adds a startup profiling flight recording to Cryostat itself in smoketesting.

## Motivation for the change:
We can/should use this recording every now and then to check Cryostat's own startup performance and look for ways to optimize it so that the startup is faster and leaner.

## How to manually test:
1. `./smoketest.bash`
2. Open web UI on `http://localhost:8080`
3. Select `localhost:0` target, go to Recordings > Active Recordings and verify that the `startup` recording is present
