### PR TITLE
feat(graphql): reimplement GraphQL API

### DIFF
--- a/.github/workflows/pr-ci.yaml
+++ b/.github/workflows/pr-ci.yaml
@@ -270,28 +270,28 @@ jobs:
             body: commentBody
           });
 
-  # compare-graphql-schema:
-  #   needs: [update-schemas]
-  #   runs-on: ubuntu-latest
-  #   permissions:
-  #     pull-requests: write
-  #   steps:
-  #   - uses: actions/download-artifact@v3
-  #     with:
-  #       name: graphql-diff
-  #   - name: Comment schema check result
-  #     uses: actions/github-script@v6
-  #     with:
-  #       script: |
-  #         const diffFmt = s => {
-  #           return "```diff\n" + s + "\n```";
-  #         };
-  #         const commentBody = ${{ needs.update-schemas.outputs.GRAPHQL_STATUS }} == '0'
-  #           ? `No GraphQL schema changes detected.`
-  #           : `GraphQL schema change detected:\n\n${diffFmt(require('fs').readFileSync('${{ needs.update-schemas.outputs.GRAPHQL_DIFF_FILE }}'))}`;
-  #         github.rest.issues.createComment({
-  #           issue_number: context.issue.number,
-  #           owner: context.repo.owner,
-  #           repo: context.repo.repo,
-  #           body: commentBody
-  #         });
+  compare-graphql-schema:
+    needs: [update-schemas]
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+    - uses: actions/download-artifact@v3
+      with:
+        name: graphql-diff
+    - name: Comment schema check result
+      uses: actions/github-script@v6
+      with:
+        script: |
+          const diffFmt = s => {
+            return "```diff\n" + s + "\n```";
+          };
+          const commentBody = ${{ needs.update-schemas.outputs.GRAPHQL_STATUS }} == '0'
+            ? `No GraphQL schema changes detected.`
+            : `GraphQL schema change detected:\n\n${diffFmt(require('fs').readFileSync('${{ needs.update-schemas.outputs.GRAPHQL_DIFF_FILE }}'))}`;
+          github.rest.issues.createComment({
+            issue_number: context.issue.number,
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            body: commentBody
+          });

--- a/compose/cryostat.yml
+++ b/compose/cryostat.yml
@@ -28,9 +28,9 @@ services:
       QUARKUS_HTTP_HOST: "cryostat"
       QUARKUS_HTTP_PORT: ${CRYOSTAT_HTTP_PORT}
       QUARKUS_HIBERNATE_ORM_LOG_SQL: "true"
-      CRYOSTAT_DISCOVERY_JDP_ENABLED: "true"
-      CRYOSTAT_DISCOVERY_PODMAN_ENABLED: "true"
-      CRYOSTAT_DISCOVERY_DOCKER_ENABLED: "true"
+      CRYOSTAT_DISCOVERY_JDP_ENABLED: ${CRYOSTAT_DISCOVERY_JDP_ENABLED:-true}
+      CRYOSTAT_DISCOVERY_PODMAN_ENABLED: ${CRYOSTAT_DISCOVERY_PODMAN_ENABLED:-true}
+      CRYOSTAT_DISCOVERY_DOCKER_ENABLED: ${CRYOSTAT_DISCOVERY_DOCKER_ENABLED:-true}
       JAVA_OPTS_APPEND: "-XX:+FlightRecorder -XX:StartFlightRecording=name=onstart,settings=default,disk=true,maxage=5m -XX:StartFlightRecording=name=startup,settings=profile,disk=true,duration=30s -Dcom.sun.management.jmxremote.autodiscovery=true -Dcom.sun.management.jmxremote -Dcom.sun.management.jmxremote.port=9091 -Dcom.sun.management.jmxremote.rmi.port=9091 -Djava.rmi.server.hostname=127.0.0.1 -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.local.only=false"
     restart: unless-stopped
     healthcheck:

--- a/pom.xml
+++ b/pom.xml
@@ -97,6 +97,10 @@
       <artifactId>quarkus-smallrye-openapi</artifactId>
     </dependency>
     <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-smallrye-graphql</artifactId>
+    </dependency>
+    <dependency>
       <groupId>io.smallrye.reactive</groupId>
       <artifactId>smallrye-mutiny-vertx-web-client</artifactId>
     </dependency>

--- a/schema/openapi.yaml
+++ b/schema/openapi.yaml
@@ -546,6 +546,30 @@ paths:
         - SecurityScheme: []
       tags:
         - Recordings
+  /api/beta/recordings/{connectUrl}/{filename}/upload:
+    post:
+      parameters:
+        - in: path
+          name: connectUrl
+          required: true
+          schema:
+            type: string
+        - in: path
+          name: filename
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: OK
+        "401":
+          description: Not Authorized
+        "403":
+          description: Not Allowed
+      security:
+        - SecurityScheme: []
+      tags:
+        - Recordings
   /api/beta/recordings/{jvmId}:
     get:
       parameters:

--- a/schema/openapi.yaml
+++ b/schema/openapi.yaml
@@ -31,6 +31,8 @@ components:
           type: integer
         downloadUrl:
           type: string
+        jvmId:
+          type: string
         metadata:
           $ref: '#/components/schemas/Metadata'
         name:
@@ -365,6 +367,31 @@ openapi: 3.0.3
 paths:
   /api/beta/fs/recordings:
     get:
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                items:
+                  $ref: '#/components/schemas/ArchivedRecordingDirectory'
+                type: array
+          description: OK
+        "401":
+          description: Not Authorized
+        "403":
+          description: Not Allowed
+      security:
+        - SecurityScheme: []
+      tags:
+        - Recordings
+  /api/beta/fs/recordings/{jvmId}:
+    get:
+      parameters:
+        - in: path
+          name: jvmId
+          required: true
+          schema:
+            type: string
       responses:
         "200":
           content:
@@ -1242,6 +1269,31 @@ paths:
           description: OK
       tags:
         - Discovery
+  /api/v2.2/graphql:
+    get:
+      responses:
+        "200":
+          description: OK
+        "401":
+          description: Not Authorized
+        "403":
+          description: Not Allowed
+      security:
+        - SecurityScheme: []
+      tags:
+        - Graph QL
+    post:
+      responses:
+        "200":
+          description: OK
+        "401":
+          description: Not Authorized
+        "403":
+          description: Not Allowed
+      security:
+        - SecurityScheme: []
+      tags:
+        - Graph QL
   /api/v2/rules:
     get:
       responses:

--- a/schema/schema.graphql
+++ b/schema/schema.graphql
@@ -1,0 +1,304 @@
+type ActiveRecording {
+  continuous: Boolean!
+  "Archive the specified Flight Recording"
+  doArchive: ArchivedRecording
+  "Delete the specified Flight Recording"
+  doDelete: ActiveRecording
+  "Updates the metadata labels for an existing Flight Recording."
+  doPutMetadata(metadataInput: MetadataLabelsInput): ActiveRecording
+  "Stop the specified Flight Recording"
+  doStop: ActiveRecording
+  "URL for GET request to retrieve the JFR binary file content of this recording"
+  downloadUrl: String
+  duration: BigInteger!
+  id: BigInteger
+  maxAge: BigInteger!
+  maxSize: BigInteger!
+  metadata: Metadata!
+  name: String!
+  remoteId: BigInteger!
+  "URL for GET request to retrieve a JSON formatted Automated Analysis Report of this recording"
+  reportUrl: String
+  startTime: BigInteger!
+  state: RecordingState!
+  target: Target!
+  toDisk: Boolean!
+}
+
+type ActiveRecordings {
+  aggregate: AggregateInfo!
+  data: [ActiveRecording]!
+}
+
+type AggregateInfo {
+  "The number of elements in this collection"
+  count: BigInteger!
+  "The sum of sizes of elements in this collection, or 0 if not applicable"
+  size: BigInteger!
+}
+
+type Annotations {
+  cryostat(
+    "Get entry/entries for a certain key/s"
+    key: [String]
+  ): [Entry_String_String]
+  platform(
+    "Get entry/entries for a certain key/s"
+    key: [String]
+  ): [Entry_String_String]
+}
+
+type ArchivedRecording {
+  archivedTime: BigInteger!
+  doDelete: ArchivedRecording!
+  doPutMetadata(metadataInput: MetadataLabelsInput): ArchivedRecording!
+  "URL for GET request to retrieve the JFR binary file content of this recording"
+  downloadUrl: String
+  jvmId: String
+  metadata: Metadata
+  name: String
+  "URL for GET request to retrieve a JSON formatted Automated Analysis Report of this recording"
+  reportUrl: String
+  size: BigInteger!
+}
+
+type ArchivedRecordings {
+  aggregate: AggregateInfo!
+  data: [ArchivedRecording]!
+}
+
+type DiscoveryNode {
+  children: [DiscoveryNode]
+  "Get target nodes that are descendants of this node. That is, get the set of leaf nodes from anywhere below this node's subtree."
+  descendantTargets(filter: DiscoveryNodeFilterInput): [DiscoveryNode]
+  id: BigInteger
+  labels(
+    "Get entry/entries for a certain key/s"
+    key: [String]
+  ): [Entry_String_String]!
+  name: String!
+  nodeType: String!
+  target: Target
+}
+
+type Entry_String_String {
+  key: String
+  value: String
+}
+
+type MBeanMetrics {
+  jvmId: String
+  memory: MemoryMetrics
+  os: OperatingSystemMetrics
+  runtime: RuntimeMetrics
+  thread: ThreadMetrics
+}
+
+type MemoryMetrics {
+  freeHeapMemory: BigInteger!
+  freeNonHeapMemory: BigInteger!
+  heapMemoryUsage: MemoryUtilization
+  heapMemoryUsagePercent: Float!
+  nonHeapMemoryUsage: MemoryUtilization
+  objectPendingFinalizationCount: BigInteger!
+  verbose: Boolean!
+}
+
+type MemoryUtilization {
+  committed: BigInteger!
+  init: BigInteger!
+  max: BigInteger!
+  used: BigInteger!
+}
+
+type Metadata {
+  "ISO-8601"
+  expiry: DateTime
+  labels(
+    "Get entry/entries for a certain key/s"
+    key: [String]
+  ): [Entry_String_String]
+}
+
+"Mutation root"
+type Mutation {
+  "Archive an existing Flight Recording matching the given filter, on all Targets under the subtrees of the discovery nodes matching the given filter"
+  archiveRecording(nodes: DiscoveryNodeFilterInput!, recordings: ActiveRecordingsFilterInput): [ArchivedRecording]
+  "Start a new Flight Recording on all Targets under the subtrees of the discovery nodes matching the given filter"
+  createRecording(nodes: DiscoveryNodeFilterInput!, recording: RecordingSettingsInput!): [ActiveRecording]
+  "Create a Flight Recorder Snapshot on all Targets under the subtrees of the discovery nodes matching the given filter"
+  createSnapshot(nodes: DiscoveryNodeFilterInput!): [ActiveRecording]
+  "Delete an existing Flight Recording matching the given filter, on all Targets under the subtrees of the discovery nodes matching the given filter"
+  deleteRecording(nodes: DiscoveryNodeFilterInput!, recordings: ActiveRecordingsFilterInput): [ActiveRecording]
+  "Stop an existing Flight Recording matching the given filter, on all Targets under the subtrees of the discovery nodes matching the given filter"
+  stopRecording(nodes: DiscoveryNodeFilterInput!, recordings: ActiveRecordingsFilterInput): [ActiveRecording]
+}
+
+type OperatingSystemMetrics {
+  arch: String
+  availableProcessors: Int!
+  committedVirtualMemorySize: BigInteger!
+  freePhysicalMemorySize: BigInteger!
+  freeSwapSpaceSize: BigInteger!
+  name: String
+  processCpuLoad: Float!
+  processCpuTime: BigInteger!
+  systemCpuLoad: Float!
+  systemLoadAverage: Float!
+  totalPhysicalMemorySize: BigInteger!
+  totalSwapSpaceSize: BigInteger!
+  version: String
+}
+
+"Query root"
+type Query {
+  archivedRecordings(filter: ArchivedRecordingsFilterInput): ArchivedRecordings
+  "Get all environment nodes in the discovery tree with optional filtering"
+  environmentNodes(filter: DiscoveryNodeFilterInput): [DiscoveryNode]
+  "Get the root target discovery node"
+  rootNode: DiscoveryNode
+  "Get the Target discovery nodes, i.e. the leaf nodes of the discovery tree"
+  targetNodes(filter: DiscoveryNodeFilterInput): [DiscoveryNode]
+}
+
+type Recordings {
+  active(filter: ActiveRecordingsFilterInput): ActiveRecordings
+  archived(filter: ArchivedRecordingsFilterInput): ArchivedRecordings
+}
+
+type RuntimeMetrics {
+  bootClassPath: String
+  bootClassPathSupported: Boolean!
+  classPath: String
+  inputArguments: [String]
+  libraryPath: String
+  managementSpecVersion: String
+  name: String
+  specName: String
+  specVendor: String
+  specVersion: String
+  startTime: BigInteger!
+  systemProperties(
+    "Get entry/entries for a certain key/s"
+    key: [String]
+  ): [Entry_String_String]
+  uptime: BigInteger!
+  vmName: String
+  vmVendor: String
+  vmVersion: String
+}
+
+type Target {
+  activeRecordings(filter: ActiveRecordingsFilterInput): ActiveRecordings
+  agent: Boolean!
+  alias: String!
+  annotations: Annotations!
+  archivedRecordings(filter: ArchivedRecordingsFilterInput): ArchivedRecordings
+  connectUrl: String!
+  "Create a new Flight Recorder Snapshot on the specified Target"
+  doSnapshot: ActiveRecording
+  "Start a new Flight Recording on the specified Target"
+  doStartRecording(recording: RecordingSettingsInput!): ActiveRecording
+  id: BigInteger
+  jvmId: String
+  labels(
+    "Get entry/entries for a certain key/s"
+    key: [String]
+  ): [Entry_String_String]!
+  "Get live MBean metrics snapshot from the specified Target"
+  mbeanMetrics: MBeanMetrics
+  "Get the active and archived recordings belonging to this target"
+  recordings: Recordings
+}
+
+type ThreadMetrics {
+  allThreadIds: [BigInteger]
+  currentThreadCpuTime: BigInteger!
+  currentThreadCpuTimeSupported: Boolean!
+  currentThreadUserTime: BigInteger!
+  daemonThreadCount: Int!
+  objectMonitorUsageSupported: Boolean!
+  peakThreadCount: Int!
+  synchronizerUsageSupported: Boolean!
+  threadContentionMonitoringEnabled: Boolean!
+  threadContentionMonitoringSupported: Boolean!
+  threadCount: Int!
+  threadCpuTimeEnabled: Boolean!
+  threadCpuTimeSupported: Boolean!
+  totalStartedThreadCount: BigInteger!
+}
+
+"Running state of an active Flight Recording"
+enum RecordingState {
+  "CLOSED"
+  CLOSED
+  "DELAYED"
+  DELAYED
+  "NEW"
+  NEW
+  "RUNNING"
+  RUNNING
+  "STOPPED"
+  STOPPED
+}
+
+input ActiveRecordingsFilterInput {
+  continuous: Boolean
+  durationMsGreaterThanEqual: BigInteger
+  durationMsLessThanEqual: BigInteger
+  labels: [String]
+  name: String
+  names: [String]
+  startTimeMsAfterEqual: BigInteger
+  startTimeMsBeforeEqual: BigInteger
+  state: RecordingState
+  toDisk: Boolean
+}
+
+input ArchivedRecordingsFilterInput {
+  archivedTimeAfterEqual: BigInteger
+  archivedTimeBeforeEqual: BigInteger
+  labels: [String]
+  name: String
+  names: [String]
+  sizeBytesGreaterThanEqual: BigInteger
+  sizeBytesLessThanEqual: BigInteger
+  sourceTarget: String
+}
+
+input DiscoveryNodeFilterInput {
+  annotations: [String]
+  id: BigInteger
+  ids: [BigInteger]
+  labels: [String]
+  name: String
+  names: [String]
+  nodeTypes: [String]
+}
+
+input Entry_String_StringInput {
+  key: String
+  value: String
+}
+
+input MetadataLabelsInput {
+  labels: [Entry_String_StringInput]
+}
+
+input RecordingMetadataInput {
+  labels: [Entry_String_StringInput]
+}
+
+input RecordingSettingsInput {
+  archiveOnStop: Boolean
+  continuous: Boolean
+  duration: BigInteger
+  maxAge: BigInteger
+  maxSize: BigInteger
+  metadata: RecordingMetadataInput
+  name: String!
+  replace: String
+  template: String!
+  templateType: String!
+  toDisk: Boolean
+}

--- a/schema/update.bash
+++ b/schema/update.bash
@@ -24,4 +24,4 @@ while true; do
     fi
 done
 wget http://localhost:8181/api -O - | yq -P 'sort_keys(..)' > "${DIR}/openapi.yaml"
-# wget http://localhost:8181/api/v3/graphql/schema.graphql -O "${DIR}/schema.graphql"
+wget http://localhost:8181/api/v3/graphql/schema.graphql -O "${DIR}/schema.graphql"

--- a/src/main/java/io/cryostat/JsonRequestFilter.java
+++ b/src/main/java/io/cryostat/JsonRequestFilter.java
@@ -37,7 +37,12 @@ public class JsonRequestFilter implements ContainerRequestFilter {
 
     static final Set<String> disallowedFields = Set.of("id");
     static final Set<String> allowedPathPatterns =
-            Set.of("/api/v2.2/discovery", "/api/v2/rules/[\\w]+", "/api/beta/matchExpressions");
+            Set.of(
+                    "/api/v2.2/discovery",
+                    "/api/v2/rules/[\\w]+",
+                    "/api/beta/matchExpressions",
+                    "/api/v2.2/graphql",
+                    "/api/v3/graphql");
 
     private final Map<String, Pattern> compiledPatterns = new HashMap<>();
     private final ObjectMapper objectMapper = new ObjectMapper();

--- a/src/main/java/io/cryostat/ObjectMapperCustomization.java
+++ b/src/main/java/io/cryostat/ObjectMapperCustomization.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright The Cryostat Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.cryostat;
+
+import java.io.IOException;
+import java.util.Map;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.Version;
+import com.fasterxml.jackson.databind.BeanDescription;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationConfig;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.module.SimpleModule;
+import com.fasterxml.jackson.databind.ser.BeanSerializerModifier;
+import com.fasterxml.jackson.databind.type.MapType;
+import io.quarkus.jackson.ObjectMapperCustomizer;
+import jakarta.inject.Singleton;
+
+@Singleton
+public class ObjectMapperCustomization implements ObjectMapperCustomizer {
+
+    @Override
+    public void customize(ObjectMapper objectMapper) {
+        // FIXME get this version information from the maven build somehow
+        SimpleModule mapModule =
+                new SimpleModule(
+                        "MapSerialization", new Version(3, 0, 0, null, "io.cryostat", "cryostat"));
+
+        mapModule.setSerializerModifier(new MapSerializerModifier());
+
+        objectMapper.registerModule(mapModule);
+    }
+
+    static class MapSerializerModifier extends BeanSerializerModifier {
+        @Override
+        public JsonSerializer<?> modifyMapSerializer(
+                SerializationConfig config,
+                MapType valueType,
+                BeanDescription beanDesc,
+                JsonSerializer serializer) {
+            if (valueType.getKeyType().getRawClass().equals(String.class)
+                    && valueType.getContentType().getRawClass().equals(String.class)) {
+                return new MapSerializer();
+            }
+            return serializer;
+        }
+    }
+
+    static class MapSerializer extends JsonSerializer<Map<?, ?>> {
+
+        @Override
+        public void serialize(Map<?, ?> map, JsonGenerator gen, SerializerProvider serializers)
+                throws IOException {
+            gen.writeStartArray();
+
+            for (var entry : map.entrySet()) {
+                gen.writeStartObject();
+
+                gen.writePOJOField("key", entry.getKey());
+                gen.writePOJOField("value", entry.getValue());
+
+                gen.writeEndObject();
+            }
+
+            gen.writeEndArray();
+        }
+    }
+}

--- a/src/main/java/io/cryostat/graphql/ActiveRecordings.java
+++ b/src/main/java/io/cryostat/graphql/ActiveRecordings.java
@@ -17,6 +17,7 @@ package io.cryostat.graphql;
 
 import java.time.Duration;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -319,6 +320,39 @@ public class ActiveRecordings {
                     Optional.ofNullable(duration),
                     Optional.ofNullable(maxSize),
                     Optional.ofNullable(maxAge));
+        }
+    }
+
+    @Blocking
+    @Transactional
+    @Description("Updates the metadata labels for an existing Flight Recording.")
+    public Uni<ActiveRecording> doPutMetadata(
+            @Source ActiveRecording recording, MetadataLabels metadataInput) {
+        return Uni.createFrom()
+                .item(
+                        () -> {
+                            return recordingHelper.updateRecordingMetadata(
+                                    recording.id, metadataInput.getLabels());
+                        });
+    }
+
+    @SuppressFBWarnings(value = "URF_UNREAD_PUBLIC_OR_PROTECTED_FIELD")
+    public static class MetadataLabels {
+
+        private Map<String, String> labels;
+
+        public MetadataLabels() {}
+
+        public MetadataLabels(Map<String, String> labels) {
+            this.labels = new HashMap<>(labels);
+        }
+
+        public Map<String, String> getLabels() {
+            return new HashMap<>(labels);
+        }
+
+        public void setLabels(Map<String, String> labels) {
+            this.labels = new HashMap<>(labels);
         }
     }
 

