### PR TITLE
ci(dependabot): remove config for GH mvn pkgs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,10 +1,4 @@
 version: 2
-registries:
-  maven-github:
-    type: maven-repository
-    url: https://maven.pkg.github.com/cryostatio/cryostat-core
-    username: dummy
-    password: ${{secrets.DEPENDABOT_READ_GHCR}}
 updates:
   - package-ecosystem: "maven"
     directory: "/"
@@ -15,8 +9,6 @@ updates:
       - "chore"
       - "safe-to-test"
     open-pull-requests-limit: 20
-    registries:
-      - "maven-github"
 
   - package-ecosystem: "docker"
     directory: "/src/main/docker"


### PR DESCRIPTION
# Welcome to Cryostat3! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat3/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] [Signed all commits using a GPG signature](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#gpg-commit-signature-verification)

**To recreate commits with GPG signature** `git fetch upstream && git rebase --force --gpg-sign upstream/main`
_______________________________________________

## Description of the change:
*This change allows an environment variable to be configured so that...*

## Motivation for the change:
*This change is helpful because users may want to...*

## How to manually test:
1. *Run CRYOSTAT_IMAGE=quay.io... bash smoketest.bash...*
2. *...*
