### PR TITLE
fix(server): should validate request payload: ensure id is not specified

### DIFF
--- a/src/main/java/io/cryostat/JsonRequestFilter.java
+++ b/src/main/java/io/cryostat/JsonRequestFilter.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright The Cryostat Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.cryostat;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+
+import jakarta.ws.rs.container.ContainerRequestContext;
+import jakarta.ws.rs.container.ContainerRequestFilter;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.ext.Provider;
+
+@Provider
+public class JsonRequestFilter implements ContainerRequestFilter {
+
+    @Override
+    public void filter(ContainerRequestContext requestContext) throws IOException {
+        if (requestContext.getMediaType() != null
+                && requestContext
+                        .getMediaType()
+                        .isCompatible(jakarta.ws.rs.core.MediaType.APPLICATION_JSON_TYPE)) {
+            BufferedReader reader =
+                    new BufferedReader(new InputStreamReader(requestContext.getEntityStream()));
+            try {
+                String line = reader.readLine();
+                if (line.contains("\"id\"")) {
+                    requestContext.abortWith(
+                            Response.status(Response.Status.BAD_REQUEST)
+                                    .entity("ID field cannot be specified in the request body")
+                                    .build());
+                }
+            } finally {
+                reader.close();
+            }
+        }
+    }
+}

--- a/src/main/java/io/cryostat/JsonRequestFilter.java
+++ b/src/main/java/io/cryostat/JsonRequestFilter.java
@@ -48,7 +48,8 @@ public class JsonRequestFilter implements ContainerRequestFilter {
                 return;
             }
 
-            requestContext.setEntityStream(new ByteArrayInputStream(json.getBytes()));
+            requestContext.setEntityStream(
+                    new ByteArrayInputStream(json.getBytes(StandardCharsets.UTF_8)));
         }
     }
 

--- a/src/main/java/io/cryostat/discovery/CustomDiscovery.java
+++ b/src/main/java/io/cryostat/discovery/CustomDiscovery.java
@@ -89,11 +89,6 @@ public class CustomDiscovery {
     @RolesAllowed("write")
     public Response create(
             Target target, @RestQuery boolean dryrun, @RestQuery boolean storeCredentials) {
-        if (target.id != null) {
-            return Response.status(Response.Status.CONFLICT.getStatusCode())
-                    .entity("ID field cannot be specified in the request body")
-                    .build();
-        }
         // TODO handle credentials embedded in JSON body
         return doV2Create(target, Optional.empty(), dryrun, storeCredentials);
     }

--- a/src/main/java/io/cryostat/discovery/CustomDiscovery.java
+++ b/src/main/java/io/cryostat/discovery/CustomDiscovery.java
@@ -89,6 +89,11 @@ public class CustomDiscovery {
     @RolesAllowed("write")
     public Response create(
             Target target, @RestQuery boolean dryrun, @RestQuery boolean storeCredentials) {
+        if (target.id != null) {
+            return Response.status(Response.Status.CONFLICT.getStatusCode())
+                    .entity("ID field cannot be specified in the request body")
+                    .build();
+        }
         // TODO handle credentials embedded in JSON body
         return doV2Create(target, Optional.empty(), dryrun, storeCredentials);
     }

--- a/src/test/java/io/cryostat/JsonRequestFilterTest.java
+++ b/src/test/java/io/cryostat/JsonRequestFilterTest.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright The Cryostat Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.cryostat;
+
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+import java.io.ByteArrayInputStream;
+import java.nio.charset.StandardCharsets;
+
+import jakarta.ws.rs.container.ContainerRequestContext;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class JsonRequestFilterTest {
+    private JsonRequestFilter filter;
+    private ContainerRequestContext requestContext;
+
+    @BeforeEach
+    void setUp() {
+        filter = new JsonRequestFilter();
+        requestContext = mock(ContainerRequestContext.class);
+    }
+
+    @Test
+    void testRejectsPayloadWithId() throws Exception {
+
+        String[] testPayloads = {
+            "{\"id\": 1}",
+            "{\n  \"id\": 1\n}",
+            "{\n  \"foo\": \"bar\",\n  \"id\": 1\n}",
+            "[\n  {\n    \"id\": 1\n  }\n]"
+        };
+
+        for (String payload : testPayloads) {
+            simulateRequest(payload);
+            verify(requestContext, times(1)).abortWith(any(Response.class));
+            reset(requestContext);
+        }
+    }
+
+    @Test
+    void testAllowsPayloadWithoutId() throws Exception {
+
+        String[] testPayloads = {
+            "{ \"message\": \"this text includes the string literal \\\"id\\\"\" }",
+            "{}",
+            "[]",
+            "{ \"foo\": \"bar\" }"
+        };
+
+        for (String payload : testPayloads) {
+            simulateRequest(payload);
+            verify(requestContext, never()).abortWith(any(Response.class));
+            reset(requestContext);
+        }
+    }
+
+    private void simulateRequest(String jsonPayload) throws Exception {
+
+        ByteArrayInputStream payloadStream =
+                new ByteArrayInputStream(jsonPayload.getBytes(StandardCharsets.UTF_8));
+        when(requestContext.getEntityStream()).thenReturn(payloadStream);
+        when(requestContext.getMediaType()).thenReturn(MediaType.APPLICATION_JSON_TYPE);
+        filter.filter(requestContext);
+    }
+}


### PR DESCRIPTION
# Welcome to Cryostat3! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat3/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] [Signed all commits using a GPG signature](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#gpg-commit-signature-verification)

**To recreate commits with GPG signature** `git fetch upstream && git rebase --force --gpg-sign upstream/main`
_______________________________________________

Fixes: #278 

## Description of the change:
Server should validates the request payload and ensures that the id field is not specified. If fails validation, server responds with a 400/409 status before it even gets to the database.

## Motivation for the change:
Mentioned by  @andrewazores [Link](https://github.com/cryostatio/cryostat3/issues/278#issue-2121313813)

## How to manually test:
1. *Run CRYOSTAT_IMAGE=quay.io... sh smoketest.sh...*
2. *...*