--- a/src/main/java/io/cryostat/graphql/ActiveRecordings.java
+++ b/src/main/java/io/cryostat/graphql/ActiveRecordings.java
@@ -1,0 +1,177 @@
+/*
+ * Copyright The Cryostat Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.cryostat.graphql;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.function.Predicate;
+
+import org.openjdk.jmc.common.unit.QuantityConversionException;
+
+import io.cryostat.core.templates.Template;
+import io.cryostat.core.templates.TemplateType;
+import io.cryostat.graphql.TargetNodes.AggregateInfo;
+import io.cryostat.graphql.TargetNodes.Recordings;
+import io.cryostat.graphql.matchers.LabelSelectorMatcher;
+import io.cryostat.recordings.ActiveRecording;
+import io.cryostat.recordings.RecordingHelper;
+import io.cryostat.recordings.RecordingHelper.RecordingOptions;
+import io.cryostat.recordings.RecordingHelper.RecordingReplace;
+import io.cryostat.recordings.Recordings.Metadata;
+import io.cryostat.targets.Target;
+
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import io.smallrye.common.annotation.Blocking;
+import io.smallrye.graphql.api.Nullable;
+import io.smallrye.mutiny.Uni;
+import jakarta.inject.Inject;
+import jakarta.transaction.Transactional;
+import jdk.jfr.RecordingState;
+import org.eclipse.microprofile.graphql.Description;
+import org.eclipse.microprofile.graphql.GraphQLApi;
+import org.eclipse.microprofile.graphql.NonNull;
+import org.eclipse.microprofile.graphql.Source;
+
+@GraphQLApi
+public class ActiveRecordings {
+
+    @Inject RecordingHelper recordingHelper;
+
+    @Blocking
+    @Transactional
+    @Description("Start a new Flight Recording on the specified Target")
+    public Uni<ActiveRecording> doStartRecording(
+            @Source Target target, @NonNull RecordingSettings settings)
+            throws QuantityConversionException {
+        var fTarget = Target.<Target>findById(target.id);
+        Template template =
+                recordingHelper.getPreferredTemplate(
+                        fTarget, settings.template, settings.templateType);
+        return recordingHelper.startRecording(
+                fTarget,
+                RecordingReplace.STOPPED,
+                template,
+                settings.asOptions(),
+                settings.metadata.labels());
+    }
+
+    @Blocking
+    @Transactional
+    @Description("Create a new Flight Recorder Snapshot on the specified Target")
+    public Uni<ActiveRecording> doSnapshot(@Source Target target) {
+        var fTarget = Target.<Target>findById(target.id);
+        return recordingHelper.createSnapshot(fTarget);
+    }
+
+    public TargetNodes.ActiveRecordings active(
+            @Source Recordings recordings, ActiveRecordingsFilter filter) {
+        var out = new TargetNodes.ActiveRecordings();
+        out.data = new ArrayList<>();
+        out.aggregate = AggregateInfo.empty();
+
+        var in = recordings.active;
+        if (in != null && in.data != null) {
+            out.data =
+                    in.data.stream().filter(r -> filter == null ? true : filter.test(r)).toList();
+            out.aggregate = AggregateInfo.fromActive(out.data);
+        }
+
+        return out;
+    }
+
+    @SuppressFBWarnings(value = "URF_UNREAD_PUBLIC_OR_PROTECTED_FIELD")
+    public static class RecordingSettings {
+        public @NonNull String name;
+        public @NonNull String template;
+        public @NonNull TemplateType templateType;
+        public @Nullable RecordingReplace replace;
+        public @Nullable Boolean continuous;
+        public @Nullable Boolean archiveOnStop;
+        public @Nullable Boolean toDisk;
+        public @Nullable Long duration;
+        public @Nullable Long maxSize;
+        public @Nullable Long maxAge;
+        public @Nullable Metadata metadata;
+
+        public RecordingOptions asOptions() {
+            return new RecordingOptions(
+                    name,
+                    Optional.ofNullable(toDisk),
+                    Optional.ofNullable(archiveOnStop),
+                    Optional.ofNullable(duration),
+                    Optional.ofNullable(maxSize),
+                    Optional.ofNullable(maxAge));
+        }
+    }
+
+    @SuppressFBWarnings(value = "URF_UNREAD_PUBLIC_OR_PROTECTED_FIELD")
+    public static class ActiveRecordingsFilter implements Predicate<ActiveRecording> {
+        public @Nullable String name;
+        public @Nullable List<String> names;
+        public @Nullable List<String> labels;
+        public @Nullable RecordingState state;
+        public @Nullable Boolean continuous;
+        public @Nullable Boolean toDisk;
+        public @Nullable Long durationMsGreaterThanEqual;
+        public @Nullable Long durationMsLessThanEqual;
+        public @Nullable Long startTimeMsAfterEqual;
+        public @Nullable Long startTimeMsBeforeEqual;
+
+        @Override
+        public boolean test(ActiveRecording r) {
+            Predicate<ActiveRecording> matchesName =
+                    n -> name == null || Objects.equals(name, n.name);
+            Predicate<ActiveRecording> matchesNames = n -> names == null || names.contains(n.name);
+            Predicate<ActiveRecording> matchesLabels =
+                    n ->
+                            labels == null
+                                    || labels.stream()
+                                            .allMatch(
+                                                    label ->
+                                                            LabelSelectorMatcher.parse(label)
+                                                                    .test(n.metadata.labels()));
+            Predicate<ActiveRecording> matchesState = n -> state == null || n.state.equals(state);
+            Predicate<ActiveRecording> matchesContinuous =
+                    n -> continuous == null || continuous.equals(n.continuous);
+            Predicate<ActiveRecording> matchesToDisk =
+                    n -> toDisk == null || toDisk.equals(n.toDisk);
+            Predicate<ActiveRecording> matchesDurationGte =
+                    n ->
+                            durationMsGreaterThanEqual == null
+                                    || durationMsGreaterThanEqual >= n.duration;
+            Predicate<ActiveRecording> matchesDurationLte =
+                    n -> durationMsLessThanEqual == null || durationMsLessThanEqual <= n.duration;
+            Predicate<ActiveRecording> matchesStartTimeAfter =
+                    n -> startTimeMsAfterEqual == null || startTimeMsAfterEqual >= n.startTime;
+            Predicate<ActiveRecording> matchesStartTimeBefore =
+                    n -> startTimeMsBeforeEqual == null || startTimeMsBeforeEqual <= n.startTime;
+
+            return matchesName
+                    .and(matchesNames)
+                    .and(matchesLabels)
+                    .and(matchesState)
+                    .and(matchesContinuous)
+                    .and(matchesToDisk)
+                    .and(matchesDurationGte)
+                    .and(matchesDurationLte)
+                    .and(matchesStartTimeBefore)
+                    .and(matchesStartTimeAfter)
+                    .test(r);
+        }
+    }
+}

--- a/src/main/java/io/cryostat/graphql/ArchivedRecordings.java
+++ b/src/main/java/io/cryostat/graphql/ArchivedRecordings.java
@@ -43,10 +43,13 @@ public class ArchivedRecordings {
     @Query("archivedRecordings")
     public TargetNodes.ArchivedRecordings listArchivedRecordings(ArchivedRecordingsFilter filter) {
         var r = new TargetNodes.ArchivedRecordings();
-        r.data = recordingHelper.listArchivedRecordings();
+        r.data =
+                recordingHelper
+                        .listArchivedRecordings(filter == null ? null : filter.sourceTarget)
+                        .stream()
+                        .filter(filter)
+                        .toList();
         r.aggregate = AggregateInfo.fromArchived(r.data);
-        r.aggregate.size = r.data.stream().mapToLong(ArchivedRecording::size).sum();
-        r.aggregate.count = r.data.size();
         return r;
     }
 
@@ -109,14 +112,17 @@ public class ArchivedRecordings {
                             archivedTimeBeforeEqual == null
                                     || archivedTimeBeforeEqual <= n.archivedTime();
 
-            return matchesName
-                    .and(matchesNames)
-                    .and(matchesSourceTarget)
-                    .and(matchesLabels)
-                    .and(matchesSizeGte)
-                    .and(matchesSizeLte)
-                    .and(matchesArchivedTimeGte)
-                    .and(matchesArchivedTimeLte)
+            return List.of(
+                            matchesName,
+                            matchesNames,
+                            matchesSourceTarget,
+                            matchesLabels,
+                            matchesSizeGte,
+                            matchesSizeLte,
+                            matchesArchivedTimeGte,
+                            matchesArchivedTimeLte)
+                    .stream()
+                    .reduce(x -> true, Predicate::and)
                     .test(r);
         }
     }

--- a/src/main/java/io/cryostat/graphql/ArchivedRecordings.java
+++ b/src/main/java/io/cryostat/graphql/ArchivedRecordings.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright The Cryostat Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.cryostat.graphql;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.function.Predicate;
+
+import io.cryostat.graphql.TargetNodes.AggregateInfo;
+import io.cryostat.graphql.TargetNodes.Recordings;
+import io.cryostat.graphql.matchers.LabelSelectorMatcher;
+import io.cryostat.recordings.RecordingHelper;
+import io.cryostat.recordings.Recordings.ArchivedRecording;
+
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import io.smallrye.common.annotation.Blocking;
+import io.smallrye.graphql.api.Nullable;
+import jakarta.inject.Inject;
+import org.eclipse.microprofile.graphql.GraphQLApi;
+import org.eclipse.microprofile.graphql.Query;
+import org.eclipse.microprofile.graphql.Source;
+
+@GraphQLApi
+public class ArchivedRecordings {
+
+    @Inject RecordingHelper recordingHelper;
+
+    @Blocking
+    @Query("archivedRecordings")
+    public TargetNodes.ArchivedRecordings listArchivedRecordings(ArchivedRecordingsFilter filter) {
+        var r = new TargetNodes.ArchivedRecordings();
+        r.data = recordingHelper.listArchivedRecordings();
+        r.aggregate = AggregateInfo.fromArchived(r.data);
+        r.aggregate.size = r.data.stream().mapToLong(ArchivedRecording::size).sum();
+        r.aggregate.count = r.data.size();
+        return r;
+    }
+
+    public TargetNodes.ArchivedRecordings archived(
+            @Source Recordings recordings, ArchivedRecordingsFilter filter) {
+        var out = new TargetNodes.ArchivedRecordings();
+        out.data = new ArrayList<>();
+        out.aggregate = AggregateInfo.empty();
+
+        var in = recordings.archived;
+        if (in != null && in.data != null) {
+            out.data =
+                    in.data.stream().filter(r -> filter == null ? true : filter.test(r)).toList();
+            out.aggregate = AggregateInfo.fromArchived(out.data);
+        }
+
+        return out;
+    }
+
+    @SuppressFBWarnings(value = "URF_UNREAD_PUBLIC_OR_PROTECTED_FIELD")
+    public static class ArchivedRecordingsFilter implements Predicate<ArchivedRecording> {
+        public @Nullable String name;
+        public @Nullable List<String> names;
+        public @Nullable String sourceTarget;
+        public @Nullable List<String> labels;
+        public @Nullable Long sizeBytesGreaterThanEqual;
+        public @Nullable Long sizeBytesLessThanEqual;
+        public @Nullable Long archivedTimeAfterEqual;
+        public @Nullable Long archivedTimeBeforeEqual;
+
+        @Override
+        public boolean test(ArchivedRecording r) {
+            Predicate<ArchivedRecording> matchesName =
+                    n -> name == null || Objects.equals(name, n.name());
+            Predicate<ArchivedRecording> matchesNames =
+                    n -> names == null || names.contains(n.name());
+            Predicate<ArchivedRecording> matchesSourceTarget =
+                    n ->
+                            sourceTarget == null
+                                    || Objects.equals(
+                                            r.metadata().labels().get("connectUrl"), sourceTarget);
+            Predicate<ArchivedRecording> matchesLabels =
+                    n ->
+                            labels == null
+                                    || labels.stream()
+                                            .allMatch(
+                                                    label ->
+                                                            LabelSelectorMatcher.parse(label)
+                                                                    .test(n.metadata().labels()));
+            Predicate<ArchivedRecording> matchesSizeGte =
+                    n -> sizeBytesGreaterThanEqual == null || sizeBytesGreaterThanEqual >= n.size();
+            Predicate<ArchivedRecording> matchesSizeLte =
+                    n -> sizeBytesLessThanEqual == null || sizeBytesLessThanEqual <= n.size();
+            Predicate<ArchivedRecording> matchesArchivedTimeGte =
+                    n ->
+                            archivedTimeAfterEqual == null
+                                    || archivedTimeAfterEqual >= n.archivedTime();
+            Predicate<ArchivedRecording> matchesArchivedTimeLte =
+                    n ->
+                            archivedTimeBeforeEqual == null
+                                    || archivedTimeBeforeEqual <= n.archivedTime();
+
+            return matchesName
+                    .and(matchesNames)
+                    .and(matchesSourceTarget)
+                    .and(matchesLabels)
+                    .and(matchesSizeGte)
+                    .and(matchesSizeLte)
+                    .and(matchesArchivedTimeGte)
+                    .and(matchesArchivedTimeLte)
+                    .test(r);
+        }
+    }
+}

--- a/src/main/java/io/cryostat/graphql/EnvironmentNodeGraphQL.java
+++ b/src/main/java/io/cryostat/graphql/EnvironmentNodeGraphQL.java
@@ -1,0 +1,133 @@
+package io.cryostat.graphql;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+import org.eclipse.microprofile.graphql.Description;
+import org.eclipse.microprofile.graphql.GraphQLApi;
+import org.eclipse.microprofile.graphql.Query;
+
+import io.cryostat.discovery.DiscoveryNode;
+import io.smallrye.graphql.api.Nullable;
+
+@GraphQLApi
+public class EnvironmentNodeGraphQL {
+
+    public static class EnvironmentNodeFilterInput {
+        @Nullable
+        public Long id;
+        @Nullable
+        public String name;
+        @Nullable
+        public List<String> names;
+        @Nullable
+        public String nodeType;
+        @Nullable
+        public List<String> labels;
+
+    }
+
+    public static class EnvironmentNode {
+        private Long id;
+        private String name;
+        private List<String> labels;
+        private String nodeType;
+        private List<EnvironmentNode> children;
+
+        public Long getId(){
+            return this.id;
+        }
+
+        public String getName(){
+            return this.name;
+        }
+
+        public List<String> getLabels(){
+            return this.labels;
+        }
+
+        public String getNodeType(){
+            return this.nodeType;
+        }
+
+        public List<EnvironmentNode> getChildren(){
+            return this.children;
+        }
+
+        public void setId(Long id) {
+            this.id = id;
+        }
+
+        public void setName(String name) {
+            this.name = name;
+        }
+
+        public void setLabels(List<String> labels) {
+            this.labels = labels;
+        }
+
+        public void setNodeType(String nodeType) {
+            this.nodeType = nodeType;
+        }
+
+        public void addChild(EnvironmentNode child) {
+            if (this.children == null) {
+                this.children = new ArrayList<>();
+            }
+            this.children.add(child);
+        }
+    }
+
+    @Query("environmentNodes")
+    @Description("Get all environment nodes in the discovery tree with optional filtering")
+    public List<EnvironmentNode> environmentNodes(EnvironmentNodeFilterInput filter) {
+        DiscoveryNode rootNode = DiscoveryNode.getUniverse();
+        return filterAndTraverse(rootNode, filter).stream()
+            .map(EnvironmentNodeGraphQL::convertDiscoveryNodeToEnvironmentNode)
+            .collect(Collectors.toList());
+    }
+
+    private List<DiscoveryNode> filterAndTraverse(DiscoveryNode node, EnvironmentNodeFilterInput filter) {
+        List<DiscoveryNode> filteredNodes = new ArrayList<>();
+        if (matchesFilter(node, filter)) {
+            filteredNodes.add(node);
+        }
+        if (node.children != null) {
+            for (DiscoveryNode child : node.children) {
+                filteredNodes.addAll(filterAndTraverse(child, filter));
+            }
+        }
+        return filteredNodes;
+    }
+
+    private static boolean matchesFilter(DiscoveryNode node, EnvironmentNodeFilterInput filter) {
+        if (filter == null) return true;
+
+        boolean matchesId = filter.id == null || filter.id.equals(node.id);
+        boolean matchesName = filter.name == null || Objects.equals(filter.name, node.name);
+        boolean matchesNames = filter.names == null || filter.names.contains(node.name);
+        boolean matchesLabels = filter.labels == null || filter.labels.stream().allMatch(label -> node.labels.containsKey(label));
+        boolean matchesNodeType = filter.nodeType == null || filter.nodeType.equals(node.nodeType);
+
+        return matchesId && matchesName && matchesNames && matchesLabels && matchesNodeType;
+    }
+
+    private static EnvironmentNode convertDiscoveryNodeToEnvironmentNode(DiscoveryNode discoveryNode) {
+        EnvironmentNode envNode = new EnvironmentNode();
+        envNode.setId(discoveryNode.id);
+        envNode.setName(discoveryNode.name);
+        List<String> labelsList = discoveryNode.labels.entrySet().stream()
+        .map(entry -> entry.getKey() + "=" + entry.getValue())
+        .collect(Collectors.toList());
+        envNode.setLabels(labelsList);
+        envNode.setNodeType(discoveryNode.nodeType);
+        if (discoveryNode.children != null) {
+            for (DiscoveryNode child : discoveryNode.children) {
+                envNode.addChild(convertDiscoveryNodeToEnvironmentNode(child));
+            }
+        }
+        return envNode;
+    }
+}

--- a/src/main/java/io/cryostat/graphql/EnvironmentNodes.java
+++ b/src/main/java/io/cryostat/graphql/EnvironmentNodes.java
@@ -20,6 +20,7 @@ import java.util.List;
 import java.util.Objects;
 
 import io.cryostat.discovery.DiscoveryNode;
+import io.cryostat.graphql.matchers.LabelSelectorMatcher;
 
 import io.smallrye.graphql.api.Nullable;
 import org.eclipse.microprofile.graphql.Description;
@@ -67,7 +68,11 @@ public class EnvironmentNodes {
         boolean matchesNames = filter.names == null || filter.names.contains(node.name);
         boolean matchesLabels =
                 filter.labels == null
-                        || filter.labels.stream().allMatch(label -> node.labels.containsKey(label));
+                        || filter.labels.stream()
+                                .allMatch(
+                                        label ->
+                                                LabelSelectorMatcher.parse(label)
+                                                        .test(node.labels));
         boolean matchesNodeType = filter.nodeType == null || filter.nodeType.equals(node.nodeType);
 
         return matchesId && matchesName && matchesNames && matchesLabels && matchesNodeType;

--- a/src/main/java/io/cryostat/graphql/EnvironmentNodes.java
+++ b/src/main/java/io/cryostat/graphql/EnvironmentNodes.java
@@ -1,95 +1,51 @@
+/*
+ * Copyright The Cryostat Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.cryostat.graphql;
 
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
-import java.util.stream.Collectors;
 
+import io.cryostat.discovery.DiscoveryNode;
+
+import io.smallrye.graphql.api.Nullable;
 import org.eclipse.microprofile.graphql.Description;
 import org.eclipse.microprofile.graphql.GraphQLApi;
 import org.eclipse.microprofile.graphql.Query;
-
-import io.cryostat.discovery.DiscoveryNode;
-import io.smallrye.graphql.api.Nullable;
 
 @GraphQLApi
 public class EnvironmentNodes {
 
     public static class EnvironmentNodeFilterInput {
-        @Nullable
-        public Long id;
-        @Nullable
-        public String name;
-        @Nullable
-        public List<String> names;
-        @Nullable
-        public String nodeType;
-        @Nullable
-        public List<String> labels;
-
-    }
-
-    public static class EnvironmentNode {
-        private Long id;
-        private String name;
-        private List<String> labels;
-        private String nodeType;
-        private List<EnvironmentNode> children;
-
-        public Long getId(){
-            return this.id;
-        }
-
-        public String getName(){
-            return this.name;
-        }
-
-        public List<String> getLabels(){
-            return this.labels;
-        }
-
-        public String getNodeType(){
-            return this.nodeType;
-        }
-
-        public List<EnvironmentNode> getChildren(){
-            return this.children;
-        }
-
-        public void setId(Long id) {
-            this.id = id;
-        }
-
-        public void setName(String name) {
-            this.name = name;
-        }
-
-        public void setLabels(List<String> labels) {
-            this.labels = labels;
-        }
-
-        public void setNodeType(String nodeType) {
-            this.nodeType = nodeType;
-        }
-
-        public void addChild(EnvironmentNode child) {
-            if (this.children == null) {
-                this.children = new ArrayList<>();
-            }
-            this.children.add(child);
-        }
+        @Nullable public Long id;
+        @Nullable public String name;
+        @Nullable public List<String> names;
+        @Nullable public String nodeType;
+        @Nullable public List<String> labels;
     }
 
     @Query("environmentNodes")
     @Description("Get all environment nodes in the discovery tree with optional filtering")
-    public List<EnvironmentNode> environmentNodes(EnvironmentNodeFilterInput filter) {
+    public List<DiscoveryNode> environmentNodes(EnvironmentNodeFilterInput filter) {
         DiscoveryNode rootNode = DiscoveryNode.getUniverse();
-        return filterAndTraverse(rootNode, filter).stream()
-            .map(EnvironmentNodes::convertDiscoveryNodeToEnvironmentNode)
-            .collect(Collectors.toList());
+        return filterAndTraverse(rootNode, filter);
     }
 
-    private List<DiscoveryNode> filterAndTraverse(DiscoveryNode node, EnvironmentNodeFilterInput filter) {
+    private List<DiscoveryNode> filterAndTraverse(
+            DiscoveryNode node, EnvironmentNodeFilterInput filter) {
         List<DiscoveryNode> filteredNodes = new ArrayList<>();
         if (matchesFilter(node, filter)) {
             filteredNodes.add(node);
@@ -103,31 +59,17 @@ public class EnvironmentNodes {
     }
 
     private static boolean matchesFilter(DiscoveryNode node, EnvironmentNodeFilterInput filter) {
+        if (node.target != null) return false;
         if (filter == null) return true;
 
         boolean matchesId = filter.id == null || filter.id.equals(node.id);
         boolean matchesName = filter.name == null || Objects.equals(filter.name, node.name);
         boolean matchesNames = filter.names == null || filter.names.contains(node.name);
-        boolean matchesLabels = filter.labels == null || filter.labels.stream().allMatch(label -> node.labels.containsKey(label));
+        boolean matchesLabels =
+                filter.labels == null
+                        || filter.labels.stream().allMatch(label -> node.labels.containsKey(label));
         boolean matchesNodeType = filter.nodeType == null || filter.nodeType.equals(node.nodeType);
 
         return matchesId && matchesName && matchesNames && matchesLabels && matchesNodeType;
-    }
-
-    private static EnvironmentNode convertDiscoveryNodeToEnvironmentNode(DiscoveryNode discoveryNode) {
-        EnvironmentNode envNode = new EnvironmentNode();
-        envNode.setId(discoveryNode.id);
-        envNode.setName(discoveryNode.name);
-        List<String> labelsList = discoveryNode.labels.entrySet().stream()
-        .map(entry -> entry.getKey() + "=" + entry.getValue())
-        .collect(Collectors.toList());
-        envNode.setLabels(labelsList);
-        envNode.setNodeType(discoveryNode.nodeType);
-        if (discoveryNode.children != null) {
-            for (DiscoveryNode child : discoveryNode.children) {
-                envNode.addChild(convertDiscoveryNodeToEnvironmentNode(child));
-            }
-        }
-        return envNode;
     }
 }

--- a/src/main/java/io/cryostat/graphql/EnvironmentNodes.java
+++ b/src/main/java/io/cryostat/graphql/EnvironmentNodes.java
@@ -13,7 +13,7 @@ import io.cryostat.discovery.DiscoveryNode;
 import io.smallrye.graphql.api.Nullable;
 
 @GraphQLApi
-public class EnvironmentNodeGraphQL {
+public class EnvironmentNodes {
 
     public static class EnvironmentNodeFilterInput {
         @Nullable
@@ -85,7 +85,7 @@ public class EnvironmentNodeGraphQL {
     public List<EnvironmentNode> environmentNodes(EnvironmentNodeFilterInput filter) {
         DiscoveryNode rootNode = DiscoveryNode.getUniverse();
         return filterAndTraverse(rootNode, filter).stream()
-            .map(EnvironmentNodeGraphQL::convertDiscoveryNodeToEnvironmentNode)
+            .map(EnvironmentNodes::convertDiscoveryNodeToEnvironmentNode)
             .collect(Collectors.toList());
     }
 

--- a/src/main/java/io/cryostat/graphql/EnvironmentNodes.java
+++ b/src/main/java/io/cryostat/graphql/EnvironmentNodes.java
@@ -15,12 +15,10 @@
  */
 package io.cryostat.graphql;
 
