### PR TITLE
feat(grafana): implement endpoint for 'view in grafana' of archived recordings

### DIFF
--- a/smoketest.bash
+++ b/smoketest.bash
@@ -9,6 +9,8 @@ DIR="$(dirname "$(readlink -f "$0")")"
 
 FILES=(
     "${DIR}/smoketest/compose/db.yml"
+    "${DIR}/smoketest/compose/cryostat-grafana.yml"
+    "${DIR}/smoketest/compose/jfr-datasource.yml"
 )
 
 USE_USERHOSTS=${USE_USERHOSTS:-true}
@@ -18,7 +20,7 @@ OPEN_TABS=${OPEN_TABS:-false}
 
 CRYOSTAT_HTTP_PORT=8080
 USE_PROXY=${USE_PROXY:-true}
-DEPLOY_GRAFANA=false
+DEPLOY_GRAFANA=true
 
 display_usage() {
     echo "Usage:"
@@ -26,7 +28,7 @@ display_usage() {
     echo -e "\t-O\t\t\t\t\t\tOffline mode, do not attempt to pull container images."
     echo -e "\t-p\t\t\t\t\t\tDisable auth Proxy."
     echo -e "\t-s [seaweed|minio|cloudserver|localstack]\tS3 implementation to spin up (default \"seaweed\")."
-    echo -e "\t-g\t\t\t\t\t\tinclude Grafana dashboard and jfr-datasource in deployment."
+    echo -e "\t-G\t\t\t\t\t\texclude Grafana dashboard and jfr-datasource from deployment."
     echo -e "\t-r\t\t\t\t\t\tconfigure a cryostat-Reports sidecar instance"
     echo -e "\t-t\t\t\t\t\t\tinclude sample applications for Testing."
     echo -e "\t-V\t\t\t\t\t\tdo not discard data storage Volumes on exit."
@@ -50,8 +52,7 @@ while getopts "hs:prgtOVXcb" opt; do
             s3="${OPTARG}"
             ;;
         g)
-            FILES+=("${DIR}/smoketest/compose/cryostat-grafana.yml" "${DIR}/smoketest/compose/jfr-datasource.yml")
-            DEPLOY_GRAFANA=true
+            DEPLOY_GRAFANA=false
             ;;
         t)
             FILES+=("${DIR}/smoketest/compose/sample-apps.yml")

--- a/smoketest.bash
+++ b/smoketest.bash
@@ -39,7 +39,7 @@ display_usage() {
 
 s3=seaweed
 ce=podman
-while getopts "hs:prgtOVXcb" opt; do
+while getopts "hs:prGtOVXcb" opt; do
     case $opt in
         h)
             display_usage
@@ -51,7 +51,7 @@ while getopts "hs:prgtOVXcb" opt; do
         s)
             s3="${OPTARG}"
             ;;
-        g)
+        G)
             DEPLOY_GRAFANA=false
             ;;
         t)

--- a/smoketest.bash
+++ b/smoketest.bash
@@ -9,8 +9,6 @@ DIR="$(dirname "$(readlink -f "$0")")"
 
 FILES=(
     "${DIR}/smoketest/compose/db.yml"
-    "${DIR}/smoketest/compose/cryostat-grafana.yml"
-    "${DIR}/smoketest/compose/jfr-datasource.yml"
 )
 
 USE_USERHOSTS=${USE_USERHOSTS:-true}
@@ -81,6 +79,14 @@ while getopts "hs:prGtOVXcb" opt; do
             ;;
     esac
 done
+
+if [ "${DEPLOY_GRAFANA}" = "true" ]; then
+    FILES+=(
+        "${DIR}/smoketest/compose/cryostat-grafana.yml"
+        "${DIR}/smoketest/compose/jfr-datasource.yml"
+    )
+fi
+
 
 if [ "${USE_PROXY}" = "true" ]; then
     FILES+=("${DIR}/smoketest/compose/auth_proxy.yml")

--- a/src/main/java/io/cryostat/ExceptionMappers.java
+++ b/src/main/java/io/cryostat/ExceptionMappers.java
@@ -15,6 +15,8 @@
  */
 package io.cryostat;
 
+import java.util.concurrent.CompletionException;
+
 import org.openjdk.jmc.rjmx.ConnectionException;
 
 import io.cryostat.targets.TargetConnectionManager;
@@ -24,6 +26,7 @@ import io.netty.handler.codec.http.HttpResponseStatus;
 import io.smallrye.mutiny.TimeoutException;
 import jakarta.inject.Inject;
 import jakarta.persistence.NoResultException;
+import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.hibernate.exception.ConstraintViolationException;
 import org.jboss.logging.Logger;
 import org.jboss.resteasy.reactive.RestResponse;
@@ -99,5 +102,11 @@ public class ExceptionMappers {
         return ResponseBuilder.create(HttpResponseStatus.CONFLICT.code())
                 .entity(ex.getMessage())
                 .build();
+    }
+
+    @ServerExceptionMapper
+    public RestResponse<Void> mapCompletionException(CompletionException ex) throws Throwable {
+        logger.warn(ex);
+        throw ExceptionUtils.getRootCause(ex);
     }
 }

