### PR TITLE
test(smoketest): add healthcheck to -reports container

### DIFF
--- a/smoketest/compose/reports.yml
+++ b/smoketest/compose/reports.yml
@@ -22,3 +22,9 @@ services:
     environment:
       JAVA_OPTS_APPEND: "-Dcom.sun.management.jmxremote.autodiscovery=true -Dcom.sun.management.jmxremote -Dcom.sun.management.jmxremote.port=11224 -Dcom.sun.management.jmxremote.rmi.port=11224 -Djava.rmi.server.hostname=reports -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.local.only=false"
       QUARKUS_HTTP_PORT: 10001
+    healthcheck:
+      test: curl --fail http://localhost:10001/ || exit 1
+      retries: 3
+      interval: 30s
+      start_period: 30s
+      timeout: 1s


### PR DESCRIPTION
# Welcome to Cryostat3! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat3/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] [Signed all commits using a GPG signature](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#gpg-commit-signature-verification)

**To recreate commits with GPG signature** `git fetch upstream && git rebase --force --gpg-sign upstream/main`
_______________________________________________

Related to #267

## Description of the change:
Adds a simple HTTP healthcheck to the reports container, similar to what other smoketest containers already have

## Motivation for the change:
Allows smoketest harness to properly determine if -reports container has started up and restart it if necessary