-import java.util.ArrayList;
 import java.util.List;
-import java.util.Objects;
 
 import io.cryostat.discovery.DiscoveryNode;
-import io.cryostat.graphql.matchers.LabelSelectorMatcher;
+import io.cryostat.graphql.RootNode.DiscoveryNodeFilter;
 
 import io.smallrye.graphql.api.Nullable;
 import org.eclipse.microprofile.graphql.Description;
@@ -30,51 +28,12 @@ import org.eclipse.microprofile.graphql.Query;
 @GraphQLApi
 public class EnvironmentNodes {
 
-    public static class EnvironmentNodeFilterInput {
-        @Nullable public Long id;
-        @Nullable public String name;
-        @Nullable public List<String> names;
-        @Nullable public String nodeType;
-        @Nullable public List<String> labels;
-    }
-
     @Query("environmentNodes")
     @Description("Get all environment nodes in the discovery tree with optional filtering")
-    public List<DiscoveryNode> environmentNodes(EnvironmentNodeFilterInput filter) {
-        DiscoveryNode rootNode = DiscoveryNode.getUniverse();
-        return filterAndTraverse(rootNode, filter);
-    }
-
-    private List<DiscoveryNode> filterAndTraverse(
-            DiscoveryNode node, EnvironmentNodeFilterInput filter) {
-        List<DiscoveryNode> filteredNodes = new ArrayList<>();
-        if (matchesFilter(node, filter)) {
-            filteredNodes.add(node);
-        }
-        if (node.children != null) {
-            for (DiscoveryNode child : node.children) {
-                filteredNodes.addAll(filterAndTraverse(child, filter));
-            }
-        }
-        return filteredNodes;
-    }
-
-    private static boolean matchesFilter(DiscoveryNode node, EnvironmentNodeFilterInput filter) {
-        if (node.target != null) return false;
-        if (filter == null) return true;
-
-        boolean matchesId = filter.id == null || filter.id.equals(node.id);
-        boolean matchesName = filter.name == null || Objects.equals(filter.name, node.name);
-        boolean matchesNames = filter.names == null || filter.names.contains(node.name);
-        boolean matchesLabels =
-                filter.labels == null
-                        || filter.labels.stream()
-                                .allMatch(
-                                        label ->
-                                                LabelSelectorMatcher.parse(label)
-                                                        .test(node.labels));
-        boolean matchesNodeType = filter.nodeType == null || filter.nodeType.equals(node.nodeType);
-
-        return matchesId && matchesName && matchesNames && matchesLabels && matchesNodeType;
+    public List<DiscoveryNode> environmentNodes(@Nullable DiscoveryNodeFilter filter) {
+        return RootNode.recurseChildren(DiscoveryNode.getUniverse(), node -> node.target == null)
+                .stream()
+                .filter(filter)
+                .toList();
     }
 }

--- a/src/main/java/io/cryostat/graphql/GraphQL.java
+++ b/src/main/java/io/cryostat/graphql/GraphQL.java
@@ -22,6 +22,8 @@ import jakarta.ws.rs.GET;
 import jakarta.ws.rs.POST;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.core.UriInfo;
+import org.apache.hc.core5.net.URIBuilder;
 import org.jboss.resteasy.reactive.RestResponse;
 
 @Path("")
@@ -30,9 +32,23 @@ public class GraphQL {
     @GET
     @Path("/api/v2.2/graphql")
     @RolesAllowed("write")
-    public Response redirectGet() throws Exception {
+    public Response redirectGet(UriInfo info) throws Exception {
+        var uriBuilder = new URIBuilder();
+        info.getQueryParameters()
+                .entrySet()
+                .forEach(
+                        entry -> {
+                            if (entry.getValue().size() != 1) {
+                                return;
+                            }
+                            uriBuilder.addParameter(entry.getKey(), entry.getValue().get(0));
+                        });
         return Response.status(RestResponse.Status.PERMANENT_REDIRECT)
-                .location(URI.create("/api/v3/graphql"))
+                .location(
+                        URI.create(
+                                String.format(
+                                        "/api/v3/graphql?%s",
+                                        String.join("&", uriBuilder.build().getRawQuery()))))
                 .build();
     }
 

--- a/src/main/java/io/cryostat/graphql/GraphQL.java
+++ b/src/main/java/io/cryostat/graphql/GraphQL.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright The Cryostat Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.cryostat.graphql;
+
+import java.net.URI;
+
+import jakarta.annotation.security.RolesAllowed;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.core.Response;
+import org.jboss.resteasy.reactive.RestResponse;
+
+@Path("")
+public class GraphQL {
+
+    @GET
+    @Path("/api/v2.2/graphql")
+    @RolesAllowed("write")
+    public Response redirectGet() throws Exception {
+        return Response.status(RestResponse.Status.PERMANENT_REDIRECT)
+                .location(URI.create("/api/v3/graphql"))
+                .build();
+    }
+
+    @POST
+    @Path("/api/v2.2/graphql")
+    @RolesAllowed("write")
+    public Response redirectPost() throws Exception {
+        return Response.status(RestResponse.Status.PERMANENT_REDIRECT)
+                .location(URI.create("/api/v3/graphql"))
+                .build();
+    }
+}

--- a/src/main/java/io/cryostat/graphql/RecordingLinks.java
+++ b/src/main/java/io/cryostat/graphql/RecordingLinks.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright The Cryostat Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.cryostat.graphql;
+
+import io.cryostat.recordings.ActiveRecording;
+import io.cryostat.recordings.RecordingHelper;
+import io.cryostat.recordings.Recordings.ArchivedRecording;
+
+import jakarta.inject.Inject;
+import org.eclipse.microprofile.graphql.Description;
+import org.eclipse.microprofile.graphql.GraphQLApi;
+import org.eclipse.microprofile.graphql.Source;
+
+@GraphQLApi
+public class RecordingLinks {
+
+    @Inject RecordingHelper recordingHelper;
+
+    @Description("URL for GET request to retrieve the JFR binary file content of this recording")
+    public String downloadUrl(@Source ActiveRecording recording) {
+        return recordingHelper.downloadUrl(recording);
+    }
+
+    @Description(
+            "URL for GET request to retrieve a JSON formatted Automated Analysis Report of this"
+                    + " recording")
+    public String reportUrl(@Source ActiveRecording recording) {
+        return recordingHelper.reportUrl(recording);
+    }
+
+    @Description("URL for GET request to retrieve the JFR binary file content of this recording")
+    public String downloadUrl(@Source ArchivedRecording recording) {
+        return recording.downloadUrl();
+    }
+
+    @Description(
+            "URL for GET request to retrieve a JSON formatted Automated Analysis Report of this"
+                    + " recording")
+    public String reportUrl(@Source ArchivedRecording recording) {
+        return recording.reportUrl();
+    }
+}

--- a/src/main/java/io/cryostat/graphql/RootNode.java
+++ b/src/main/java/io/cryostat/graphql/RootNode.java
@@ -73,7 +73,7 @@ public class RootNode {
 
         @Override
         public boolean test(DiscoveryNode t) {
-            Predicate<DiscoveryNode> matchesId = n -> id == null || id == n.id;
+            Predicate<DiscoveryNode> matchesId = n -> id == null || id.equals(n.id);
             Predicate<DiscoveryNode> matchesName =
                     n -> name == null || Objects.equals(name, n.name);
             Predicate<DiscoveryNode> matchesNames = n -> names == null || names.contains(n.name);

--- a/src/main/java/io/cryostat/graphql/RootNode.java
+++ b/src/main/java/io/cryostat/graphql/RootNode.java
@@ -17,7 +17,6 @@ package io.cryostat.graphql;
 
 import io.cryostat.discovery.DiscoveryNode;
 
-import io.smallrye.mutiny.Uni;
 import org.eclipse.microprofile.graphql.Description;
 import org.eclipse.microprofile.graphql.GraphQLApi;
 import org.eclipse.microprofile.graphql.Query;
@@ -27,7 +26,7 @@ public class RootNode {
 
     @Query("rootNode")
     @Description("Get the root target discovery node")
-    public Uni<DiscoveryNode> getRootNode() {
-        return Uni.createFrom().item(DiscoveryNode::getUniverse);
+    public DiscoveryNode getRootNode() {
+        return DiscoveryNode.getUniverse();
     }
 }

--- a/src/main/java/io/cryostat/graphql/RootNode.java
+++ b/src/main/java/io/cryostat/graphql/RootNode.java
@@ -24,6 +24,7 @@ import java.util.function.Predicate;
 import io.cryostat.discovery.DiscoveryNode;
 import io.cryostat.graphql.matchers.LabelSelectorMatcher;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.smallrye.graphql.api.Nullable;
 import org.eclipse.microprofile.graphql.Description;
 import org.eclipse.microprofile.graphql.GraphQLApi;
@@ -43,7 +44,7 @@ public class RootNode {
             "Get target nodes that are descendants of this node. That is, get the set of leaf nodes"
                     + " from anywhere below this node's subtree.")
     public List<DiscoveryNode> descendantTargets(
-            @Source DiscoveryNode discoveryNode, DescendantTargetsFilterInput filter) {
+            @Source DiscoveryNode discoveryNode, DiscoveryNodeFilter filter) {
         // TODO do this filtering at the database query level as much as possible. As is, this will
         // load the entire discovery tree out of the database, then perform the filtering at the
         // application level.
@@ -64,7 +65,8 @@ public class RootNode {
         return result;
     }
 
-    public static class DescendantTargetsFilterInput implements Predicate<DiscoveryNode> {
+    @SuppressFBWarnings(value = "URF_UNREAD_PUBLIC_OR_PROTECTED_FIELD")
+    public static class DiscoveryNodeFilter implements Predicate<DiscoveryNode> {
         public @Nullable Long id;
         public @Nullable String name;
         public @Nullable List<String> names;

--- a/src/main/java/io/cryostat/graphql/RootNode.java
+++ b/src/main/java/io/cryostat/graphql/RootNode.java
@@ -39,6 +39,9 @@ public class RootNode {
         return DiscoveryNode.getUniverse();
     }
 
+    @Description(
+            "Get target nodes that are descendants of this node. That is, get the set of leaf nodes"
+                    + " from anywhere below this node's subtree.")
     public List<DiscoveryNode> descendantTargets(
             @Source DiscoveryNode discoveryNode, DescendantTargetsFilterInput filter) {
         // TODO do this filtering at the database query level as much as possible. As is, this will

--- a/src/main/java/io/cryostat/graphql/RootNode.java
+++ b/src/main/java/io/cryostat/graphql/RootNode.java
@@ -17,6 +17,7 @@ package io.cryostat.graphql;
 
 import io.cryostat.discovery.DiscoveryNode;
 
+import io.smallrye.mutiny.Uni;
 import org.eclipse.microprofile.graphql.Description;
 import org.eclipse.microprofile.graphql.GraphQLApi;
 import org.eclipse.microprofile.graphql.Query;
@@ -26,7 +27,7 @@ public class RootNode {
 
     @Query("rootNode")
     @Description("Get the root target discovery node")
-    public DiscoveryNode getRootNode() {
-        return DiscoveryNode.getUniverse();
+    public Uni<DiscoveryNode> getRootNode() {
+        return Uni.createFrom().item(DiscoveryNode::getUniverse);
     }
 }

--- a/src/main/java/io/cryostat/graphql/RootNode.java
+++ b/src/main/java/io/cryostat/graphql/RootNode.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright The Cryostat Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.cryostat.graphql;
+
+import io.cryostat.discovery.DiscoveryNode;
+
+import org.eclipse.microprofile.graphql.Description;
+import org.eclipse.microprofile.graphql.GraphQLApi;
+import org.eclipse.microprofile.graphql.Query;
+
+@GraphQLApi
+public class RootNode {
+
+    @Query("rootNode")
+    @Description("Get the root target discovery node")
+    public DiscoveryNode getRootNode() {
+        return DiscoveryNode.getUniverse();
+    }
+}

--- a/src/main/java/io/cryostat/graphql/RootNode.java
+++ b/src/main/java/io/cryostat/graphql/RootNode.java
@@ -78,29 +78,23 @@ public class RootNode {
                     n -> name == null || Objects.equals(name, n.name);
             Predicate<DiscoveryNode> matchesNames = n -> names == null || names.contains(n.name);
             Predicate<DiscoveryNode> matchesLabels =
-                    n -> {
-                        if (labels == null) {
-                            return true;
-                        }
-                        var allMatch = true;
-                        for (var l : labels) {
-                            allMatch &= LabelSelectorMatcher.parse(l).test(n.labels);
-                        }
-                        return allMatch;
-                    };
+                    n ->
+                            labels == null
+                                    || labels.stream()
+                                            .allMatch(
+                                                    label ->
+                                                            LabelSelectorMatcher.parse(label)
+                                                                    .test(n.labels));
             Predicate<DiscoveryNode> matchesAnnotations =
-                    n -> {
-                        if (annotations == null) {
-                            return true;
-                        }
-                        var allMatch = true;
-                        for (var l : annotations) {
-                            allMatch &=
-                                    LabelSelectorMatcher.parse(l)
-                                            .test(n.target.annotations.merged());
-                        }
-                        return allMatch;
-                    };
+                    n ->
+                            annotations == null
+                                    || annotations.stream()
+                                            .allMatch(
+                                                    annotation ->
+                                                            LabelSelectorMatcher.parse(annotation)
+                                                                    .test(
+                                                                            n.target.annotations
+                                                                                    .merged()));
 
             return matchesId
                     .and(matchesName)

--- a/src/main/java/io/cryostat/graphql/RootNode.java
+++ b/src/main/java/io/cryostat/graphql/RootNode.java
@@ -15,11 +15,19 @@
  */
 package io.cryostat.graphql;
 
+import java.util.HashSet;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+import java.util.function.Predicate;
+
 import io.cryostat.discovery.DiscoveryNode;
 
+import io.smallrye.graphql.api.Nullable;
 import org.eclipse.microprofile.graphql.Description;
 import org.eclipse.microprofile.graphql.GraphQLApi;
 import org.eclipse.microprofile.graphql.Query;
+import org.eclipse.microprofile.graphql.Source;
 
 @GraphQLApi
 public class RootNode {
@@ -28,5 +36,47 @@ public class RootNode {
     @Description("Get the root target discovery node")
     public DiscoveryNode getRootNode() {
         return DiscoveryNode.getUniverse();
+    }
+
+    public List<DiscoveryNode> descendantTargets(
+            @Source DiscoveryNode discoveryNode, DescendantTargetsFilterInput filter) {
+        // TODO do this filtering at the database query level as much as possible. As is, this will
+        // load the entire discovery tree out of the database, then perform the filtering at the
+        // application level.
+        return recurseChildren(discoveryNode, n -> n.target != null).stream()
+                .filter(n -> filter == null ? true : filter.test(n))
+                .toList();
+    }
+
+    private Set<DiscoveryNode> recurseChildren(
+            DiscoveryNode node, Predicate<DiscoveryNode> predicate) {
+        Set<DiscoveryNode> result = new HashSet<>();
+        if (predicate.test(node)) {
+            result.add(node);
+        }
+        if (node.children != null) {
+            node.children.forEach(c -> result.addAll(recurseChildren(c, predicate)));
+        }
+        return result;
+    }
+
+    public static class DescendantTargetsFilterInput implements Predicate<DiscoveryNode> {
+        public @Nullable Long id;
+        public @Nullable String name;
+        public @Nullable List<String> names;
+
+        // TODO reimplement label and annotations matching syntax
+        // public List<String> labels;
+        // public List<String> annotations;
+
+        @Override
+        public boolean test(DiscoveryNode t) {
+            Predicate<DiscoveryNode> matchesId = n -> id == null || id == n.id;
+            Predicate<DiscoveryNode> matchesName =
+                    n -> name == null || Objects.equals(name, n.name);
+            Predicate<DiscoveryNode> matchesNames = n -> names == null || names.contains(n.name);
+
+            return matchesId.and(matchesName).and(matchesNames).test(t);
+        }
     }
 }

--- a/src/main/java/io/cryostat/graphql/SchemaExtension.java
+++ b/src/main/java/io/cryostat/graphql/SchemaExtension.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright The Cryostat Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.cryostat.graphql;
+
+import java.util.Arrays;
+
+import graphql.schema.GraphQLEnumType;
+import graphql.schema.GraphQLEnumValueDefinition;
+import graphql.schema.GraphQLSchema;
+import jakarta.enterprise.event.Observes;
+import jdk.jfr.RecordingState;
+import org.eclipse.microprofile.graphql.GraphQLApi;
+
+@GraphQLApi
+public class SchemaExtension {
+
+    public GraphQLSchema.Builder registerRecordingStateEnum(
+            @Observes GraphQLSchema.Builder builder) {
+        return createEnumType(
+                builder, RecordingState.class, "Running state of an active Flight Recording");
+    }
+
+    private static GraphQLSchema.Builder createEnumType(
+            GraphQLSchema.Builder builder, Class<? extends Enum<?>> klazz, String description) {
+        return builder.additionalType(
+                GraphQLEnumType.newEnum()
+                        .name(klazz.getSimpleName())
+                        .description(description)
+                        .values(
+                                Arrays.asList(klazz.getEnumConstants()).stream()
+                                        .map(
+                                                s ->
+                                                        new GraphQLEnumValueDefinition.Builder()
+                                                                .name(s.name())
+                                                                .value(s)
+                                                                .description(s.name())
+                                                                .build())
+                                        .toList())
+                        .build());
+    }
+}

--- a/src/main/java/io/cryostat/graphql/TargetNodes.java
+++ b/src/main/java/io/cryostat/graphql/TargetNodes.java
@@ -1,0 +1,363 @@
+/*
+ * Copyright The Cryostat Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.cryostat.graphql;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Function;
+import java.util.function.Predicate;
+
+import org.openjdk.jmc.common.unit.QuantityConversionException;
+
+import io.cryostat.core.net.JFRConnection;
+import io.cryostat.core.net.MBeanMetrics;
+import io.cryostat.core.templates.Template;
+import io.cryostat.core.templates.TemplateType;
+import io.cryostat.discovery.DiscoveryNode;
+import io.cryostat.graphql.RootNode.DiscoveryNodeFilter;
+import io.cryostat.graphql.matchers.LabelSelectorMatcher;
+import io.cryostat.recordings.ActiveRecording;
+import io.cryostat.recordings.RecordingHelper;
+import io.cryostat.recordings.RecordingHelper.RecordingOptions;
+import io.cryostat.recordings.RecordingHelper.RecordingReplace;
+import io.cryostat.recordings.Recordings.ArchivedRecording;
+import io.cryostat.recordings.Recordings.Metadata;
+import io.cryostat.targets.Target;
+import io.cryostat.targets.TargetConnectionManager;
+
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import graphql.schema.DataFetchingEnvironment;
+import graphql.schema.GraphQLEnumType;
+import graphql.schema.GraphQLEnumValueDefinition;
+import graphql.schema.GraphQLSchema;
+import io.smallrye.common.annotation.Blocking;
+import io.smallrye.graphql.api.Context;
+import io.smallrye.graphql.api.Nullable;
+import io.smallrye.mutiny.Uni;
+import jakarta.enterprise.event.Observes;
+import jakarta.inject.Inject;
+import jakarta.transaction.Transactional;
+import jdk.jfr.RecordingState;
+import org.eclipse.microprofile.graphql.Description;
+import org.eclipse.microprofile.graphql.GraphQLApi;
+import org.eclipse.microprofile.graphql.NonNull;
+import org.eclipse.microprofile.graphql.Query;
+import org.eclipse.microprofile.graphql.Source;
+
+@GraphQLApi
+public class TargetNodes {
+
+    @Inject RecordingHelper recordingHelper;
+    @Inject TargetConnectionManager connectionManager;
+
+    public GraphQLSchema.Builder registerRecordingStateEnum(
+            @Observes GraphQLSchema.Builder builder) {
+        return createEnumType(
+                builder, RecordingState.class, "Running state of an active Flight Recording");
+    }
+
+    private static GraphQLSchema.Builder createEnumType(
+            GraphQLSchema.Builder builder, Class<? extends Enum<?>> klazz, String description) {
+        return builder.additionalType(
+                GraphQLEnumType.newEnum()
+                        .name(klazz.getSimpleName())
+                        .description(description)
+                        .values(
+                                Arrays.asList(klazz.getEnumConstants()).stream()
+                                        .map(
+                                                s ->
+                                                        new GraphQLEnumValueDefinition.Builder()
+                                                                .name(s.name())
+                                                                .value(s)
+                                                                .description(s.name())
+                                                                .build())
+                                        .toList())
+                        .build());
+    }
+
+    @Blocking
+    @Query("targetNodes")
+    @Description("Get the Target discovery nodes, i.e. the leaf nodes of the discovery tree")
+    public List<DiscoveryNode> getTargetNodes(DiscoveryNodeFilter filter) {
+        // TODO do this filtering at the database query level as much as possible. As is, this will
+        // load the entire discovery tree out of the database, then perform the filtering at the
+        // application level.
+        return Target.<Target>findAll().stream()
+                .filter(distinctWith(t -> t.jvmId))
+                .map(t -> t.discoveryNode)
+                .filter(n -> filter == null ? true : filter.test(n))
+                .toList();
+    }
+
+    private static <T> Predicate<T> distinctWith(Function<? super T, ?> fn) {
+        Set<Object> observed = ConcurrentHashMap.newKeySet();
+        return t -> observed.add(fn.apply(t));
+    }
+
+    @Blocking
+    @Description("Get the active and archived recordings belonging to this target")
+    public Recordings recordings(@Source Target target, Context context) {
+        var dfe = context.unwrap(DataFetchingEnvironment.class);
+        var requestedFields =
+                dfe.getSelectionSet().getFields().stream().map(field -> field.getName()).toList();
+
+        var recordings = new Recordings();
+
+        if (requestedFields.contains("active")) {
+            recordings.active = new ActiveRecordings();
+            recordings.active.data = target.activeRecordings;
+            recordings.active.aggregate = new AggregateInfo();
+            recordings.active.aggregate.count = recordings.active.data.size();
+            recordings.active.aggregate.size = 0;
+        }
+
+        if (requestedFields.contains("archived")) {
+            recordings.archived = new ArchivedRecordings();
+            recordings.archived.data = recordingHelper.listArchivedRecordings(target);
+            recordings.archived.aggregate = new AggregateInfo();
+            recordings.archived.aggregate.count = recordings.archived.data.size();
+            recordings.archived.aggregate.size =
+                    recordings.archived.data.stream().mapToLong(ArchivedRecording::size).sum();
+        }
+
+        return recordings;
+    }
+
+    public ActiveRecordings active(@Source Recordings recordings, ActiveRecordingsFilter filter) {
+        var out = new ActiveRecordings();
+        out.data = new ArrayList<>();
+        out.aggregate = new AggregateInfo();
+
+        var in = recordings.active;
+        if (in != null && in.data != null) {
+            out.data =
+                    in.data.stream().filter(r -> filter == null ? true : filter.test(r)).toList();
+            out.aggregate.size = 0;
+            out.aggregate.count = out.data.size();
+        }
+
+        return out;
+    }
+
+    public ArchivedRecordings archived(
+            @Source Recordings recordings, ArchivedRecordingsFilter filter) {
+        var out = new ArchivedRecordings();
+        out.data = new ArrayList<>();
+        out.aggregate = new AggregateInfo();
+
+        var in = recordings.archived;
+        if (in != null && in.data != null) {
+            out.data =
+                    in.data.stream().filter(r -> filter == null ? true : filter.test(r)).toList();
+            out.aggregate.size = 0;
+            out.aggregate.count = out.data.size();
+        }
+
+        return out;
+    }
+
+    @Blocking
+    @Description("Get live MBean metrics snapshot from the specified Target")
+    public Uni<MBeanMetrics> mbeanMetrics(@Source Target target) {
+        return connectionManager.executeConnectedTaskUni(target, JFRConnection::getMBeanMetrics);
+    }
+
+    @Blocking
+    @Transactional
+    @Description("Start a new Flight Recording on the specified Target")
+    public Uni<ActiveRecording> doStartRecording(
+            @Source Target target, @NonNull RecordingSettings settings)
+            throws QuantityConversionException {
+        var fTarget = Target.<Target>findById(target.id);
+        Template template =
+                recordingHelper.getPreferredTemplate(
+                        fTarget, settings.template, settings.templateType);
+        return recordingHelper.startRecording(
+                fTarget,
+                RecordingReplace.STOPPED,
+                template,
+                settings.asOptions(),
+                settings.metadata.labels());
+    }
+
+    @Blocking
+    @Transactional
+    @Description("Create a new Flight Recorder Snapshot on the specified Target")
+    public Uni<ActiveRecording> doSnapshot(@Source Target target) {
+        var fTarget = Target.<Target>findById(target.id);
+        return recordingHelper.createSnapshot(fTarget);
+    }
+
+    @SuppressFBWarnings(value = "URF_UNREAD_PUBLIC_OR_PROTECTED_FIELD")
+    public static class Recordings {
+        public @NonNull ActiveRecordings active;
+        public @NonNull ArchivedRecordings archived;
+    }
+
+    @SuppressFBWarnings(value = "URF_UNREAD_PUBLIC_OR_PROTECTED_FIELD")
+    public static class ActiveRecordings {
+        public @NonNull List<ActiveRecording> data;
+        public @NonNull AggregateInfo aggregate;
+    }
+
+    @SuppressFBWarnings(value = "URF_UNREAD_PUBLIC_OR_PROTECTED_FIELD")
+    public static class ArchivedRecordings {
+        public @NonNull List<ArchivedRecording> data;
+        public @NonNull AggregateInfo aggregate;
+    }
+
+    @SuppressFBWarnings(value = "URF_UNREAD_PUBLIC_OR_PROTECTED_FIELD")
+    public static class AggregateInfo {
+        public @NonNull @Description("The number of elements in this collection") long count;
+        public @NonNull @Description(
+                "The sum of sizes of elements in this collection, or 0 if not applicable") long
+                size;
+    }
+
+    @SuppressFBWarnings(value = "URF_UNREAD_PUBLIC_OR_PROTECTED_FIELD")
+    public static class ActiveRecordingsFilter implements Predicate<ActiveRecording> {
+        public @Nullable String name;
+        public @Nullable List<String> names;
+        public @Nullable List<String> labels;
+        public @Nullable RecordingState state;
+        public @Nullable Boolean continuous;
+        public @Nullable Boolean toDisk;
+        public @Nullable Long durationMsGreaterThanEqual;
+        public @Nullable Long durationMsLessThanEqual;
+        public @Nullable Long startTimeMsAfterEqual;
+        public @Nullable Long startTimeMsBeforeEqual;
+
+        @Override
+        public boolean test(ActiveRecording r) {
+            Predicate<ActiveRecording> matchesName =
+                    n -> name == null || Objects.equals(name, n.name);
+            Predicate<ActiveRecording> matchesNames = n -> names == null || names.contains(n.name);
+            Predicate<ActiveRecording> matchesLabels =
+                    n ->
+                            labels == null
+                                    || labels.stream()
+                                            .allMatch(
+                                                    label ->
+                                                            LabelSelectorMatcher.parse(label)
+                                                                    .test(n.metadata.labels()));
+            Predicate<ActiveRecording> matchesState = n -> state == null || n.state.equals(state);
+            Predicate<ActiveRecording> matchesContinuous =
+                    n -> continuous == null || continuous.equals(n.continuous);
+            Predicate<ActiveRecording> matchesToDisk =
+                    n -> toDisk == null || toDisk.equals(n.toDisk);
+            Predicate<ActiveRecording> matchesDurationGte =
+                    n ->
+                            durationMsGreaterThanEqual == null
+                                    || durationMsGreaterThanEqual >= n.duration;
+            Predicate<ActiveRecording> matchesDurationLte =
+                    n -> durationMsLessThanEqual == null || durationMsLessThanEqual <= n.duration;
+            Predicate<ActiveRecording> matchesStartTimeAfter =
+                    n -> startTimeMsAfterEqual == null || startTimeMsAfterEqual >= n.startTime;
+            Predicate<ActiveRecording> matchesStartTimeBefore =
+                    n -> startTimeMsBeforeEqual == null || startTimeMsBeforeEqual <= n.startTime;
+
+            return matchesName
+                    .and(matchesNames)
+                    .and(matchesLabels)
+                    .and(matchesState)
+                    .and(matchesContinuous)
+                    .and(matchesToDisk)
+                    .and(matchesDurationGte)
+                    .and(matchesDurationLte)
+                    .and(matchesStartTimeBefore)
+                    .and(matchesStartTimeAfter)
+                    .test(r);
+        }
+    }
+
+    @SuppressFBWarnings(value = "URF_UNREAD_PUBLIC_OR_PROTECTED_FIELD")
+    public static class ArchivedRecordingsFilter implements Predicate<ArchivedRecording> {
+        public @Nullable String name;
+        public @Nullable List<String> names;
+        public @Nullable List<String> labels;
+        public @Nullable Long sizeBytesGreaterThanEqual;
+        public @Nullable Long sizeBytesLessThanEqual;
+        public @Nullable Long archivedTimeAfterEqual;
+        public @Nullable Long archivedTimeBeforeEqual;
+
+        @Override
+        public boolean test(ArchivedRecording r) {
+            Predicate<ArchivedRecording> matchesName =
+                    n -> name == null || Objects.equals(name, n.name());
+            Predicate<ArchivedRecording> matchesNames =
+                    n -> names == null || names.contains(n.name());
+            Predicate<ArchivedRecording> matchesLabels =
+                    n ->
+                            labels == null
+                                    || labels.stream()
+                                            .allMatch(
+                                                    label ->
+                                                            LabelSelectorMatcher.parse(label)
+                                                                    .test(n.metadata().labels()));
+            Predicate<ArchivedRecording> matchesSizeGte =
+                    n -> sizeBytesGreaterThanEqual == null || sizeBytesGreaterThanEqual >= n.size();
+            Predicate<ArchivedRecording> matchesSizeLte =
+                    n -> sizeBytesLessThanEqual == null || sizeBytesLessThanEqual <= n.size();
+            Predicate<ArchivedRecording> matchesArchivedTimeGte =
+                    n ->
+                            archivedTimeAfterEqual == null
+                                    || archivedTimeAfterEqual >= n.archivedTime();
+            Predicate<ArchivedRecording> matchesArchivedTimeLte =
+                    n ->
+                            archivedTimeBeforeEqual == null
+                                    || archivedTimeBeforeEqual <= n.archivedTime();
+
+            return matchesName
+                    .and(matchesNames)
+                    .and(matchesLabels)
+                    .and(matchesSizeGte)
+                    .and(matchesSizeLte)
+                    .and(matchesArchivedTimeGte)
+                    .and(matchesArchivedTimeLte)
+                    .test(r);
+        }
+    }
+
+    @SuppressFBWarnings(value = "URF_UNREAD_PUBLIC_OR_PROTECTED_FIELD")
+    public static class RecordingSettings {
+        public @NonNull String name;
+        public @NonNull String template;
+        public @NonNull TemplateType templateType;
+        public @Nullable RecordingReplace replace;
+        public @Nullable Boolean continuous;
+        public @Nullable Boolean archiveOnStop;
+        public @Nullable Boolean toDisk;
+        public @Nullable Long duration;
+        public @Nullable Long maxSize;
+        public @Nullable Long maxAge;
+        public @Nullable Metadata metadata;
+
+        public RecordingOptions asOptions() {
+            return new RecordingOptions(
+                    name,
+                    Optional.ofNullable(toDisk),
+                    Optional.ofNullable(archiveOnStop),
+                    Optional.ofNullable(duration),
+                    Optional.ofNullable(maxSize),
+                    Optional.ofNullable(maxAge));
+        }
+    }
+}

--- a/src/main/java/io/cryostat/graphql/matchers/EqualityMatcher.java
+++ b/src/main/java/io/cryostat/graphql/matchers/EqualityMatcher.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright The Cryostat Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.cryostat.graphql.matchers;
+
+import java.util.Objects;
+import java.util.function.Function;
+import java.util.function.Predicate;
+
+public class EqualityMatcher implements LabelMatcher {
+
+    private final String key;
+    private final EqualityMatcher.Operator operator;
+    private final String value;
+
+    EqualityMatcher(String key, EqualityMatcher.Operator operator, String value) {
+        this.key = key;
+        this.operator = operator;
+        this.value = value;
+    }
+
+    @Override
+    public String getKey() {
+        return key;
+    }
+
+    @Override
+    public boolean test(String s) {
+        return operator.with(value).test(s);
+    }
+
+    public enum Operator {
+        EQUAL("=", arg -> v -> Objects.equals(arg, v)),
+        DOUBLE_EQUAL("==", arg -> v -> Objects.equals(arg, v)),
+        NOT_EQUAL("!=", arg -> v -> !Objects.equals(arg, v)),
+        ;
+
+        private final String token;
+        private final Function<String, Predicate<String>> fn;
+
+        Operator(String token, Function<String, Predicate<String>> fn) {
+            this.token = token;
+            this.fn = fn;
+        }
+
+        Predicate<String> with(String value) {
+            return fn.apply(value);
+        }
+
+        public static Operator fromString(String str) {
+            for (Operator op : Operator.values()) {
+                if (op.token.equals(str)) {
+                    return op;
+                }
+            }
+            return null;
+        }
+    }
+}

--- a/src/main/java/io/cryostat/graphql/matchers/LabelMatcher.java
+++ b/src/main/java/io/cryostat/graphql/matchers/LabelMatcher.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright The Cryostat Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.cryostat.graphql.matchers;
+
+import java.util.function.Predicate;
+
+interface LabelMatcher extends Predicate<String> {
+    String getKey();
+}

--- a/src/main/java/io/cryostat/graphql/matchers/LabelSelectorMatcher.java
+++ b/src/main/java/io/cryostat/graphql/matchers/LabelSelectorMatcher.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright The Cryostat Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.cryostat.graphql.matchers;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.function.Function;
+import java.util.function.Predicate;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+public class LabelSelectorMatcher implements Predicate<Map<String, String>> {
+
+    // ex. "my.prefix/label = something". Whitespaces around the operator are ignored. Left side
+    // must loosely look like a k8s label (not strictly enforced here), right side must loosely look
+    // like a k8s label value, which may be empty. Allowed operators are "=", "==", "!=".
+    static final Pattern EQUALITY_PATTERN =
+            Pattern.compile("^(?<key>[^!=\\s]+)\\s*(?<op>=|==|!=)\\s*(?<value>[^!=\\s]*)$");
+
+    // ex. "environment in (production, qa)" or "tier NotIn (frontend, backend)". Tests if the given
+    // label has or does not have any of the specified values.
+    static final Pattern SET_MEMBER_PATTERN =
+            Pattern.compile(
+                    "(?<key>\\S+)\\s+(?<op>in|notin)\\s+\\((?<values>.+)\\)",
+                    Pattern.CASE_INSENSITIVE);
+
+    // ex. "mykey" or "!mykey". Tests whether the given key name exists in the test label set as a
+    // key, with or without a value.
+    static final Pattern SET_EXISTENCE_PATTERN =
+            Pattern.compile("^(?<op>!?)(?<key>\\S+)$", Pattern.MULTILINE);
+
+    private final List<LabelMatcher> matchers = new ArrayList<>();
+
+    private LabelSelectorMatcher() {
+        this(List.of());
+    }
+
+    private LabelSelectorMatcher(Collection<LabelMatcher> matchers) {
+        this.matchers.addAll(matchers);
+    }
+
+    @Override
+    public boolean test(Map<String, String> labels) {
+        return this.matchers.stream().allMatch(m -> m.test(labels.get(m.getKey())));
+    }
+
+    public static LabelSelectorMatcher parse(String clause) throws IllegalArgumentException {
+        Collection<Function<String, LabelMatcher>> parsers =
+                Arrays.asList(
+                        LabelSelectorMatcher::parseEqualities,
+                        LabelSelectorMatcher::parseSetMemberships,
+                        LabelSelectorMatcher::parseSetExistences);
+        for (var parser : parsers) {
+            LabelMatcher matcher = parser.apply(clause);
+            if (matcher != null) {
+                return new LabelSelectorMatcher(List.of(matcher));
+            }
+        }
+        return new LabelSelectorMatcher();
+    }
+
+    private static LabelMatcher parseEqualities(String clause) {
+        Matcher m = EQUALITY_PATTERN.matcher(clause);
+        if (!m.matches()) {
+            return null;
+        }
+        String key = m.group("key");
+        String op = m.group("op");
+        EqualityMatcher.Operator operator = EqualityMatcher.Operator.fromString(op);
+        Objects.requireNonNull(operator, "Unknown equality operator " + op);
+        String value = m.group("value");
+        return new EqualityMatcher(key, operator, value);
+    }
+
+    private static LabelMatcher parseSetMemberships(String clause) {
+        Matcher m = SET_MEMBER_PATTERN.matcher(clause);
+        if (!m.matches()) {
+            return null;
+        }
+        String key = m.group("key");
+        String op = m.group("op");
+        SetMatcher.Operator operator = SetMatcher.Operator.fromString(op);
+        Objects.requireNonNull(operator, "Unknown set operator " + op);
+        String value = m.group("values");
+        List<String> values =
+                Arrays.asList(value.split(",")).stream()
+                        .map(String::trim)
+                        .collect(Collectors.toList());
+        return new SetMatcher(key, operator, values);
+    }
+
+    private static LabelMatcher parseSetExistences(String clause) {
+        Matcher m = SET_EXISTENCE_PATTERN.matcher(clause);
+        if (!m.matches()) {
+            return null;
+        }
+        String key = m.group("key");
+        String op = m.group("op");
+        SetMatcher.Operator operator = SetMatcher.Operator.fromString(op);
+        Objects.requireNonNull(operator, "Unknown set operator " + op);
+        return new SetMatcher(key, operator);
+    }
+}

--- a/src/main/java/io/cryostat/graphql/matchers/SetMatcher.java
+++ b/src/main/java/io/cryostat/graphql/matchers/SetMatcher.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright The Cryostat Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.cryostat.graphql.matchers;
+
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.function.Predicate;
+
+public class SetMatcher implements LabelMatcher {
+
+    private final SetMatcher.Operator operator;
+    private final String key;
+    private final Set<String> values;
+
+    SetMatcher(String key, SetMatcher.Operator operator) {
+        this(key, operator, Set.of());
+    }
+
+    SetMatcher(String key, SetMatcher.Operator operator, Collection<String> values) {
+        this.key = key;
+        this.operator = operator;
+        this.values = new HashSet<>(values);
+    }
+
+    @Override
+    public String getKey() {
+        return key;
+    }
+
+    @Override
+    public boolean test(String s) {
+        return operator.with(values).test(s);
+    }
+
+    public enum Operator {
+        IN("In", args -> v -> contains(args, v)),
+        NOT_IN("NotIn", args -> v -> !contains(args, v)),
+        EXISTS("", args -> v -> v != null),
+        DOES_NOT_EXIST("!", args -> v -> v == null),
+        ;
+
+        private final String token;
+        private final Function<Collection<String>, Predicate<String>> fn;
+
+        Operator(String token, Function<Collection<String>, Predicate<String>> fn) {
+            this.token = token;
+            this.fn = fn;
+        }
+
+        Predicate<String> with(Collection<String> values) {
+            return fn.apply(values);
+        }
+
+        public static Operator fromString(String str) {
+            for (Operator op : Operator.values()) {
+                if (op.token.equalsIgnoreCase(str)) {
+                    return op;
+                }
+            }
+            return null;
+        }
+
+        private static boolean contains(Collection<String> args, String v) {
+            return args.stream().anyMatch(s -> s.equals(v));
+        }
+    }
+}

--- a/src/main/java/io/cryostat/recordings/ActiveRecording.java
+++ b/src/main/java/io/cryostat/recordings/ActiveRecording.java
@@ -141,6 +141,10 @@ public class ActiveRecording extends PanacheEntity {
         return find("name", name).singleResult();
     }
 
+    public void setMetadata(Metadata metadata) {
+        this.metadata = metadata;
+    }
+
     @Transactional
     public static boolean deleteFromTarget(Target target, String recordingName) {
         Optional<ActiveRecording> recording =
@@ -282,16 +286,19 @@ public class ActiveRecording extends PanacheEntity {
                 Objects.requireNonNull(payload);
             }
 
-            public record Payload(String target, LinkedRecordingDescriptor recording) {
+            public record Payload(
+                    String target, LinkedRecordingDescriptor recording, String jvmId) {
                 public Payload {
                     Objects.requireNonNull(target);
                     Objects.requireNonNull(recording);
+                    Objects.requireNonNull(jvmId);
                 }
 
                 public static Payload of(RecordingHelper helper, ActiveRecording recording) {
                     return new Payload(
                             recording.target.connectUrl.toString(),
-                            helper.toExternalForm(recording));
+                            helper.toExternalForm(recording),
+                            recording.target.jvmId);
                 }
             }
         }

--- a/src/main/java/io/cryostat/recordings/RecordingHelper.java
+++ b/src/main/java/io/cryostat/recordings/RecordingHelper.java
@@ -278,7 +278,7 @@ public class RecordingHelper {
                             String.format("%s-%d", desc.getName().toLowerCase(), desc.getId());
 
                     RecordingOptionsBuilder recordingOptionsBuilder =
-                            recordingOptionsBuilderFactory.create(target);
+                            recordingOptionsBuilderFactory.create(target).name(rename);
 
                     connection
                             .getService()

--- a/src/main/java/io/cryostat/recordings/Recordings.java
+++ b/src/main/java/io/cryostat/recordings/Recordings.java
@@ -222,6 +222,7 @@ public class Recordings {
                         ArchivedRecordingEvent.Payload.of(
                                 target.map(t -> t.connectUrl).orElse(null),
                                 new ArchivedRecording(
+                                        jvmId,
                                         recording.fileName(),
                                         recordingHelper.downloadUrl(jvmId, recording.fileName()),
                                         recordingHelper.reportUrl(jvmId, recording.fileName()),
@@ -275,6 +276,7 @@ public class Recordings {
                                             .orElseGet(Metadata::empty);
                             result.add(
                                     new ArchivedRecording(
+                                            jvmId,
                                             filename,
                                             recordingHelper.downloadUrl(jvmId, filename),
                                             recordingHelper.reportUrl(jvmId, filename),
@@ -338,6 +340,7 @@ public class Recordings {
                         ArchivedRecordingEvent.Payload.of(
                                 target.map(t -> t.connectUrl).orElse(null),
                                 new ArchivedRecording(
+                                        jvmId,
                                         filename,
                                         recordingHelper.downloadUrl(jvmId, filename),
                                         recordingHelper.reportUrl(jvmId, filename),
@@ -395,6 +398,7 @@ public class Recordings {
                                                             connectUrl, id, new ArrayList<>()));
                             dir.recordings.add(
                                     new ArchivedRecording(
+                                            jvmId,
                                             filename,
                                             recordingHelper.downloadUrl(jvmId, filename),
                                             recordingHelper.reportUrl(jvmId, filename),
@@ -432,6 +436,7 @@ public class Recordings {
                                                             connectUrl, id, new ArrayList<>()));
                             dir.recordings.add(
                                     new ArchivedRecording(
+                                            jvmId,
                                             filename,
                                             recordingHelper.downloadUrl(jvmId, filename),
                                             recordingHelper.reportUrl(jvmId, filename),
@@ -768,6 +773,7 @@ public class Recordings {
                             ArchivedRecordingEvent.Payload.of(
                                     URI.create(connectUrl),
                                     new ArchivedRecording(
+                                            jvmId,
                                             filename,
                                             recordingHelper.downloadUrl(jvmId, filename),
                                             recordingHelper.reportUrl(jvmId, filename),
@@ -1127,6 +1133,7 @@ public class Recordings {
 
     // TODO include jvmId and filename
     public record ArchivedRecording(
+            String jvmId,
             String name,
             String downloadUrl,
             String reportUrl,
@@ -1134,6 +1141,7 @@ public class Recordings {
             long size,
             long archivedTime) {
         public ArchivedRecording {
+            Objects.requireNonNull(jvmId);
             Objects.requireNonNull(name);
             Objects.requireNonNull(downloadUrl);
             Objects.requireNonNull(reportUrl);
@@ -1183,6 +1191,7 @@ public class Recordings {
     public static final String ACTIVE_RECORDING_DELETED = "ActiveRecordingDeleted";
     public static final String ACTIVE_RECORDING_SAVED = "ActiveRecordingSaved";
     public static final String SNAPSHOT_RECORDING_CREATED = "SnapshotCreated";
+    public static final String RECORDING_METADATA_UPDATED = "RecordingMetadataUpdated";
 
     public enum RecordingEventCategory {
         ACTIVE_CREATED(ACTIVE_RECORDING_CREATED),
@@ -1192,6 +1201,7 @@ public class Recordings {
         ARCHIVED_CREATED(ARCHIVED_RECORDING_CREATED),
         ARCHIVED_DELETED(ARCHIVED_RECORDING_DELETED),
         SNAPSHOT_CREATED(SNAPSHOT_RECORDING_CREATED),
+        METADATA_UPDATED(RECORDING_METADATA_UPDATED),
         ;
 
         private final String category;

--- a/src/main/java/io/cryostat/recordings/Recordings.java
+++ b/src/main/java/io/cryostat/recordings/Recordings.java
@@ -833,10 +833,25 @@ public class Recordings {
     }
 
     @POST
+    @Path("/api/beta/recordings/{connectUrl}/{filename}/upload")
+    @RolesAllowed("write")
+    public Response uploadArchivedToGrafanaBeta(
+            @RestPath String connectUrl, @RestPath String filename) throws Exception {
+        var jvmId = Target.getTargetByConnectUrl(URI.create(connectUrl)).jvmId;
+        return Response.status(RestResponse.Status.PERMANENT_REDIRECT)
+                .location(
+                        URI.create(
+                                String.format(
+                                        "/api/v3/grafana/%s",
+                                        recordingHelper.encodedKey(jvmId, filename))))
+                .build();
+    }
+
+    @POST
     @Path("/api/beta/fs/recordings/{jvmId}/{filename}/upload")
     @RolesAllowed("write")
-    public Response uploadArchivedToGrafanaBeta(@RestPath String jvmId, @RestPath String filename)
-            throws Exception {
+    public Response uploadArchivedToGrafanaFromPath(
+            @RestPath String jvmId, @RestPath String filename) throws Exception {
         return Response.status(RestResponse.Status.PERMANENT_REDIRECT)
                 .location(
                         URI.create(

--- a/src/main/java/io/cryostat/recordings/Recordings.java
+++ b/src/main/java/io/cryostat/recordings/Recordings.java
@@ -52,6 +52,7 @@ import io.cryostat.core.sys.Clock;
 import io.cryostat.core.templates.Template;
 import io.cryostat.core.templates.TemplateType;
 import io.cryostat.recordings.ActiveRecording.Listener.ArchivedRecordingEvent;
+import io.cryostat.recordings.RecordingHelper.RecordingOptions;
 import io.cryostat.recordings.RecordingHelper.RecordingReplace;
 import io.cryostat.recordings.RecordingHelper.SnapshotCreationException;
 import io.cryostat.targets.Target;
@@ -156,29 +157,7 @@ public class Recordings {
     @Path("/api/v1/recordings")
     @RolesAllowed("read")
     public List<ArchivedRecording> listArchivesV1() {
-        var result = new ArrayList<ArchivedRecording>();
-        recordingHelper
-                .listArchivedRecordingObjects()
-                .forEach(
-                        item -> {
-                            String path = item.key().strip();
-                            String[] parts = path.split("/");
-                            String jvmId = parts[0];
-                            String filename = parts[1];
-                            Metadata metadata =
-                                    recordingHelper
-                                            .getArchivedRecordingMetadata(jvmId, filename)
-                                            .orElseGet(Metadata::empty);
-                            result.add(
-                                    new ArchivedRecording(
-                                            filename,
-                                            recordingHelper.downloadUrl(jvmId, filename),
-                                            recordingHelper.reportUrl(jvmId, filename),
-                                            metadata,
-                                            item.size(),
-                                            item.lastModified().getEpochSecond()));
-                        });
-        return result;
+        return recordingHelper.listArchivedRecordings();
     }
 
     @POST
@@ -510,9 +489,8 @@ public class Recordings {
     @RolesAllowed("write")
     public Uni<Response> createSnapshotV1(@RestPath URI connectUrl) throws Exception {
         Target target = Target.getTargetByConnectUrl(connectUrl);
-        return connectionManager
-                .executeConnectedTaskUni(
-                        target, connection -> recordingHelper.createSnapshot(target, connection))
+        return recordingHelper
+                .createSnapshot(target)
                 .onItem()
                 .transform(
                         recording ->
@@ -527,9 +505,8 @@ public class Recordings {
     @RolesAllowed("write")
     public Uni<Response> createSnapshotV2(@RestPath URI connectUrl) throws Exception {
         Target target = Target.getTargetByConnectUrl(connectUrl);
-        return connectionManager
-                .executeConnectedTaskUni(
-                        target, connection -> recordingHelper.createSnapshot(target, connection))
+        return recordingHelper
+                .createSnapshot(target)
                 .onItem()
                 .transform(
                         recording ->
@@ -552,9 +529,8 @@ public class Recordings {
     @RolesAllowed("write")
     public Uni<Response> createSnapshot(@RestPath long id) throws Exception {
         Target target = Target.find("id", id).singleResult();
-        return connectionManager
-                .executeConnectedTaskUni(
-                        target, connection -> recordingHelper.createSnapshot(target, connection))
+        return recordingHelper
+                .createSnapshot(target)
                 .onItem()
                 .transform(
                         recording ->
@@ -598,50 +574,32 @@ public class Recordings {
         Template template =
                 recordingHelper.getPreferredTemplate(target, pair.getKey(), pair.getValue());
 
+        Map<String, String> labels = new HashMap<>();
+        if (rawMetadata.isPresent()) {
+            labels.putAll(mapper.readValue(rawMetadata.get(), Metadata.class).labels);
+        }
+        RecordingReplace replacement = RecordingReplace.NEVER;
+        if (replace.isPresent()) {
+            replacement = RecordingReplace.fromString(replace.get());
+        } else if (restart.isPresent()) {
+            replacement = restart.get() ? RecordingReplace.ALWAYS : RecordingReplace.NEVER;
+        }
         ActiveRecording recording =
-                connectionManager.executeConnectedTask(
-                        target,
-                        connection -> {
-                            RecordingOptionsBuilder optionsBuilder =
-                                    recordingOptionsBuilderFactory
-                                            .create(connection.getService())
-                                            .name(recordingName);
-                            if (duration.isPresent()) {
-                                optionsBuilder.duration(TimeUnit.SECONDS.toMillis(duration.get()));
-                            }
-                            if (toDisk.isPresent()) {
-                                optionsBuilder.toDisk(toDisk.get());
-                            }
-                            if (maxAge.isPresent()) {
-                                optionsBuilder.maxAge(maxAge.get());
-                            }
-                            if (maxSize.isPresent()) {
-                                optionsBuilder.maxSize(maxSize.get());
-                            }
-                            Map<String, String> labels = new HashMap<>();
-                            if (rawMetadata.isPresent()) {
-                                labels.putAll(
-                                        mapper.readValue(rawMetadata.get(), Metadata.class).labels);
-                            }
-                            RecordingReplace replacement = RecordingReplace.NEVER;
-                            if (replace.isPresent()) {
-                                replacement = RecordingReplace.fromString(replace.get());
-                            } else if (restart.isPresent()) {
-                                replacement =
-                                        restart.get()
-                                                ? RecordingReplace.ALWAYS
-                                                : RecordingReplace.NEVER;
-                            }
-                            IConstrainedMap<String> recordingOptions = optionsBuilder.build();
-                            return recordingHelper.startRecording(
-                                    target,
-                                    recordingOptions,
-                                    template,
-                                    new Metadata(labels),
-                                    archiveOnStop.orElse(false),
-                                    replacement,
-                                    connection);
-                        });
+                recordingHelper
+                        .startRecording(
+                                target,
+                                replacement,
+                                template,
+                                new RecordingOptions(
+                                        recordingName,
+                                        toDisk,
+                                        archiveOnStop,
+                                        duration,
+                                        maxSize,
+                                        maxAge),
+                                labels)
+                        .await()
+                        .atMost(Duration.ofSeconds(10));
 
         if (recording.duration > 0) {
             scheduler.schedule(

--- a/src/main/java/io/cryostat/rules/RuleService.java
+++ b/src/main/java/io/cryostat/rules/RuleService.java
@@ -15,32 +15,25 @@
  */
 package io.cryostat.rules;
 
-import java.io.IOException;
+import java.time.Duration;
 import java.util.Date;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import org.openjdk.jmc.common.unit.IConstrainedMap;
-import org.openjdk.jmc.common.unit.QuantityConversionException;
-import org.openjdk.jmc.flightrecorder.configuration.recording.RecordingOptionsBuilder;
-import org.openjdk.jmc.rjmx.ConnectionException;
-import org.openjdk.jmc.rjmx.ServiceNotAvailableException;
-
-import io.cryostat.core.net.JFRConnection;
 import io.cryostat.core.templates.Template;
 import io.cryostat.core.templates.TemplateType;
 import io.cryostat.expressions.MatchExpressionEvaluator;
 import io.cryostat.recordings.ActiveRecording;
 import io.cryostat.recordings.RecordingHelper;
+import io.cryostat.recordings.RecordingHelper.RecordingOptions;
 import io.cryostat.recordings.RecordingHelper.RecordingReplace;
 import io.cryostat.recordings.RecordingOptionsBuilderFactory;
-import io.cryostat.recordings.Recordings.Metadata;
 import io.cryostat.rules.Rule.RuleEvent;
 import io.cryostat.targets.Target;
 import io.cryostat.targets.TargetConnectionManager;
@@ -139,30 +132,22 @@ public class RuleService {
 
     @Transactional
     public void activate(Rule rule, Target target) throws Exception {
+        var options = createRecordingOptions(rule);
+
+        Pair<String, TemplateType> pair = recordingHelper.parseEventSpecifier(rule.eventSpecifier);
+        Template template =
+                recordingHelper.getPreferredTemplate(target, pair.getKey(), pair.getValue());
+
         ActiveRecording recording =
-                connectionManager.executeConnectedTask(
-                        target,
-                        connection -> {
-                            var recordingOptions = createRecordingOptions(rule, connection);
-
-                            Pair<String, TemplateType> pair =
-                                    recordingHelper.parseEventSpecifier(rule.eventSpecifier);
-                            Template template =
-                                    recordingHelper.getPreferredTemplate(
-                                            target, pair.getKey(), pair.getValue());
-
-                            Map<String, String> labels = new HashMap<>();
-                            labels.put("rule", rule.name);
-                            Metadata meta = new Metadata(labels);
-                            return recordingHelper.startRecording(
-                                    target,
-                                    recordingOptions,
-                                    template,
-                                    meta,
-                                    false,
-                                    RecordingReplace.ALWAYS,
-                                    connection);
-                        });
+                recordingHelper
+                        .startRecording(
+                                target,
+                                RecordingReplace.STOPPED,
+                                template,
+                                options,
+                                Map.of("rule", rule.name))
+                        .await()
+                        .atMost(Duration.ofSeconds(10));
         Target attachedTarget = entityManager.merge(target);
 
         var relatedRecordings = ruleRecordingMap.get(rule.id);
@@ -173,22 +158,14 @@ public class RuleService {
         }
     }
 
-    private IConstrainedMap<String> createRecordingOptions(Rule rule, JFRConnection connection)
-            throws ConnectionException,
-                    QuantityConversionException,
-                    IOException,
-                    ServiceNotAvailableException {
-        RecordingOptionsBuilder optionsBuilder =
-                recordingOptionsBuilderFactory
-                        .create(connection.getService())
-                        .name(rule.getRecordingName());
-        if (rule.maxAgeSeconds > 0) {
-            optionsBuilder.maxAge(rule.maxAgeSeconds);
-        }
-        if (rule.maxSizeBytes > 0) {
-            optionsBuilder.maxSize(rule.maxSizeBytes);
-        }
-        return optionsBuilder.build();
+    private RecordingOptions createRecordingOptions(Rule rule) {
+        return new RecordingOptions(
+                rule.getRecordingName(),
+                Optional.of(true),
+                Optional.of(true),
+                Optional.empty(),
+                Optional.ofNullable((long) rule.maxSizeBytes),
+                Optional.ofNullable((long) rule.maxAgeSeconds));
     }
 
     @Transactional

--- a/src/main/java/io/cryostat/rules/ScheduledArchiveJob.java
+++ b/src/main/java/io/cryostat/rules/ScheduledArchiveJob.java
@@ -92,7 +92,7 @@ class ScheduledArchiveJob implements Job {
     @Transactional
     void performArchival(ActiveRecording recording, Queue<String> previousRecordings)
             throws Exception {
-        String filename = recordingHelper.saveRecording(recording);
+        String filename = recordingHelper.archiveRecording(recording, null, null).name();
         previousRecordings.add(filename);
     }
 

--- a/src/main/java/io/cryostat/targets/Target.java
+++ b/src/main/java/io/cryostat/targets/Target.java
@@ -188,10 +188,11 @@ public class Target extends PanacheEntity {
     }
 
     @SuppressFBWarnings(value = {"EI_EXPOSE_REP", "EI_EXPOSE_REP2"})
-    public record TargetDiscovery(EventKind kind, Target serviceRef) {
+    public record TargetDiscovery(EventKind kind, Target serviceRef, String jvmId) {
         public TargetDiscovery {
             Objects.requireNonNull(kind);
             Objects.requireNonNull(serviceRef);
+            Objects.requireNonNull(jvmId);
         }
     }
 
@@ -275,13 +276,18 @@ public class Target extends PanacheEntity {
                     MessagingServer.class.getName(),
                     new Notification(
                             TARGET_JVM_DISCOVERY,
-                            new TargetDiscoveryEvent(new TargetDiscovery(eventKind, target))));
-            bus.publish(TARGET_JVM_DISCOVERY, new TargetDiscovery(eventKind, target));
+                            new TargetDiscoveryEvent(
+                                    new TargetDiscovery(eventKind, target, target.jvmId))));
+            bus.publish(TARGET_JVM_DISCOVERY, new TargetDiscovery(eventKind, target, target.jvmId));
         }
 
         public record TargetDiscoveryEvent(TargetDiscovery event) {
             public TargetDiscoveryEvent {
                 Objects.requireNonNull(event);
+            }
+
+            public String jvmId() {
+                return event.serviceRef().jvmId;
             }
         }
     }

--- a/src/main/java/io/cryostat/targets/Target.java
+++ b/src/main/java/io/cryostat/targets/Target.java
@@ -147,6 +147,13 @@ public class Target extends PanacheEntity {
         public Annotations() {
             this(new HashMap<>(), new HashMap<>());
         }
+
+        public Map<String, String> merged() {
+            Map<String, String> merged = new HashMap<>();
+            cryostat().entrySet().forEach((e) -> merged.put(e.getKey(), e.getValue()));
+            merged.putAll(platform());
+            return merged;
+        }
     }
 
     @Override

--- a/src/main/java/io/cryostat/ws/MessagingServer.java
+++ b/src/main/java/io/cryostat/ws/MessagingServer.java
@@ -47,11 +47,11 @@ public class MessagingServer {
 
     private static final String CLIENT_ACTIVITY_CATEGORY = "WsClientActivity";
 
+    @Inject ObjectMapper mapper;
     @Inject Logger logger;
     private final ExecutorService executor = Executors.newSingleThreadExecutor();
     private final BlockingQueue<Notification> msgQ;
     private final Set<Session> sessions = new CopyOnWriteArraySet<>();
-    private final ObjectMapper mapper = new ObjectMapper();
 
     MessagingServer(@ConfigProperty(name = "cryostat.messaging.queue.size") int capacity) {
         this.msgQ = new ArrayBlockingQueue<>(capacity);

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -52,6 +52,9 @@ quarkus.smallrye-openapi.info-contact-url=https://cryostat.io
 quarkus.smallrye-openapi.info-license-name=Apache 2.0
 quarkus.smallrye-openapi.info-license-url=https://github.com/cryostatio/cryostat3/blob/main/LICENSE
 
+quarkus.smallrye-graphql.root-path=/api/v3/graphql
+quarkus.smallrye-graphql.http.get.enabled=true
+
 quarkus.http.access-log.enabled=true
 quarkus.log.category."io.quarkus.http.access-log".level=DEBUG
 quarkus.http.enable-compression=true

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -52,6 +52,7 @@ quarkus.smallrye-openapi.info-contact-url=https://cryostat.io
 quarkus.smallrye-openapi.info-license-name=Apache 2.0
 quarkus.smallrye-openapi.info-license-url=https://github.com/cryostatio/cryostat3/blob/main/LICENSE
 
+quarkus.smallrye-graphql.events.enabled=true
 quarkus.smallrye-graphql.root-path=/api/v3/graphql
 quarkus.smallrye-graphql.http.get.enabled=true
 quarkus.smallrye-graphql.print-data-fetcher-exception=true

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -54,6 +54,8 @@ quarkus.smallrye-openapi.info-license-url=https://github.com/cryostatio/cryostat
 
 quarkus.smallrye-graphql.root-path=/api/v3/graphql
 quarkus.smallrye-graphql.http.get.enabled=true
+quarkus.smallrye-graphql.print-data-fetcher-exception=true
+quarkus.smallrye-graphql.log-payload=queryOnly
 
 quarkus.http.access-log.enabled=true
 quarkus.log.category."io.quarkus.http.access-log".level=DEBUG

--- a/src/test/java/itest/CustomTargetsTest.java
+++ b/src/test/java/itest/CustomTargetsTest.java
@@ -16,6 +16,7 @@
 package itest;
 
 import java.net.UnknownHostException;
+import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.CountDownLatch;
@@ -224,16 +225,21 @@ public class CustomTargetsTest extends StandardSelfTest {
         MatcherAssert.assertThat(item.getString("jvmId"), Matchers.equalTo(itestJvmId));
         MatcherAssert.assertThat(item.getString("alias"), Matchers.equalTo(alias));
         MatcherAssert.assertThat(item.getString("connectUrl"), Matchers.equalTo(SELF_JMX_URL));
-        MatcherAssert.assertThat(item.getJsonObject("labels"), Matchers.equalTo(new JsonObject()));
+        MatcherAssert.assertThat(item.getJsonArray("labels"), Matchers.equalTo(new JsonArray()));
         MatcherAssert.assertThat(
                 item.getJsonObject("annotations"),
                 Matchers.equalTo(
                         new JsonObject(
                                 Map.of(
                                         "platform",
-                                        Map.of(),
+                                        List.of(),
                                         "cryostat",
-                                        Map.of("REALM", "Custom Targets")))));
+                                        List.of(
+                                                Map.of(
+                                                        "key",
+                                                        "REALM",
+                                                        "value",
+                                                        "Custom Targets"))))));
     }
 
     @Test

--- a/src/test/java/itest/GraphQLTest.java
+++ b/src/test/java/itest/GraphQLTest.java
@@ -1,0 +1,2125 @@
+/*
+ * Copyright The Cryostat Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package itest;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.is;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.ForkJoinPool;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+
+import io.cryostat.util.HttpMimeType;
+
+import io.vertx.core.MultiMap;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.core.http.HttpHeaders;
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+import io.vertx.ext.web.client.HttpResponse;
+import itest.bases.StandardSelfTest;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.MethodOrderer.OrderAnnotation;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+@TestMethodOrder(OrderAnnotation.class)
+@Disabled("TODO not all GraphQL queries are implemented")
+class GraphQLTest extends StandardSelfTest {
+
+    private final ExecutorService worker = ForkJoinPool.commonPool();
+
+    static final String TEST_RECORDING_NAME = "archivedRecording";
+
+    @Test
+    @Order(0)
+    void testEnvironmentNodeListing() throws Exception {
+        JsonObject query = new JsonObject();
+        query.put(
+                "query",
+                "query { environmentNodes(filter: { name: \"Custom Targets\" }) { name nodeType"
+                        + " descendantTargets { name nodeType } } }");
+        HttpResponse<Buffer> resp =
+                webClient
+                        .extensions()
+                        .post("/api/v2.2/graphql", query.toBuffer(), REQUEST_TIMEOUT_SECONDS);
+        MatcherAssert.assertThat(
+                resp.statusCode(),
+                Matchers.both(Matchers.greaterThanOrEqualTo(200)).and(Matchers.lessThan(300)));
+        EnvironmentNodesResponse actual =
+                mapper.readValue(resp.bodyAsString(), EnvironmentNodesResponse.class);
+
+        EnvironmentNodes expected = new EnvironmentNodes();
+
+        EnvironmentNode jdp = new EnvironmentNode();
+        jdp.name = "JDP";
+        jdp.nodeType = "Realm";
+
+        jdp.descendantTargets = new ArrayList<>();
+        Node cryostat = new Node();
+        cryostat.name = "service:jmx:rmi:///jndi/rmi://localhost:0/jmxrmi";
+        cryostat.nodeType = "JVM";
+        jdp.descendantTargets.add(cryostat);
+
+        Node target = new Node();
+        target.name = "service:jmx:rmi:///jndi/rmi://localhost:0/jmxrmi";
+        target.nodeType = "JVM";
+        jdp.descendantTargets.add(target);
+
+        expected.environmentNodes = List.of(jdp);
+
+        MatcherAssert.assertThat(actual.data, Matchers.equalTo(expected));
+    }
+
+    @Test
+    @Order(1)
+    void testOtherContainersFound() throws Exception {
+        JsonObject query = new JsonObject();
+        query.put(
+                "query",
+                "query { targetNodes { name nodeType labels target { alias connectUrl annotations {"
+                        + " cryostat platform } } } }");
+        HttpResponse<Buffer> resp =
+                webClient
+                        .extensions()
+                        .post("/api/v2.2/graphql", query.toBuffer(), REQUEST_TIMEOUT_SECONDS);
+        MatcherAssert.assertThat(
+                resp.statusCode(),
+                Matchers.both(Matchers.greaterThanOrEqualTo(200)).and(Matchers.lessThan(300)));
+
+        TargetNodesQueryResponse actual =
+                mapper.readValue(resp.bodyAsString(), TargetNodesQueryResponse.class);
+        MatcherAssert.assertThat(actual.data.targetNodes, Matchers.hasSize(1));
+
+        TargetNode cryostat = new TargetNode();
+        Target cryostatTarget = new Target();
+        cryostatTarget.alias = "io.cryostat.Cryostat";
+        cryostatTarget.connectUrl = "service:jmx:rmi:///jndi/rmi://localhost:0/jmxrmi";
+        cryostat.name = cryostatTarget.connectUrl;
+        cryostat.target = cryostatTarget;
+        cryostat.nodeType = "JVM";
+        Annotations cryostatAnnotations = new Annotations();
+        cryostatAnnotations.cryostat =
+                Map.of(
+                        "REALM",
+                        "JDP",
+                        "JAVA_MAIN",
+                        "io.cryostat.Cryostat",
+                        "HOST",
+                        "localhost",
+                        "PORT",
+                        "0");
+        cryostatAnnotations.platform = Map.of();
+        cryostatTarget.annotations = cryostatAnnotations;
+        cryostat.labels = Map.of();
+        MatcherAssert.assertThat(actual.data.targetNodes, Matchers.hasItem(cryostat));
+
+        String uri = "service:jmx:rmi:///jndi/rmi://localhost:0/jmxrmi";
+        String mainClass = "es.andrewazor.demo.Main";
+        TargetNode ext = new TargetNode();
+        Target target = new Target();
+        target.alias = mainClass;
+        target.connectUrl = uri;
+        ext.name = target.connectUrl;
+        ext.target = target;
+        ext.nodeType = "JVM";
+        Annotations annotations = new Annotations();
+        annotations.cryostat =
+                Map.of("REALM", "JDP", "JAVA_MAIN", mainClass, "HOST", "localhost", "PORT", "0");
+        annotations.platform = Map.of();
+        target.annotations = annotations;
+        ext.labels = Map.of();
+        MatcherAssert.assertThat(actual.data.targetNodes, Matchers.hasItem(ext));
+    }
+
+    @Test
+    @Order(2)
+    void testQueryForSpecificTargetWithSpecificFields() throws Exception {
+        JsonObject query = new JsonObject();
+        query.put(
+                "query",
+                "query { targetNodes(filter: { annotations: \"PORT == 0\" }) { name nodeType }"
+                        + " }");
+        HttpResponse<Buffer> resp =
+                webClient
+                        .extensions()
+                        .post("/api/v2.2/graphql", query.toBuffer(), REQUEST_TIMEOUT_SECONDS);
+        MatcherAssert.assertThat(
+                resp.statusCode(),
+                Matchers.both(Matchers.greaterThanOrEqualTo(200)).and(Matchers.lessThan(300)));
+
+        TargetNodesQueryResponse actual =
+                mapper.readValue(resp.bodyAsString(), TargetNodesQueryResponse.class);
+        MatcherAssert.assertThat(actual.data.targetNodes, Matchers.hasSize(1));
+
+        String uri = "service:jmx:rmi:///jndi/rmi://localhost:0/jmxrmi";
+        TargetNode ext = new TargetNode();
+        ext.name = uri;
+        ext.nodeType = "JVM";
+        MatcherAssert.assertThat(actual.data.targetNodes, Matchers.hasItem(ext));
+    }
+
+    @Test
+    @Order(3)
+    void testStartRecordingMutationOnSpecificTarget() throws Exception {
+        CountDownLatch latch = new CountDownLatch(2);
+        JsonObject query = new JsonObject();
+        query.put(
+                "query",
+                "query { targetNodes(filter: { annotations: \"PORT == 0\" }) {"
+                    + " doStartRecording(recording: { name: \"graphql-itest\", duration: 30,"
+                    + " template: \"Profiling\", templateType: \"TARGET\", archiveOnStop: true,"
+                    + " metadata: { labels: [ { key: \"newLabel\", value: \"someValue\"} ] }  }) {"
+                    + " name state duration archiveOnStop }} }");
+        Map<String, String> expectedLabels =
+                Map.of(
+                        "template.name",
+                        "Profiling",
+                        "template.type",
+                        "TARGET",
+                        "newLabel",
+                        "someValue");
+        Future<JsonObject> f =
+                worker.submit(
+                        () -> {
+                            try {
+                                return expectNotification(
+                                                "ActiveRecordingCreated", 15, TimeUnit.SECONDS)
+                                        .get();
+                            } catch (Exception e) {
+                                throw new RuntimeException(e);
+                            } finally {
+                                latch.countDown();
+                            }
+                        });
+
+        Thread.sleep(5000); // Sleep to setup notification listening before query resolves
+
+        HttpResponse<Buffer> resp =
+                webClient
+                        .extensions()
+                        .post("/api/v2.2/graphql", query.toBuffer(), REQUEST_TIMEOUT_SECONDS);
+        MatcherAssert.assertThat(
+                resp.statusCode(),
+                Matchers.both(Matchers.greaterThanOrEqualTo(200)).and(Matchers.lessThan(300)));
+
+        StartRecordingMutationResponse actual =
+                mapper.readValue(resp.bodyAsString(), StartRecordingMutationResponse.class);
+
+        latch.await(30, TimeUnit.SECONDS);
+
+        // Ensure ActiveRecordingCreated notification emitted matches expected values
+        JsonObject notification = f.get(5, TimeUnit.SECONDS);
+
+        JsonObject notificationRecording =
+                notification.getJsonObject("message").getJsonObject("recording");
+        MatcherAssert.assertThat(
+                notificationRecording.getString("name"), Matchers.equalTo("graphql-itest"));
+        MatcherAssert.assertThat(
+                notificationRecording.getString("archiveOnStop"), Matchers.equalTo("true"));
+        MatcherAssert.assertThat(
+                notification.getJsonObject("message").getString("target"),
+                Matchers.equalTo(
+                        String.format(
+                                "service:jmx:rmi:///jndi/rmi://%s:%d/jmxrmi", "localhost", 0)));
+        Map<String, Object> notificationLabels =
+                notificationRecording.getJsonObject("metadata").getJsonObject("labels").getMap();
+        for (var entry : expectedLabels.entrySet()) {
+            MatcherAssert.assertThat(
+                    notificationLabels, Matchers.hasEntry(entry.getKey(), entry.getValue()));
+        }
+
+        RecordingNodes nodes = new RecordingNodes();
+
+        ActiveRecording recording = new ActiveRecording();
+        recording.name = "graphql-itest";
+        recording.duration = 30_000L;
+        recording.state = "RUNNING";
+        recording.archiveOnStop = true;
+        recording.metadata = RecordingMetadata.of(expectedLabels);
+
+        StartRecording startRecording = new StartRecording();
+        startRecording.doStartRecording = recording;
+
+        nodes.targetNodes = List.of(startRecording);
+
+        MatcherAssert.assertThat(actual.data, Matchers.equalTo(nodes));
+    }
+
+    @Test
+    @Order(4)
+    void testArchiveMutation() throws Exception {
+        Thread.sleep(5000);
+        JsonObject query = new JsonObject();
+        query.put(
+                "query",
+                "query { targetNodes(filter: { annotations: \"PORT == 0\" }) { recordings {"
+                        + " active { data { name doArchive { name } } } } } }");
+        HttpResponse<Buffer> resp =
+                webClient
+                        .extensions()
+                        .post("/api/v2.2/graphql", query.toBuffer(), REQUEST_TIMEOUT_SECONDS);
+        MatcherAssert.assertThat(
+                resp.statusCode(),
+                Matchers.both(Matchers.greaterThanOrEqualTo(200)).and(Matchers.lessThan(300)));
+
+        ArchiveMutationResponse actual =
+                mapper.readValue(resp.bodyAsString(), ArchiveMutationResponse.class);
+
+        MatcherAssert.assertThat(actual.data.targetNodes, Matchers.hasSize(1));
+
+        TargetNode node = actual.data.targetNodes.get(0);
+
+        MatcherAssert.assertThat(node.recordings.active.data, Matchers.hasSize(1));
+
+        ActiveRecording activeRecording = node.recordings.active.data.get(0);
+
+        MatcherAssert.assertThat(activeRecording.name, Matchers.equalTo("graphql-itest"));
+
+        ArchivedRecording archivedRecording = activeRecording.doArchive;
+        MatcherAssert.assertThat(
+                archivedRecording.name,
+                Matchers.matchesRegex(
+                        "^es-andrewazor-demo-Main_graphql-itest_[0-9]{8}T[0-9]{6}Z\\.jfr$"));
+    }
+
+    @Test
+    @Order(5)
+    void testActiveRecordingMetadataMutation() throws Exception {
+        JsonObject query = new JsonObject();
+        query.put(
+                "query",
+                "query { targetNodes(filter: { annotations: \"PORT == 9093\" }) {"
+                        + "recordings { active {"
+                        + " data {"
+                        + " doPutMetadata(metadata: { labels: ["
+                        + " {key:\"template.name\",value:\"Profiling\"},"
+                        + " {key:\"template.type\",value:\"TARGET\"},"
+                        + " {key:\"newLabel\",value:\"newValue\"}] })"
+                        + " { metadata { labels } } } } } } }");
+        HttpResponse<Buffer> resp =
+                webClient
+                        .extensions()
+                        .post("/api/v2.2/graphql", query.toBuffer(), REQUEST_TIMEOUT_SECONDS);
+        MatcherAssert.assertThat(
+                resp.statusCode(),
+                Matchers.both(Matchers.greaterThanOrEqualTo(200)).and(Matchers.lessThan(300)));
+
+        ActiveMutationResponse actual =
+                mapper.readValue(resp.bodyAsString(), ActiveMutationResponse.class);
+
+        MatcherAssert.assertThat(actual.data.targetNodes, Matchers.hasSize(1));
+
+        TargetNode node = actual.data.targetNodes.get(0);
+
+        MatcherAssert.assertThat(node.recordings.active.data, Matchers.hasSize(1));
+
+        ActiveRecording activeRecording = node.recordings.active.data.get(0);
+
+        MatcherAssert.assertThat(
+                activeRecording.metadata,
+                Matchers.equalTo(
+                        RecordingMetadata.of(
+                                Map.of(
+                                        "template.name",
+                                        "Profiling",
+                                        "template.type",
+                                        "TARGET",
+                                        "newLabel",
+                                        "newValue"))));
+    }
+
+    @Test
+    @Order(6)
+    void testArchivedRecordingMetadataMutation() throws Exception {
+        JsonObject query = new JsonObject();
+        query.put(
+                "query",
+                "query { targetNodes(filter: { annotations: \"PORT == 0\" }) {"
+                        + "recordings { archived {"
+                        + " data { name size "
+                        + " doPutMetadata(metadata: { labels: ["
+                        + " {key:\"template.name\",value:\"Profiling\"},"
+                        + " {key:\"template.type\",value:\"TARGET\"},"
+                        + " {key:\"newArchivedLabel\",value:\"newArchivedValue\"}] })"
+                        + " { metadata { labels } } } } } } }");
+        HttpResponse<Buffer> resp =
+                webClient
+                        .extensions()
+                        .post("/api/v2.2/graphql", query.toBuffer(), REQUEST_TIMEOUT_SECONDS);
+        MatcherAssert.assertThat(
+                resp.statusCode(),
+                Matchers.both(Matchers.greaterThanOrEqualTo(200)).and(Matchers.lessThan(300)));
+
+        ArchiveMutationResponse actual =
+                mapper.readValue(resp.bodyAsString(), ArchiveMutationResponse.class);
+
+        MatcherAssert.assertThat(actual.data.targetNodes, Matchers.hasSize(1));
+
+        TargetNode node = actual.data.targetNodes.get(0);
+
+        MatcherAssert.assertThat(node.recordings.archived.data, Matchers.hasSize(1));
+
+        ArchivedRecording archivedRecording = node.recordings.archived.data.get(0);
+        MatcherAssert.assertThat(archivedRecording.size, Matchers.greaterThan(0L));
+
+        MatcherAssert.assertThat(
+                archivedRecording.metadata,
+                Matchers.equalTo(
+                        RecordingMetadata.of(
+                                Map.of(
+                                        "template.name",
+                                        "Profiling",
+                                        "template.type",
+                                        "TARGET",
+                                        "newArchivedLabel",
+                                        "newArchivedValue"))));
+    }
+
+    @Test
+    @Order(7)
+    void testDeleteMutation() throws Exception {
+        JsonObject query = new JsonObject();
+        query.put(
+                "query",
+                "query { targetNodes(filter: { annotations: \"PORT == 0\" }) { recordings {"
+                        + " active { data { name doDelete { name }"
+                        + " } aggregate { count } }"
+                        + " archived { data { name doDelete { name }"
+                        + " } aggregate { count size } }"
+                        + " } } }");
+        HttpResponse<Buffer> resp =
+                webClient
+                        .extensions()
+                        .post("/api/v2.2/graphql", query.toBuffer(), REQUEST_TIMEOUT_SECONDS);
+        MatcherAssert.assertThat(
+                resp.statusCode(),
+                Matchers.both(Matchers.greaterThanOrEqualTo(200)).and(Matchers.lessThan(300)));
+
+        DeleteMutationResponse actual =
+                mapper.readValue(resp.bodyAsString(), DeleteMutationResponse.class);
+
+        MatcherAssert.assertThat(actual.data.targetNodes, Matchers.hasSize(1));
+
+        TargetNode node = actual.data.targetNodes.get(0);
+
+        MatcherAssert.assertThat(node.recordings.active.data, Matchers.hasSize(1));
+        MatcherAssert.assertThat(node.recordings.archived.data, Matchers.hasSize(1));
+        MatcherAssert.assertThat(node.recordings.archived.aggregate.count, Matchers.equalTo(1L));
+        MatcherAssert.assertThat(node.recordings.archived.aggregate.size, Matchers.greaterThan(0L));
+
+        ActiveRecording activeRecording = node.recordings.active.data.get(0);
+        ArchivedRecording archivedRecording = node.recordings.archived.data.get(0);
+
+        MatcherAssert.assertThat(activeRecording.name, Matchers.equalTo("graphql-itest"));
+        MatcherAssert.assertThat(activeRecording.doDelete.name, Matchers.equalTo("graphql-itest"));
+
+        MatcherAssert.assertThat(
+                archivedRecording.name,
+                Matchers.matchesRegex(
+                        "^es-andrewazor-demo-Main_graphql-itest_[0-9]{8}T[0-9]{6}Z\\.jfr$"));
+    }
+
+    @Test
+    @Order(8)
+    void testNodesHaveIds() throws Exception {
+        JsonObject query = new JsonObject();
+        query.put(
+                "query",
+                "query { environmentNodes(filter: { name: \"JDP\" }) { id descendantTargets { id }"
+                        + " } }");
+        HttpResponse<Buffer> resp =
+                webClient
+                        .extensions()
+                        .post("/api/v2.2/graphql", query.toBuffer(), REQUEST_TIMEOUT_SECONDS);
+        MatcherAssert.assertThat(
+                resp.statusCode(),
+                Matchers.both(Matchers.greaterThanOrEqualTo(200)).and(Matchers.lessThan(300)));
+
+        // if any of the nodes in the query did not have an ID property then the request
+        // would fail
+        EnvironmentNodesResponse actual =
+                mapper.readValue(resp.bodyAsString(), EnvironmentNodesResponse.class);
+        Set<Integer> observedIds = new HashSet<>();
+        for (var env : actual.data.environmentNodes) {
+            // ids should be unique
+            MatcherAssert.assertThat(observedIds, Matchers.not(Matchers.contains(env.id)));
+            observedIds.add(env.id);
+            for (var target : env.descendantTargets) {
+                MatcherAssert.assertThat(observedIds, Matchers.not(Matchers.contains(target.id)));
+                observedIds.add(target.id);
+            }
+        }
+    }
+
+    @Test
+    @Order(9)
+    void testQueryForSpecificTargetsByNames() throws Exception {
+        JsonObject query = new JsonObject();
+        query.put(
+                "query",
+                String.format(
+                        "query { targetNodes(filter: { names:"
+                                + " [\"service:jmx:rmi:///jndi/rmi://localhost:0/jmxrmi\","
+                                + " \"service:jmx:rmi:///jndi/rmi://localhost:9091/jmxrmi\"] }) {"
+                                + " name nodeType } }"));
+        HttpResponse<Buffer> resp =
+                webClient
+                        .extensions()
+                        .post("/api/v2.2/graphql", query.toBuffer(), REQUEST_TIMEOUT_SECONDS);
+        MatcherAssert.assertThat(
+                resp.statusCode(),
+                Matchers.both(Matchers.greaterThanOrEqualTo(200)).and(Matchers.lessThan(300)));
+
+        TargetNodesQueryResponse actual =
+                mapper.readValue(resp.bodyAsString(), TargetNodesQueryResponse.class);
+        List<TargetNode> targetNodes = actual.data.targetNodes;
+
+        int expectedSize = 2;
+
+        assertThat(targetNodes.size(), is(expectedSize));
+
+        TargetNode target1 = new TargetNode();
+        target1.name = "service:jmx:rmi:///jndi/rmi://localhost:0/jmxrmi";
+        target1.nodeType = "JVM";
+        TargetNode target2 = new TargetNode();
+        target2.name = "service:jmx:rmi:///jndi/rmi://localhost:9091/jmxrmi";
+        target2.nodeType = "JVM";
+
+        assertThat(targetNodes, hasItem(target1));
+        assertThat(targetNodes, hasItem(target2));
+    }
+
+    @Test
+    @Order(10)
+    public void testQueryForFilteredActiveRecordingsByNames() throws Exception {
+        // Check preconditions
+        CompletableFuture<JsonArray> listRespFuture1 = new CompletableFuture<>();
+        webClient
+                .get(
+                        String.format(
+                                "/api/v1/targets/%s/recordings",
+                                getSelfReferenceConnectUrlEncoded()))
+                .send(
+                        ar -> {
+                            if (assertRequestStatus(ar, listRespFuture1)) {
+                                listRespFuture1.complete(ar.result().bodyAsJsonArray());
+                            }
+                        });
+        JsonArray listResp = listRespFuture1.get(REQUEST_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+        Assertions.assertTrue(listResp.isEmpty());
+
+        // Create two new recordings
+        CompletableFuture<Void> createRecordingFuture1 = new CompletableFuture<>();
+        MultiMap form1 = MultiMap.caseInsensitiveMultiMap();
+        form1.add("recordingName", "Recording1");
+        form1.add("duration", "5");
+        form1.add("events", "template=ALL");
+        webClient
+                .post(
+                        String.format(
+                                "/api/v1/targets/%s/recordings",
+                                getSelfReferenceConnectUrlEncoded()))
+                .sendForm(
+                        form1,
+                        ar -> {
+                            if (assertRequestStatus(ar, createRecordingFuture1)) {
+                                createRecordingFuture1.complete(null);
+                            }
+                        });
+        createRecordingFuture1.get(REQUEST_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+
+        CompletableFuture<Void> createRecordingFuture2 = new CompletableFuture<>();
+        MultiMap form2 = MultiMap.caseInsensitiveMultiMap();
+        form2.add("recordingName", "Recording2");
+        form2.add("duration", "5");
+        form2.add("events", "template=ALL");
+        webClient
+                .post(
+                        String.format(
+                                "/api/v1/targets/%s/recordings",
+                                getSelfReferenceConnectUrlEncoded()))
+                .sendForm(
+                        form2,
+                        ar -> {
+                            if (assertRequestStatus(ar, createRecordingFuture2)) {
+                                createRecordingFuture2.complete(null);
+                            }
+                        });
+        createRecordingFuture2.get(REQUEST_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+
+        // GraphQL Query to filter Active recordings by names
+        JsonObject query = new JsonObject();
+        query.put(
+                "query",
+                "query { targetNodes (filter: {name:"
+                    + " \"service:jmx:rmi:///jndi/rmi://localhost:0/jmxrmi\"}){ recordings"
+                    + " {active(filter: { names: [\"Recording1\", \"Recording2\",\"Recording3\"] })"
+                    + " {data {name}}}}}");
+        HttpResponse<Buffer> resp =
+                webClient
+                        .extensions()
+                        .post("/api/v2.2/graphql", query.toBuffer(), REQUEST_TIMEOUT_SECONDS);
+        MatcherAssert.assertThat(
+                resp.statusCode(),
+                Matchers.both(Matchers.greaterThanOrEqualTo(200)).and(Matchers.lessThan(300)));
+
+        TargetNodesQueryResponse graphqlResp =
+                mapper.readValue(resp.bodyAsString(), TargetNodesQueryResponse.class);
+
+        List<String> filterNames = Arrays.asList("Recording1", "Recording2");
+
+        List<ActiveRecording> filteredRecordings =
+                graphqlResp.data.targetNodes.stream()
+                        .flatMap(targetNode -> targetNode.recordings.active.data.stream())
+                        .filter(recording -> filterNames.contains(recording.name))
+                        .collect(Collectors.toList());
+
+        MatcherAssert.assertThat(filteredRecordings.size(), Matchers.equalTo(2));
+        ActiveRecording r1 = new ActiveRecording();
+        r1.name = "Recording1";
+        ActiveRecording r2 = new ActiveRecording();
+        r2.name = "Recording2";
+
+        assertThat(filteredRecordings, hasItem(r1));
+        assertThat(filteredRecordings, hasItem(r2));
+
+        // Delete recordings
+        for (ActiveRecording recording : filteredRecordings) {
+            String recordingName = recording.name;
+            CompletableFuture<Void> deleteRecordingFuture = new CompletableFuture<>();
+            webClient
+                    .delete(
+                            String.format(
+                                    "/api/v1/targets/%s/recordings/%s",
+                                    getSelfReferenceConnectUrlEncoded(), recordingName))
+                    .send(
+                            ar -> {
+                                if (assertRequestStatus(ar, deleteRecordingFuture)) {
+                                    deleteRecordingFuture.complete(null);
+                                }
+                            });
+            deleteRecordingFuture.get(REQUEST_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+        }
+        // Verify no recordings available
+        CompletableFuture<JsonArray> listRespFuture4 = new CompletableFuture<>();
+        webClient
+                .get(
+                        String.format(
+                                "/api/v1/targets/%s/recordings",
+                                getSelfReferenceConnectUrlEncoded()))
+                .send(
+                        ar -> {
+                            if (assertRequestStatus(ar, listRespFuture4)) {
+                                listRespFuture4.complete(ar.result().bodyAsJsonArray());
+                            }
+                        });
+        listResp = listRespFuture4.get(REQUEST_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+
+        MatcherAssert.assertThat(
+                "list should have size 0 after deleting recordings",
+                listResp.size(),
+                Matchers.equalTo(0));
+    }
+
+    @Test
+    @Order(11)
+    public void shouldReturnArchivedRecordingsFilteredByNames() throws Exception {
+        // Check preconditions
+        CompletableFuture<JsonArray> listRespFuture1 = new CompletableFuture<>();
+        webClient
+                .get(
+                        String.format(
+                                "/api/v1/targets/%s/recordings",
+                                getSelfReferenceConnectUrlEncoded()))
+                .send(
+                        ar -> {
+                            if (assertRequestStatus(ar, listRespFuture1)) {
+                                listRespFuture1.complete(ar.result().bodyAsJsonArray());
+                            }
+                        });
+        JsonArray listResp = listRespFuture1.get(REQUEST_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+        Assertions.assertTrue(listResp.isEmpty());
+
+        // Create a new recording
+        CompletableFuture<Void> createRecordingFuture = new CompletableFuture<>();
+        MultiMap form = MultiMap.caseInsensitiveMultiMap();
+        form.add("recordingName", TEST_RECORDING_NAME);
+        form.add("duration", "5");
+        form.add("events", "template=ALL");
+        webClient
+                .post(
+                        String.format(
+                                "/api/v1/targets/%s/recordings",
+                                getSelfReferenceConnectUrlEncoded()))
+                .sendForm(
+                        form,
+                        ar -> {
+                            if (assertRequestStatus(ar, createRecordingFuture)) {
+                                createRecordingFuture.complete(null);
+                            }
+                        });
+        createRecordingFuture.get(REQUEST_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+
+        // Archive the recording
+        CompletableFuture<Void> archiveRecordingFuture = new CompletableFuture<>();
+        webClient
+                .patch(
+                        String.format(
+                                "/api/v1/targets/%s/recordings/%s",
+                                getSelfReferenceConnectUrlEncoded(), TEST_RECORDING_NAME))
+                .putHeader(HttpHeaders.CONTENT_TYPE.toString(), HttpMimeType.PLAINTEXT.mime())
+                .sendBuffer(
+                        Buffer.buffer("SAVE"),
+                        ar -> {
+                            if (assertRequestStatus(ar, archiveRecordingFuture)) {
+                                archiveRecordingFuture.complete(null);
+                            } else {
+
+                                archiveRecordingFuture.completeExceptionally(
+                                        new RuntimeException("Archive request failed"));
+                            }
+                        });
+
+        archiveRecordingFuture.get(REQUEST_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+
+        // retrieve to match the exact name
+        CompletableFuture<JsonArray> archivedRecordingsFuture2 = new CompletableFuture<>();
+        webClient
+                .get(String.format("/api/v1/recordings"))
+                .send(
+                        ar -> {
+                            if (assertRequestStatus(ar, archivedRecordingsFuture2)) {
+                                archivedRecordingsFuture2.complete(ar.result().bodyAsJsonArray());
+                            }
+                        });
+        JsonArray retrivedArchivedRecordings =
+                archivedRecordingsFuture2.get(REQUEST_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+        JsonObject retrievedArchivedrecordings = retrivedArchivedRecordings.getJsonObject(0);
+        String retrievedArchivedRecordingsName = retrievedArchivedrecordings.getString("name");
+
+        // GraphQL Query to filter Archived recordings by names
+        CompletableFuture<TargetNodesQueryResponse> resp2 = new CompletableFuture<>();
+
+        JsonObject query = new JsonObject();
+        query.put(
+                "query",
+                "query { targetNodes {"
+                        + "recordings {"
+                        + "archived(filter: { names: [\""
+                        + retrievedArchivedRecordingsName
+                        + "\",\"someOtherName\"] }) {"
+                        + "data {"
+                        + "name"
+                        + "}"
+                        + "}"
+                        + "}"
+                        + "}"
+                        + "}");
+        HttpResponse<Buffer> resp =
+                webClient
+                        .extensions()
+                        .post("/api/v2.2/graphql", query.toBuffer(), REQUEST_TIMEOUT_SECONDS);
+        MatcherAssert.assertThat(
+                resp.statusCode(),
+                Matchers.both(Matchers.greaterThanOrEqualTo(200)).and(Matchers.lessThan(300)));
+
+        TargetNodesQueryResponse graphqlResp =
+                mapper.readValue(resp.bodyAsString(), TargetNodesQueryResponse.class);
+
+        List<ArchivedRecording> archivedRecordings2 =
+                graphqlResp.data.targetNodes.stream()
+                        .flatMap(targetNode -> targetNode.recordings.archived.data.stream())
+                        .collect(Collectors.toList());
+
+        int filteredRecordingsCount = archivedRecordings2.size();
+        Assertions.assertEquals(
+                1, filteredRecordingsCount, "Number of filtered recordings should be 1");
+
+        ArchivedRecording archivedRecording = archivedRecordings2.get(0);
+        String filteredName = archivedRecording.name;
+        Assertions.assertEquals(
+                filteredName,
+                retrievedArchivedRecordingsName,
+                "Filtered name should match the archived recording name");
+
+        // Delete archived recording by name
+        for (ArchivedRecording archrecording : archivedRecordings2) {
+            String nameMatch = archrecording.name;
+
+            CompletableFuture<Void> deleteFuture = new CompletableFuture<>();
+            webClient
+                    .delete(
+                            String.format(
+                                    "/api/beta/recordings/%s/%s",
+                                    getSelfReferenceConnectUrlEncoded(), nameMatch))
+                    .send(
+                            ar -> {
+                                if (assertRequestStatus(ar, deleteFuture)) {
+                                    deleteFuture.complete(null);
+                                } else {
+                                    deleteFuture.completeExceptionally(
+                                            new RuntimeException("Delete request failed"));
+                                }
+                            });
+
+            deleteFuture.get(REQUEST_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+        }
+
+        // Retrieve the list of updated archived recordings to verify that the targeted
+        // recordings
+        // have been deleted
+        CompletableFuture<JsonArray> updatedArchivedRecordingsFuture = new CompletableFuture<>();
+        webClient
+                .get("/api/v1/recordings")
+                .send(
+                        ar -> {
+                            if (assertRequestStatus(ar, updatedArchivedRecordingsFuture)) {
+                                updatedArchivedRecordingsFuture.complete(
+                                        ar.result().bodyAsJsonArray());
+                            }
+                        });
+
+        JsonArray updatedArchivedRecordings =
+                updatedArchivedRecordingsFuture.get(REQUEST_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+
+        // Assert that the targeted recordings have been deleted
+        boolean recordingsDeleted =
+                updatedArchivedRecordings.stream()
+                        .noneMatch(
+                                json -> {
+                                    JsonObject recording = (JsonObject) json;
+                                    return recording.getString("name").equals(TEST_RECORDING_NAME);
+                                });
+
+        Assertions.assertTrue(
+                recordingsDeleted, "The targeted archived recordings should be deleted");
+
+        // Clean up what we created
+        CompletableFuture<Void> deleteRespFuture1 = new CompletableFuture<>();
+        webClient
+                .delete(
+                        String.format(
+                                "/api/v1/targets/%s/recordings/%s",
+                                getSelfReferenceConnectUrlEncoded(), TEST_RECORDING_NAME))
+                .send(
+                        ar -> {
+                            if (assertRequestStatus(ar, deleteRespFuture1)) {
+                                deleteRespFuture1.complete(null);
+                            }
+                        });
+
+        deleteRespFuture1.get(REQUEST_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+
+        CompletableFuture<JsonArray> savedRecordingsFuture = new CompletableFuture<>();
+        webClient
+                .get("/api/v1/recordings")
+                .send(
+                        ar -> {
+                            if (assertRequestStatus(ar, savedRecordingsFuture)) {
+                                savedRecordingsFuture.complete(ar.result().bodyAsJsonArray());
+                            }
+                        });
+
+        JsonArray savedRecordings =
+                savedRecordingsFuture.get(REQUEST_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+
+        for (Object savedRecording : savedRecordings) {
+            String recordingName = ((JsonObject) savedRecording).getString("name");
+            if (recordingName.matches("archivedRecordings")) {
+                CompletableFuture<Void> deleteRespFuture2 = new CompletableFuture<>();
+                webClient
+                        .delete(
+                                String.format(
+                                        "/api/beta/recordings/%s/%s",
+                                        getSelfReferenceConnectUrlEncoded(), recordingName))
+                        .send(
+                                ar -> {
+                                    if (assertRequestStatus(ar, deleteRespFuture2)) {
+                                        deleteRespFuture2.complete(null);
+                                    }
+                                });
+
+                deleteRespFuture2.get(REQUEST_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+            }
+        }
+    }
+
+    @Test
+    @Order(12)
+    public void testQueryforFilteredEnvironmentNodesByNames() throws Exception {
+        JsonObject query = new JsonObject();
+        query.put(
+                "query",
+                "query { environmentNodes(filter: { names: [\"anotherName1\","
+                        + " \"JDP\",\"anotherName2\"] }) { name nodeType } }");
+        HttpResponse<Buffer> resp =
+                webClient
+                        .extensions()
+                        .post("/api/v2.2/graphql", query.toBuffer(), REQUEST_TIMEOUT_SECONDS);
+        MatcherAssert.assertThat(
+                resp.statusCode(),
+                Matchers.both(Matchers.greaterThanOrEqualTo(200)).and(Matchers.lessThan(300)));
+
+        EnvironmentNodesResponse actual =
+                mapper.readValue(resp.bodyAsString(), EnvironmentNodesResponse.class);
+        List<EnvironmentNode> environmentNodes = actual.data.environmentNodes;
+
+        Assertions.assertEquals(1, environmentNodes.size(), "The list filtered should be 1");
+
+        boolean nameExists = false;
+        for (EnvironmentNode environmentNode : environmentNodes) {
+            if (environmentNode.name.matches("JDP")) {
+                nameExists = true;
+                break;
+            }
+        }
+        Assertions.assertTrue(nameExists, "Name not found");
+    }
+
+    @Test
+    @Order(13)
+    void testReplaceAlwaysOnStoppedRecording() throws Exception {
+        try {
+            // Start a Recording
+            JsonObject notificationRecording = startRecording();
+            Assertions.assertEquals("test", notificationRecording.getString("name"));
+            Assertions.assertEquals("RUNNING", notificationRecording.getString("state"));
+
+            // Stop the Recording
+            notificationRecording = stopRecording();
+            Assertions.assertEquals("test", notificationRecording.getString("name"));
+            Assertions.assertEquals("STOPPED", notificationRecording.getString("state"));
+
+            // Restart the recording with replace:ALWAYS
+            notificationRecording = restartRecording("ALWAYS");
+            Assertions.assertEquals("test", notificationRecording.getString("name"));
+            Assertions.assertEquals("RUNNING", notificationRecording.getString("state"));
+        } finally {
+            // Delete the Recording
+            deleteRecording();
+        }
+    }
+
+    @Test
+    @Order(14)
+    void testReplaceNeverOnStoppedRecording() throws Exception {
+        try {
+            // Start a Recording
+            JsonObject notificationRecording = startRecording();
+            Assertions.assertEquals("test", notificationRecording.getString("name"));
+            Assertions.assertEquals("RUNNING", notificationRecording.getString("state"));
+
+            // Stop the Recording
+            notificationRecording = stopRecording();
+            Assertions.assertEquals("test", notificationRecording.getString("name"));
+            Assertions.assertEquals("STOPPED", notificationRecording.getString("state"));
+
+            // Restart the recording with replace:NEVER
+            JsonObject error = restartRecordingWithError("NEVER");
+            Assertions.assertTrue(
+                    error.getString("message")
+                            .contains("Recording with name \"test\" already exists"),
+                    "Expected error message to contain 'Recording with name \"test\" already"
+                            + " exists'");
+        } finally {
+            // Delete the Recording
+            deleteRecording();
+        }
+    }
+
+    @Test
+    @Order(15)
+    void testReplaceStoppedOnStoppedRecording() throws Exception {
+        try {
+            // Start a Recording
+            JsonObject notificationRecording = startRecording();
+            Assertions.assertEquals("test", notificationRecording.getString("name"));
+            Assertions.assertEquals("RUNNING", notificationRecording.getString("state"));
+
+            // Stop the Recording
+            notificationRecording = stopRecording();
+            Assertions.assertEquals("test", notificationRecording.getString("name"));
+            Assertions.assertEquals("STOPPED", notificationRecording.getString("state"));
+
+            // Restart the recording with replace:STOPPED
+            notificationRecording = restartRecording("STOPPED");
+            Assertions.assertEquals("test", notificationRecording.getString("name"));
+            Assertions.assertEquals("RUNNING", notificationRecording.getString("state"));
+        } finally {
+            // Delete the Recording
+            deleteRecording();
+        }
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"STOPPED", "NEVER"})
+    @Order(16)
+    void testReplaceStoppedOrNeverOnRunningRecording(String replace) throws Exception {
+        try {
+            // Start a Recording
+            JsonObject notificationRecording = startRecording();
+            Assertions.assertEquals("test", notificationRecording.getString("name"));
+            Assertions.assertEquals("RUNNING", notificationRecording.getString("state"));
+
+            // Restart the recording with replace:NEVER
+            JsonObject error = restartRecordingWithError("STOPPED");
+            Assertions.assertTrue(
+                    error.getString("message")
+                            .contains("Recording with name \"test\" already exists"),
+                    "Expected error message to contain 'Recording with name \"test\" already"
+                            + " exists'");
+        } finally {
+            // Delete the Recording
+            deleteRecording();
+        }
+    }
+
+    @Test
+    @Order(17)
+    void testReplaceAlwaysOnRunningRecording() throws Exception {
+        try {
+            // Start a Recording
+            JsonObject notificationRecording = startRecording();
+            Assertions.assertEquals("test", notificationRecording.getString("name"));
+            Assertions.assertEquals("RUNNING", notificationRecording.getString("state"));
+
+            // Restart the recording with replace:ALWAYS
+            notificationRecording = restartRecording("ALWAYS");
+            Assertions.assertEquals("test", notificationRecording.getString("name"));
+            Assertions.assertEquals("RUNNING", notificationRecording.getString("state"));
+        } finally {
+            // Delete the Recording
+            deleteRecording();
+        }
+    }
+
+    @Test
+    @Order(18)
+    void testRestartTrueOnRunningRecording() throws Exception {
+        try {
+            // Start a Recording
+            JsonObject notificationRecording = startRecording();
+            Assertions.assertEquals("test", notificationRecording.getString("name"));
+            Assertions.assertEquals("RUNNING", notificationRecording.getString("state"));
+
+            // Restart the recording with replace:ALWAYS
+            notificationRecording = restartRecording(true);
+            Assertions.assertEquals("test", notificationRecording.getString("name"));
+            Assertions.assertEquals("RUNNING", notificationRecording.getString("state"));
+        } finally {
+            // Delete the Recording
+            deleteRecording();
+        }
+    }
+
+    @Test
+    @Order(19)
+    void testRestartFalseOnRunningRecording() throws Exception {
+        try {
+            // Start a Recording
+            JsonObject notificationRecording = startRecording();
+            Assertions.assertEquals("test", notificationRecording.getString("name"));
+            Assertions.assertEquals("RUNNING", notificationRecording.getString("state"));
+
+            // Restart the recording with replace:NEVER
+            JsonObject error = restartRecordingWithError(false);
+            Assertions.assertTrue(
+                    error.getString("message")
+                            .contains("Recording with name \"test\" already exists"),
+                    "Expected error message to contain 'Recording with name \"test\" already"
+                            + " exists'");
+        } finally {
+            // Delete the Recording
+            deleteRecording();
+        }
+    }
+
+    @Test
+    @Order(20)
+    void testRestartTrueOnStoppedRecording() throws Exception {
+        try {
+            // Start a Recording
+            JsonObject notificationRecording = startRecording();
+            Assertions.assertEquals("test", notificationRecording.getString("name"));
+            Assertions.assertEquals("RUNNING", notificationRecording.getString("state"));
+
+            // Stop the Recording
+            notificationRecording = stopRecording();
+            Assertions.assertEquals("test", notificationRecording.getString("name"));
+            Assertions.assertEquals("STOPPED", notificationRecording.getString("state"));
+
+            // Restart the recording with replace:ALWAYS
+            notificationRecording = restartRecording(true);
+            Assertions.assertEquals("test", notificationRecording.getString("name"));
+            Assertions.assertEquals("RUNNING", notificationRecording.getString("state"));
+        } finally {
+            // Delete the Recording
+            deleteRecording();
+        }
+    }
+
+    @Test
+    @Order(21)
+    void testRestartFalseOnStoppedRecording() throws Exception {
+        try {
+            // Start a Recording
+            JsonObject notificationRecording = startRecording();
+            Assertions.assertEquals("test", notificationRecording.getString("name"));
+            Assertions.assertEquals("RUNNING", notificationRecording.getString("state"));
+
+            // Stop the Recording
+            notificationRecording = stopRecording();
+            Assertions.assertEquals("test", notificationRecording.getString("name"));
+            Assertions.assertEquals("STOPPED", notificationRecording.getString("state"));
+
+            // Restart the recording with replace:NEVER
+            JsonObject error = restartRecordingWithError(false);
+            Assertions.assertTrue(
+                    error.getString("message")
+                            .contains("Recording with name \"test\" already exists"),
+                    "Expected error message to contain 'Recording with name \"test\" already"
+                            + " exists'");
+        } finally {
+            // Delete the Recording
+            deleteRecording();
+        }
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"ALWAYS", "STOPPED", "NEVER"})
+    @Order(22)
+    void testStartRecordingwithReplaceNever(String replace) throws Exception {
+        try {
+            JsonObject notificationRecording = restartRecording(replace);
+            Assertions.assertEquals("test", notificationRecording.getString("name"));
+            Assertions.assertEquals("RUNNING", notificationRecording.getString("state"));
+        } finally {
+            // Delete the Recording
+            deleteRecording();
+        }
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    @Order(23)
+    void testRestartRecordingWithReplaceTrue(boolean restart) throws Exception {
+        try {
+            JsonObject notificationRecording = restartRecording(restart);
+            Assertions.assertEquals("test", notificationRecording.getString("name"));
+            Assertions.assertEquals("RUNNING", notificationRecording.getString("state"));
+        } finally {
+            // Delete the recording
+            deleteRecording();
+        }
+    }
+
+    static class Target {
+        String alias;
+        String connectUrl;
+        Annotations annotations;
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(alias, connectUrl, annotations);
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (this == obj) {
+                return true;
+            }
+            if (obj == null) {
+                return false;
+            }
+            if (getClass() != obj.getClass()) {
+                return false;
+            }
+            Target other = (Target) obj;
+            return Objects.equals(alias, other.alias)
+                    && Objects.equals(connectUrl, other.connectUrl)
+                    && Objects.equals(annotations, other.annotations);
+        }
+    }
+
+    static class Annotations {
+        Map<String, String> platform;
+        Map<String, String> cryostat;
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(cryostat, platform);
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (this == obj) {
+                return true;
+            }
+            if (obj == null) {
+                return false;
+            }
+            if (getClass() != obj.getClass()) {
+                return false;
+            }
+            Annotations other = (Annotations) obj;
+            return Objects.equals(cryostat, other.cryostat)
+                    && Objects.equals(platform, other.platform);
+        }
+    }
+
+    static class ArchivedRecording {
+        String name;
+        String reportUrl;
+        String downloadUrl;
+        RecordingMetadata metadata;
+        long size;
+        long archivedTime;
+
+        ArchivedRecording doDelete;
+
+        @Override
+        public String toString() {
+            return "ArchivedRecording [doDelete="
+                    + doDelete
+                    + ", downloadUrl="
+                    + downloadUrl
+                    + ", metadata="
+                    + metadata
+                    + ", name="
+                    + name
+                    + ", reportUrl="
+                    + reportUrl
+                    + ", size="
+                    + size
+                    + ", archivedTime="
+                    + archivedTime
+                    + "]";
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(doDelete, downloadUrl, metadata, name, reportUrl, size);
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (this == obj) {
+                return true;
+            }
+            if (obj == null) {
+                return false;
+            }
+            if (getClass() != obj.getClass()) {
+                return false;
+            }
+            ArchivedRecording other = (ArchivedRecording) obj;
+            return Objects.equals(doDelete, other.doDelete)
+                    && Objects.equals(downloadUrl, other.downloadUrl)
+                    && Objects.equals(metadata, other.metadata)
+                    && Objects.equals(name, other.name)
+                    && Objects.equals(reportUrl, other.reportUrl)
+                    && Objects.equals(size, other.size);
+        }
+    }
+
+    static class AggregateInfo {
+        long count;
+        long size;
+
+        @Override
+        public String toString() {
+            return "AggregateInfo [count=" + count + ", size=" + size + "]";
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(count, size);
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (this == obj) return true;
+            if (obj == null) return false;
+            if (getClass() != obj.getClass()) return false;
+            AggregateInfo other = (AggregateInfo) obj;
+            if (count != other.count) return false;
+            if (size != other.size) return false;
+            return true;
+        }
+    }
+
+    static class Archived {
+        List<ArchivedRecording> data;
+        AggregateInfo aggregate;
+
+        @Override
+        public String toString() {
+            return "Archived [data=" + data + ", aggregate=" + aggregate + "]";
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(data, aggregate);
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (this == obj) {
+                return true;
+            }
+            if (obj == null) {
+                return false;
+            }
+            if (getClass() != obj.getClass()) {
+                return false;
+            }
+            Archived other = (Archived) obj;
+            return Objects.equals(data, other.data) && Objects.equals(aggregate, other.aggregate);
+        }
+    }
+
+    static class Recordings {
+        Active active;
+        Archived archived;
+
+        @Override
+        public String toString() {
+            return "Recordings [active=" + active + ", archived=" + archived + "]";
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(active, archived);
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (this == obj) {
+                return true;
+            }
+            if (obj == null) {
+                return false;
+            }
+            if (getClass() != obj.getClass()) {
+                return false;
+            }
+            Recordings other = (Recordings) obj;
+            return Objects.equals(active, other.active) && Objects.equals(archived, other.archived);
+        }
+    }
+
+    static class TargetNode {
+        String name;
+        String nodeType;
+        Map<String, String> labels;
+        Target target;
+        Recordings recordings;
+        ActiveRecording doStartRecording;
+
+        @Override
+        public String toString() {
+            return "TargetNode [doStartRecording="
+                    + doStartRecording
+                    + ", labels="
+                    + labels
+                    + ", name="
+                    + name
+                    + ", nodeType="
+                    + nodeType
+                    + ", recordings="
+                    + recordings
+                    + ", target="
+                    + target
+                    + "]";
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(doStartRecording, labels, name, nodeType, recordings, target);
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (this == obj) {
+                return true;
+            }
+            if (obj == null) {
+                return false;
+            }
+            if (getClass() != obj.getClass()) {
+                return false;
+            }
+            TargetNode other = (TargetNode) obj;
+            return Objects.equals(doStartRecording, other.doStartRecording)
+                    && Objects.equals(labels, other.labels)
+                    && Objects.equals(name, other.name)
+                    && Objects.equals(nodeType, other.nodeType)
+                    && Objects.equals(recordings, other.recordings)
+                    && Objects.equals(target, other.target);
+        }
+    }
+
+    static class TargetNodes {
+
+        List<TargetNode> targetNodes;
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(targetNodes);
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (this == obj) {
+                return true;
+            }
+            if (obj == null) {
+                return false;
+            }
+            if (getClass() != obj.getClass()) {
+                return false;
+            }
+            TargetNodes other = (TargetNodes) obj;
+            return Objects.equals(targetNodes, other.targetNodes);
+        }
+
+        @Override
+        public String toString() {
+            return "TargetNodes [targetNodes=" + targetNodes + "]";
+        }
+    }
+
+    static class TargetNodesQueryResponse {
+        TargetNodes data;
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(data);
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (this == obj) {
+                return true;
+            }
+            if (obj == null) {
+                return false;
+            }
+            if (getClass() != obj.getClass()) {
+                return false;
+            }
+            TargetNodesQueryResponse other = (TargetNodesQueryResponse) obj;
+            return Objects.equals(data, other.data);
+        }
+    }
+
+    static class Active {
+        List<ActiveRecording> data;
+        AggregateInfo aggregate;
+
+        @Override
+        public String toString() {
+            return "Active [data=" + data + ", aggregate=" + aggregate + "]";
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(data, aggregate);
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (this == obj) {
+                return true;
+            }
+            if (obj == null) {
+                return false;
+            }
+            if (getClass() != obj.getClass()) {
+                return false;
+            }
+            Active other = (Active) obj;
+            return Objects.equals(data, other.data) && Objects.equals(aggregate, other.aggregate);
+        }
+    }
+
+    static class ActiveRecording {
+        String name;
+        String reportUrl;
+        String downloadUrl;
+        RecordingMetadata metadata;
+        String state;
+        long startTime;
+        long duration;
+        boolean continuous;
+        boolean toDisk;
+        long maxSize;
+        long maxAge;
+        boolean archiveOnStop;
+
+        ArchivedRecording doArchive;
+        ActiveRecording doDelete;
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(
+                    continuous,
+                    doArchive,
+                    doDelete,
+                    downloadUrl,
+                    duration,
+                    maxAge,
+                    maxSize,
+                    archiveOnStop,
+                    metadata,
+                    name,
+                    reportUrl,
+                    startTime,
+                    state,
+                    toDisk);
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (this == obj) {
+                return true;
+            }
+            if (obj == null) {
+                return false;
+            }
+            if (getClass() != obj.getClass()) {
+                return false;
+            }
+            ActiveRecording other = (ActiveRecording) obj;
+            return continuous == other.continuous
+                    && Objects.equals(doArchive, other.doArchive)
+                    && Objects.equals(doDelete, other.doDelete)
+                    && Objects.equals(downloadUrl, other.downloadUrl)
+                    && duration == other.duration
+                    && maxAge == other.maxAge
+                    && maxSize == other.maxSize
+                    && archiveOnStop == other.archiveOnStop
+                    && Objects.equals(metadata, other.metadata)
+                    && Objects.equals(name, other.name)
+                    && Objects.equals(reportUrl, other.reportUrl)
+                    && startTime == other.startTime
+                    && Objects.equals(state, other.state)
+                    && toDisk == other.toDisk;
+        }
+
+        @Override
+        public String toString() {
+            return "ActiveRecording [continuous="
+                    + continuous
+                    + ", doArchive="
+                    + doArchive
+                    + ", doDelete="
+                    + doDelete
+                    + ", downloadUrl="
+                    + downloadUrl
+                    + ", duration="
+                    + duration
+                    + ", maxAge="
+                    + maxAge
+                    + ", maxSize="
+                    + maxSize
+                    + ", archiveOnStop="
+                    + archiveOnStop
+                    + ", metadata="
+                    + metadata
+                    + ", name="
+                    + name
+                    + ", reportUrl="
+                    + reportUrl
+                    + ", startTime="
+                    + startTime
+                    + ", state="
+                    + state
+                    + ", toDisk="
+                    + toDisk
+                    + "]";
+        }
+    }
+
+    static class RecordingMetadata {
+        Map<String, String> labels;
+
+        public static RecordingMetadata of(Map<String, String> of) {
+            return null;
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(labels);
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (this == obj) {
+                return true;
+            }
+            if (obj == null) {
+                return false;
+            }
+            if (getClass() != obj.getClass()) {
+                return false;
+            }
+            RecordingMetadata other = (RecordingMetadata) obj;
+            return Objects.equals(labels, other.labels);
+        }
+
+        @Override
+        public String toString() {
+            return "RecordingMetadata [labels=" + labels + "]";
+        }
+    }
+
+    static class StartRecording {
+        ActiveRecording doStartRecording;
+        ArchivedRecording doArchive;
+        ActiveRecording doPutMetadata;
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(doArchive, doStartRecording, doPutMetadata);
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (this == obj) {
+                return true;
+            }
+            if (obj == null) {
+                return false;
+            }
+            if (getClass() != obj.getClass()) {
+                return false;
+            }
+            StartRecording other = (StartRecording) obj;
+            return Objects.equals(doArchive, other.doArchive)
+                    && Objects.equals(doStartRecording, other.doStartRecording)
+                    && Objects.equals(doPutMetadata, other.doPutMetadata);
+        }
+
+        @Override
+        public String toString() {
+            return "StartRecording [doArchive="
+                    + doArchive
+                    + ", doStartRecording="
+                    + doStartRecording
+                    + ", doPutMetadata="
+                    + doPutMetadata
+                    + "]";
+        }
+    }
+
+    static class RecordingNodes {
+        List<StartRecording> targetNodes;
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(targetNodes);
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (this == obj) {
+                return true;
+            }
+            if (obj == null) {
+                return false;
+            }
+            if (getClass() != obj.getClass()) {
+                return false;
+            }
+            RecordingNodes other = (RecordingNodes) obj;
+            return Objects.equals(targetNodes, other.targetNodes);
+        }
+
+        @Override
+        public String toString() {
+            return "RecordingNodes [targetNodes=" + targetNodes + "]";
+        }
+    }
+
+    static class StartRecordingMutationResponse {
+        RecordingNodes data;
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(data);
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (this == obj) {
+                return true;
+            }
+            if (obj == null) {
+                return false;
+            }
+            if (getClass() != obj.getClass()) {
+                return false;
+            }
+            StartRecordingMutationResponse other = (StartRecordingMutationResponse) obj;
+            return Objects.equals(data, other.data);
+        }
+
+        @Override
+        public String toString() {
+            return "StartRecordingMutationResponse [data=" + data + "]";
+        }
+    }
+
+    static class Node {
+        int id;
+        String name;
+        String nodeType;
+
+        @Override
+        public String toString() {
+            return "Node [id=" + id + ", name=" + name + ", nodeType=" + nodeType + "]";
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(id, name, nodeType);
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (this == obj) {
+                return true;
+            }
+            if (obj == null) {
+                return false;
+            }
+            if (getClass() != obj.getClass()) {
+                return false;
+            }
+            Node other = (Node) obj;
+            return id == other.id
+                    && Objects.equals(name, other.name)
+                    && Objects.equals(nodeType, other.nodeType);
+        }
+    }
+
+    static class EnvironmentNode extends Node {
+        List<Node> descendantTargets;
+
+        @Override
+        public String toString() {
+            return "EnvironmentNode [descendantTargets="
+                    + descendantTargets
+                    + ", name="
+                    + name
+                    + ", nodeType="
+                    + nodeType
+                    + "]";
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(descendantTargets);
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (this == obj) {
+                return true;
+            }
+            if (obj == null) {
+                return false;
+            }
+            if (getClass() != obj.getClass()) {
+                return false;
+            }
+            EnvironmentNode other = (EnvironmentNode) obj;
+            return Objects.equals(descendantTargets, other.descendantTargets);
+        }
+    }
+
+    static class EnvironmentNodes {
+        List<EnvironmentNode> environmentNodes;
+
+        @Override
+        public String toString() {
+            return "EnvironmentNodes [environmentNodes=" + environmentNodes + "]";
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(environmentNodes);
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (this == obj) {
+                return true;
+            }
+            if (obj == null) {
+                return false;
+            }
+            if (getClass() != obj.getClass()) {
+                return false;
+            }
+            EnvironmentNodes other = (EnvironmentNodes) obj;
+            return Objects.equals(environmentNodes, other.environmentNodes);
+        }
+    }
+
+    static class EnvironmentNodesResponse {
+        EnvironmentNodes data;
+
+        @Override
+        public String toString() {
+            return "EnvironmentNodesResponse [data=" + data + "]";
+        }
+
+        public EnvironmentNodes getData() {
+            return data;
+        }
+
+        public void setData(EnvironmentNodes data) {
+            this.data = data;
+        }
+    }
+
+    static class ArchiveMutationResponse {
+        TargetNodes data;
+
+        @Override
+        public String toString() {
+            return "ArchiveMutationResponse [data=" + data + "]";
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(data);
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (this == obj) {
+                return true;
+            }
+            if (obj == null) {
+                return false;
+            }
+            if (getClass() != obj.getClass()) {
+                return false;
+            }
+            ArchiveMutationResponse other = (ArchiveMutationResponse) obj;
+            return Objects.equals(data, other.data);
+        }
+    }
+
+    static class ActiveMutationResponse extends ArchiveMutationResponse {
+        @Override
+        public String toString() {
+            return "ActiveMutationResponse [data=" + data + "]";
+        }
+    }
+
+    static class DeleteMutationResponse {
+        TargetNodes data;
+
+        @Override
+        public String toString() {
+            return "DeleteMutationResponse [data=" + data + "]";
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(data);
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (this == obj) {
+                return true;
+            }
+            if (obj == null) {
+                return false;
+            }
+            if (getClass() != obj.getClass()) {
+                return false;
+            }
+            DeleteMutationResponse other = (DeleteMutationResponse) obj;
+            return Objects.equals(data, other.data);
+        }
+    }
+
+    // start recording
+    private JsonObject startRecording() throws Exception {
+        CountDownLatch latch = new CountDownLatch(1);
+
+        JsonObject query = new JsonObject();
+        query.put(
+                "query",
+                "query { targetNodes(filter: {"
+                        + " name:\"service:jmx:rmi:///jndi/rmi://localhost:0/jmxrmi\" }) {"
+                        + " doStartRecording(recording: { name: \"test\", template:\"Profiling\","
+                        + " templateType: \"TARGET\"}) { name state}} }");
+        Future<JsonObject> f =
+                worker.submit(
+                        () -> {
+                            try {
+                                return expectNotification(
+                                                "ActiveRecordingCreated", 15, TimeUnit.SECONDS)
+                                        .get();
+                            } catch (Exception e) {
+                                throw new RuntimeException(e);
+                            } finally {
+                                latch.countDown();
+                            }
+                        });
+
+        Thread.sleep(5000);
+
+        HttpResponse<Buffer> resp =
+                webClient
+                        .extensions()
+                        .post("/api/v2.2/graphql", query.toBuffer(), REQUEST_TIMEOUT_SECONDS);
+        MatcherAssert.assertThat(
+                resp.statusCode(),
+                Matchers.both(Matchers.greaterThanOrEqualTo(200)).and(Matchers.lessThan(300)));
+
+        latch.await(REQUEST_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+
+        JsonObject notification = f.get(REQUEST_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+        return notification.getJsonObject("message").getJsonObject("recording");
+    }
+
+    // Stop the Recording
+    private JsonObject stopRecording() throws Exception {
+        CountDownLatch latch = new CountDownLatch(1);
+
+        JsonObject query = new JsonObject();
+        query.put(
+                "query",
+                "query { targetNodes(filter: { name:"
+                        + " \"service:jmx:rmi:///jndi/rmi://localhost:0/jmxrmi\" })  {"
+                        + " recordings { active { data { doStop { name state } } } } } }");
+
+        Future<JsonObject> f2 =
+                worker.submit(
+                        () -> {
+                            try {
+                                return expectNotification(
+                                                "ActiveRecordingStopped", 15, TimeUnit.SECONDS)
+                                        .get();
+                            } catch (Exception e) {
+                                throw new RuntimeException(e);
+                            } finally {
+                                latch.countDown();
+                            }
+                        });
+
+        Thread.sleep(5000);
+
+        HttpResponse<Buffer> resp =
+                webClient
+                        .extensions()
+                        .post("/api/v2.2/graphql", query.toBuffer(), REQUEST_TIMEOUT_SECONDS);
+        MatcherAssert.assertThat(
+                resp.statusCode(),
+                Matchers.both(Matchers.greaterThanOrEqualTo(200)).and(Matchers.lessThan(300)));
+
+        latch.await(REQUEST_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+
+        JsonObject notification = f2.get(REQUEST_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+        return notification.getJsonObject("message").getJsonObject("recording");
+    }
+
+    // Delete the Recording
+    private void deleteRecording() throws Exception {
+        JsonObject query = new JsonObject();
+        query.put(
+                "query",
+                "query { targetNodes(filter: { name:"
+                        + " \"service:jmx:rmi:///jndi/rmi://localhost:0/jmxrmi\" }) {"
+                        + " recordings { active { data { doDelete { name state } } } } } }");
+
+        Thread.sleep(5000);
+
+        HttpResponse<Buffer> resp =
+                webClient
+                        .extensions()
+                        .post("/api/v2.2/graphql", query.toBuffer(), REQUEST_TIMEOUT_SECONDS);
+        MatcherAssert.assertThat(
+                resp.statusCode(),
+                Matchers.both(Matchers.greaterThanOrEqualTo(200)).and(Matchers.lessThan(300)));
+    }
+
+    // Restart the recording with given replacement policy
+    private JsonObject restartRecording(String replace) throws Exception {
+        CountDownLatch latch = new CountDownLatch(1);
+
+        JsonObject query = new JsonObject();
+        query.put(
+                "query",
+                String.format(
+                        "query { targetNodes(filter: { name:"
+                            + " \"service:jmx:rmi:///jndi/rmi://localhost:0/jmxrmi\" }) {"
+                            + " doStartRecording(recording: { name: \"test\","
+                            + " template:\"Profiling\", templateType: \"TARGET\", replace: %s}) {"
+                            + " name state }} }",
+                        replace));
+        Future<JsonObject> f =
+                worker.submit(
+                        () -> {
+                            try {
+                                return expectNotification(
+                                                "ActiveRecordingCreated", 15, TimeUnit.SECONDS)
+                                        .get();
+                            } catch (Exception e) {
+                                throw new RuntimeException(e);
+                            } finally {
+                                latch.countDown();
+                            }
+                        });
+
+        Thread.sleep(5000);
+
+        HttpResponse<Buffer> resp =
+                webClient
+                        .extensions()
+                        .post("/api/v2.2/graphql", query.toBuffer(), REQUEST_TIMEOUT_SECONDS);
+        MatcherAssert.assertThat(
+                resp.statusCode(),
+                Matchers.both(Matchers.greaterThanOrEqualTo(200)).and(Matchers.lessThan(300)));
+
+        latch.await(REQUEST_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+
+        JsonObject notification = f.get(REQUEST_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+        return notification.getJsonObject("message").getJsonObject("recording");
+    }
+
+    private JsonObject restartRecording(boolean restart) throws Exception {
+        CountDownLatch latch = new CountDownLatch(1);
+
+        JsonObject query = new JsonObject();
+        query.put(
+                "query",
+                String.format(
+                        "query { targetNodes(filter: { name:"
+                            + " \"service:jmx:rmi:///jndi/rmi://localhost:0/jmxrmi\" }) {"
+                            + " doStartRecording(recording: { name: \"test\","
+                            + " template:\"Profiling\", templateType: \"TARGET\", restart: %b}) {"
+                            + " name state }} }",
+                        restart));
+        Future<JsonObject> f =
+                worker.submit(
+                        () -> {
+                            try {
+                                return expectNotification(
+                                                "ActiveRecordingCreated", 15, TimeUnit.SECONDS)
+                                        .get();
+                            } catch (Exception e) {
+                                throw new RuntimeException(e);
+                            } finally {
+                                latch.countDown();
+                            }
+                        });
+
+        Thread.sleep(5000);
+
+        HttpResponse<Buffer> resp =
+                webClient
+                        .extensions()
+                        .post("/api/v2.2/graphql", query.toBuffer(), REQUEST_TIMEOUT_SECONDS);
+        MatcherAssert.assertThat(
+                resp.statusCode(),
+                Matchers.both(Matchers.greaterThanOrEqualTo(200)).and(Matchers.lessThan(300)));
+
+        latch.await(REQUEST_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+
+        JsonObject notification = f.get(REQUEST_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+        return notification.getJsonObject("message").getJsonObject("recording");
+    }
+
+    private JsonObject restartRecordingWithError(String replace) throws Exception {
+        JsonObject query = new JsonObject();
+
+        query.put(
+                "query",
+                String.format(
+                        "query { targetNodes(filter: { name:"
+                                + " \"service:jmx:rmi:///jndi/rmi://localhost:0/jmxrmi\""
+                                + " }) { doStartRecording(recording: { name: \"test\","
+                                + " template:\"Profiling\", templateType: \"TARGET\", replace: %s})"
+                                + " { name state }} }",
+                        replace));
+        Thread.sleep(5000);
+        HttpResponse<Buffer> resp =
+                webClient
+                        .extensions()
+                        .post("/api/v2.2/graphql", query.toBuffer(), REQUEST_TIMEOUT_SECONDS);
+        MatcherAssert.assertThat(
+                resp.statusCode(),
+                Matchers.both(Matchers.greaterThanOrEqualTo(400)).and(Matchers.lessThan(600)));
+
+        JsonObject response = resp.bodyAsJsonObject();
+        JsonArray errors = response.getJsonArray("errors");
+        return errors.getJsonObject(0);
+    }
+
+    private JsonObject restartRecordingWithError(boolean restart) throws Exception {
+        JsonObject query = new JsonObject();
+
+        query.put(
+                "query",
+                String.format(
+                        "query { targetNodes(filter: { name:"
+                                + " \"service:jmx:rmi:///jndi/rmi://localhost:0/jmxrmi\""
+                                + " }) { doStartRecording(recording: { name: \"test\","
+                                + " template:\"Profiling\", templateType: \"TARGET\", restart: %b})"
+                                + " { name state }} }",
+                        restart));
+        Thread.sleep(5000);
+        HttpResponse<Buffer> resp =
+                webClient
+                        .extensions()
+                        .post("/api/v2.2/graphql", query.toBuffer(), REQUEST_TIMEOUT_SECONDS);
+        MatcherAssert.assertThat(
+                resp.statusCode(),
+                Matchers.both(Matchers.greaterThanOrEqualTo(400)).and(Matchers.lessThan(600)));
+
+        JsonObject response = resp.bodyAsJsonObject();
+        JsonArray errors = response.getJsonArray("errors");
+        return errors.getJsonObject(0);
+    }
+}


### PR DESCRIPTION
# Welcome to Cryostat3! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat3/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] [Signed all commits using a GPG signature](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#gpg-commit-signature-verification)

**To recreate commits with GPG signature** `git fetch upstream && git rebase --force --gpg-sign upstream/main`
_______________________________________________

Fixes: #11

Includes:
- [x] #307
- [x] #308
- [x] #312
- [x] #315
- [x] #319 
- [x] #324
- [x] #335

## Description of the change:
This is a roll-up PR which will include other PRs re-implementing various GraphQL features present in Cryostat 2.4. This first PR includes adding the GraphQL extension, plus implementing the first `rootNode` query and label selection matching.

## Motivation for the change:
Feature parity between the major release versions.

## How to manually test:
1. *Run CRYOSTAT_IMAGE=quay.io... bash smoketest.bash -O ...*
2. Try GraphQL queries, ex:

```bash
$ http --follow -v --auth=user:pass :8080/api/v2.2/graphql query='query { rootNode { id name nodeType labels { key } descendantTargets(filter: { labels: ["io.openshift.tags in (go, rust, java)"] }) { id name nodeType labels { key value } } } }'
```

You can also retrieve the generated GraphQL schema to compare against 2.4's [`queries.graphqls`](https://github.com/cryostatio/cryostat/blob/main/src/main/resources/queries.graphqls) and [`types.graphqls`](https://github.com/cryostatio/cryostat/blob/main/src/main/resources/types.graphqls).

```bash
$ http --follow -v --auth=user:pass :8080/api/v3/graphql/schema.graphql
```