--- a/src/main/java/io/cryostat/ExceptionMappers.java
+++ b/src/main/java/io/cryostat/ExceptionMappers.java
@@ -16,6 +16,7 @@
 package io.cryostat;
 
 import java.util.concurrent.CompletionException;
+import java.util.concurrent.ExecutionException;
 
 import org.openjdk.jmc.rjmx.ConnectionException;
 
@@ -106,6 +107,12 @@ public class ExceptionMappers {
 
     @ServerExceptionMapper
     public RestResponse<Void> mapCompletionException(CompletionException ex) throws Throwable {
+        logger.warn(ex);
+        throw ExceptionUtils.getRootCause(ex);
+    }
+
+    @ServerExceptionMapper
+    public RestResponse<Void> mapExecutionException(ExecutionException ex) throws Throwable {
         logger.warn(ex);
         throw ExceptionUtils.getRootCause(ex);
     }

--- a/src/main/java/io/cryostat/recordings/RecordingHelper.java
+++ b/src/main/java/io/cryostat/recordings/RecordingHelper.java
@@ -912,10 +912,6 @@ public class RecordingHelper {
         }
     }
 
-    public Response uploadToJFRDatasource(String jvmId, String filename) throws Exception {
-        return uploadToJFRDatasource(Pair.of(jvmId, filename));
-    }
-
     Optional<Path> getRecordingCopyPath(
             JFRConnection connection, Target target, String recordingName) throws Exception {
         return connection.getService().getAvailableRecordings().stream()

--- a/src/main/java/io/cryostat/recordings/RecordingHelper.java
+++ b/src/main/java/io/cryostat/recordings/RecordingHelper.java
@@ -586,6 +586,8 @@ public class RecordingHelper {
     }
 
     public String encodedKey(String jvmId, String filename) {
+        Objects.requireNonNull(jvmId);
+        Objects.requireNonNull(filename);
         return base64Url.encodeAsString(
                 (archivedRecordingKey(jvmId, filename)).getBytes(StandardCharsets.UTF_8));
     }
@@ -803,15 +805,12 @@ public class RecordingHelper {
         }
     }
 
-    public Response uploadToJFRDatasource(String jvmId, String filename, URL uploadUrl)
+    public Response uploadToJFRDatasource(Pair<String, String> key, URL uploadUrl)
             throws Exception {
-        Objects.requireNonNull(jvmId);
-        Objects.requireNonNull(filename);
-
         GetObjectRequest getRequest =
                 GetObjectRequest.builder()
                         .bucket(archiveBucket)
-                        .key(archivedRecordingKey(Pair.of(jvmId, filename)))
+                        .key(archivedRecordingKey(key))
                         .build();
 
         Path recordingPath = fs.createTempFile(null, null);
@@ -852,6 +851,11 @@ public class RecordingHelper {
         } finally {
             fs.deleteIfExists(recordingPath);
         }
+    }
+
+    public Response uploadToJFRDatasource(String jvmId, String filename, URL uploadUrl)
+            throws Exception {
+        return uploadToJFRDatasource(Pair.of(jvmId, filename), uploadUrl);
     }
 
     Optional<Path> getRecordingCopyPath(

--- a/src/main/java/io/cryostat/recordings/Recordings.java
+++ b/src/main/java/io/cryostat/recordings/Recordings.java
@@ -838,13 +838,12 @@ public class Recordings {
     @Blocking
     @Path("/api/v3/targets/{targetId}/recordings/{remoteId}/upload")
     @RolesAllowed("write")
-    public Response uploadActiveToGrafana(@RestPath long targetId, @RestPath long remoteId)
+    public Uni<String> uploadActiveToGrafana(@RestPath long targetId, @RestPath long remoteId)
             throws Exception {
         return recordingHelper.uploadToJFRDatasource(targetId, remoteId);
     }
 
     @POST
-    @Blocking
     @Path("/api/beta/fs/recordings/{jvmId}/{filename}/upload")
     @RolesAllowed("write")
     public Response uploadArchivedToGrafanaBeta(@RestPath String jvmId, @RestPath String filename)
@@ -862,7 +861,7 @@ public class Recordings {
     @Blocking
     @Path("/api/v3/grafana/{encodedKey}")
     @RolesAllowed("write")
-    public Response uploadArchivedToGrafana(@RestPath String encodedKey) throws Exception {
+    public Uni<String> uploadArchivedToGrafana(@RestPath String encodedKey) throws Exception {
         var key = recordingHelper.decodedKey(encodedKey);
         var found =
                 recordingHelper.listArchivedRecordingObjects().stream()


### PR DESCRIPTION
# Welcome to Cryostat3! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat3/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] [Signed all commits using a GPG signature](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#gpg-commit-signature-verification)

**To recreate commits with GPG signature** `git fetch upstream && git rebase --force --gpg-sign upstream/main`
_______________________________________________

Related to #2

## Description of the change:
Implements endpoints for "View in Grafana" feature upon archived recordings.

## Motivation for the change:
Previously, 3.0 only supported "View in Grafana" on active recordings.

## How to manually test:
1. *Run CRYOSTAT_IMAGE=quay.io... sh smoketest.sh...*
2. Find or start an active running recording
3. Archive the recording, go to Archives view
4. Find the archived recording and "View in Grafana". Verify that the Grafana dashboard appears and has sensible data content.
