### PR TITLE
feat(download): implement download piping as default rather than presigned URLs

### DIFF
--- a/src/main/java/io/cryostat/ConfigProperties.java
+++ b/src/main/java/io/cryostat/ConfigProperties.java
@@ -48,4 +48,5 @@ public class ConfigProperties {
             "storage.presigned-downloads.enabled";
     public static final String STORAGE_TRANSIENT_ARCHIVES_ENABLED =
             "storage.transient-archives.enabled";
+    public static final String STORAGE_TRANSIENT_ARCHIVES_TTL = "storage.transient-archives.ttl";
 }

--- a/src/main/java/io/cryostat/ConfigProperties.java
+++ b/src/main/java/io/cryostat/ConfigProperties.java
@@ -46,4 +46,6 @@ public class ConfigProperties {
     public static final String STORAGE_EXT_URL = "storage-ext.url";
     public static final String STORAGE_PRESIGNED_DOWNLOADS_ENABLED =
             "storage.presigned-downloads.enabled";
+    public static final String STORAGE_TRANSIENT_ARCHIVES_ENABLED =
+            "storage.transient-archives.enabled";
 }

--- a/src/main/java/io/cryostat/ConfigProperties.java
+++ b/src/main/java/io/cryostat/ConfigProperties.java
@@ -44,4 +44,6 @@ public class ConfigProperties {
     public static final String GRAFANA_DATASOURCE_URL = "grafana-datasource.url";
 
     public static final String STORAGE_EXT_URL = "storage-ext.url";
+    public static final String STORAGE_PRESIGNED_DOWNLOADS_ENABLED =
+            "storage.presigned-downloads.enabled";
 }

--- a/src/main/java/io/cryostat/recordings/Recordings.java
+++ b/src/main/java/io/cryostat/recordings/Recordings.java
@@ -141,6 +141,9 @@ public class Recordings {
     @ConfigProperty(name = ConfigProperties.STORAGE_TRANSIENT_ARCHIVES_ENABLED)
     boolean transientArchivesEnabled;
 
+    @ConfigProperty(name = ConfigProperties.STORAGE_TRANSIENT_ARCHIVES_TTL)
+    Duration transientArchivesTtl;
+
     @ConfigProperty(name = ConfigProperties.STORAGE_PRESIGNED_DOWNLOADS_ENABLED)
     boolean presignedDownloadsEnabled;
 
@@ -982,9 +985,7 @@ public class Recordings {
         String savename = recording.name;
         String filename =
                 recordingHelper.saveRecording(
-                        recording,
-                        savename,
-                        Instant.now().plusSeconds(60)); // TODO make expiry configurable
+                        recording, savename, Instant.now().plus(transientArchivesTtl));
         String encodedKey = recordingHelper.encodedKey(recording.target.jvmId, filename);
         if (!savename.endsWith(".jfr")) {
             savename += ".jfr";

--- a/src/main/java/io/cryostat/recordings/Recordings.java
+++ b/src/main/java/io/cryostat/recordings/Recordings.java
@@ -138,6 +138,9 @@ public class Recordings {
     @ConfigProperty(name = ConfigProperties.GRAFANA_DATASOURCE_URL)
     Optional<String> grafanaDatasourceURL;
 
+    @ConfigProperty(name = ConfigProperties.STORAGE_TRANSIENT_ARCHIVES_ENABLED)
+    boolean transientArchivesEnabled;
+
     @ConfigProperty(name = ConfigProperties.STORAGE_PRESIGNED_DOWNLOADS_ENABLED)
     boolean presignedDownloadsEnabled;
 
@@ -967,6 +970,15 @@ public class Recordings {
         if (recording == null) {
             throw new NotFoundException();
         }
+        if (!transientArchivesEnabled) {
+            return Response.status(RestResponse.Status.OK)
+                    .header(
+                            HttpHeaders.CONTENT_DISPOSITION,
+                            String.format("attachment; filename=\"%s.jfr\"", recording.name))
+                    .entity(recordingHelper.getActiveInputStream(recording))
+                    .build();
+        }
+
         String savename = recording.name;
         String filename =
                 recordingHelper.saveRecording(

--- a/src/main/java/io/cryostat/recordings/Recordings.java
+++ b/src/main/java/io/cryostat/recordings/Recordings.java
@@ -482,6 +482,12 @@ public class Recordings {
                 return null;
             case "save":
                 try {
+                    // FIXME this operation might take a long time to complete, depending on the
+                    // amount of JFR data in the target and the speed of the connection between the
+                    // target and Cryostat. We should not make the client wait until this operation
+                    // completes before sending a response - it should be async. Here we should just
+                    // return an Accepted response, and if a failure occurs that should be indicated
+                    // as a websocket notification.
                     return recordingHelper.saveRecording(activeRecording);
                 } catch (IOException ioe) {
                     logger.warn(ioe);

--- a/src/main/java/io/cryostat/recordings/Recordings.java
+++ b/src/main/java/io/cryostat/recordings/Recordings.java
@@ -56,6 +56,7 @@ import io.cryostat.recordings.RecordingHelper.RecordingReplace;
 import io.cryostat.recordings.RecordingHelper.SnapshotCreationException;
 import io.cryostat.targets.Target;
 import io.cryostat.targets.TargetConnectionManager;
+import io.cryostat.util.HttpMimeType;
 import io.cryostat.util.HttpStatusCodeIdentifier;
 import io.cryostat.ws.MessagingServer;
 import io.cryostat.ws.Notification;
@@ -984,6 +985,7 @@ public class Recordings {
                     .header(
                             HttpHeaders.CONTENT_DISPOSITION,
                             String.format("attachment; filename=\"%s.jfr\"", recording.name))
+                    .header(HttpHeaders.CONTENT_TYPE, HttpMimeType.OCTET_STREAM.mime())
                     .entity(recordingHelper.getActiveInputStream(recording))
                     .build();
         }
@@ -1023,6 +1025,7 @@ public class Recordings {
                     .header(
                             HttpHeaders.CONTENT_DISPOSITION,
                             String.format("attachment; filename=\"%s\"", pair.getValue()))
+                    .header(HttpHeaders.CONTENT_TYPE, HttpMimeType.OCTET_STREAM.mime())
                     .entity(recordingHelper.getArchivedRecordingStream(encodedKey))
                     .build();
         }

--- a/src/main/java/io/cryostat/recordings/Recordings.java
+++ b/src/main/java/io/cryostat/recordings/Recordings.java
@@ -997,13 +997,17 @@ public class Recordings {
     @RolesAllowed("read")
     public Response handleStorageDownload(@RestPath String encodedKey, @RestQuery String f)
             throws URISyntaxException {
+        Pair<String, String> pair = recordingHelper.decodedKey(encodedKey);
+
         if (!presignedDownloadsEnabled) {
             return Response.status(RestResponse.Status.OK)
+                    .header(
+                            HttpHeaders.CONTENT_DISPOSITION,
+                            String.format("attachment; filename=\"%s\"", pair.getValue()))
                     .entity(recordingHelper.getArchivedRecordingStream(encodedKey))
                     .build();
         }
 
-        Pair<String, String> pair = recordingHelper.decodedKey(encodedKey);
         logger.infov("Handling presigned download request for {0}", pair);
         GetObjectRequest getRequest =
                 GetObjectRequest.builder()

--- a/src/main/java/io/cryostat/recordings/Recordings.java
+++ b/src/main/java/io/cryostat/recordings/Recordings.java
@@ -965,7 +965,7 @@ public class Recordings {
     @Blocking
     @Path("/api/v3/activedownload/{id}")
     @RolesAllowed("read")
-    public Response createAndRedirectDownload(@RestPath long id) throws Exception {
+    public Response handleActiveDownload(@RestPath long id) throws Exception {
         ActiveRecording recording = ActiveRecording.findById(id);
         if (recording == null) {
             throw new NotFoundException();

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -54,6 +54,7 @@ quarkus.http.filter.static.methods=GET
 quarkus.http.filter.static.order=1
 
 storage-ext.url=
+storage.presigned-downloads.enabled=false
 storage.buckets.archives.name=archivedrecordings
 storage.buckets.archives.expiration-label=expiration
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -56,6 +56,7 @@ quarkus.http.filter.static.order=1
 storage-ext.url=
 storage.presigned-downloads.enabled=false
 storage.transient-archives.enabled=false
+storage.transient-archives.ttl=60s
 storage.buckets.archives.name=archivedrecordings
 storage.buckets.archives.expiration-label=expiration
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -55,6 +55,7 @@ quarkus.http.filter.static.order=1
 
 storage-ext.url=
 storage.presigned-downloads.enabled=false
+storage.transient-archives.enabled=false
 storage.buckets.archives.name=archivedrecordings
 storage.buckets.archives.expiration-label=expiration
 


### PR DESCRIPTION
# Welcome to Cryostat3! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat3/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] [Signed all commits using a GPG signature](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#gpg-commit-signature-verification)

**To recreate commits with GPG signature** `git fetch upstream && git rebase --force --gpg-sign upstream/main`
_______________________________________________

Related to #284

## Description of the change:
Provides an alternative recording file download mechanism. Rather than creating an S3 presigned GET request URL and redirecting the client to that URL, Cryostat simply uses its own credentials to perform a standard GET request to S3, acting as a network pipe or proxy between the client and S3. This is more similar to the classic Cryostat 2.x implementation where Cryostat read archived recording files directly from the filesystem and served the client these bytes directly (as opposed to delegating to another server like the S3 container).

Similarly, the existing implementation for downloading active recordings works by first archiving the source recording, then redirecting the client so that it tries to download the just-archived recording file. This step is now also made optional and off by default - the new default implementation also works like classic Cryostat 2.x, where Cryostat opens a direct network connection to the remote target JVM and pipes the JFR file contents directly to the requesting client.

## Motivation for the change:
Presigned request handling is currently broken due to request signature validation. I haven't figured out what changed and why it is broken, but this highlights that this mechanism is relatively fragile and needs careful configuration. It is probably worthwhile to configure and use where feasible, but this PR introduces a simpler fallback behaviour that does not require any configuration. Taken together, the two new default implementations work very similarly to classic Cryostat 2.x behaviour, and the new more S3-reliant behaviours are made optional.

As an additional benefit of sorts, by avoiding uploads of "transient" copies of active recordings into S3 storage, this bypasses the need to configure/implement any kind of TTL and expiry for these copies. Before this PR these copies accumulate in storage over time and are not (yet) ever cleaned up.

## How to manually test:
1. *Run CRYOSTAT_IMAGE=quay.io... sh smoketest.sh...*
2. Open UI
3. Select a target
4. Start a new recording if needed
5. Try to download that recording
6. Archive that recording
7. Try to download that archived recording

Watch the browser's devtools console and see what the final request is that results in the JFR file download. It should *not* be a redirected presigned URL request but instead simply a GET served by Cryostat itself.
