### PR TITLE
feat(graphql): add top-level query for targetNodes

### DIFF
--- a/src/main/java/io/cryostat/ObjectMapperCustomization.java
+++ b/src/main/java/io/cryostat/ObjectMapperCustomization.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright The Cryostat Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.cryostat;
+
+import java.io.IOException;
+import java.util.Map;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.Version;
+import com.fasterxml.jackson.databind.BeanDescription;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationConfig;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.module.SimpleModule;
+import com.fasterxml.jackson.databind.ser.BeanSerializerModifier;
+import com.fasterxml.jackson.databind.type.MapType;
+import io.quarkus.jackson.ObjectMapperCustomizer;
+import jakarta.inject.Singleton;
+
+@Singleton
+public class ObjectMapperCustomization implements ObjectMapperCustomizer {
+
+    @Override
+    public void customize(ObjectMapper objectMapper) {
+        // FIXME get this version information from the maven build somehow
+        SimpleModule mapModule =
+                new SimpleModule(
+                        "MapSerialization", new Version(3, 0, 0, null, "io.cryostat", "cryostat"));
+
+        mapModule.setSerializerModifier(new MapSerializerModifier());
+
+        objectMapper.registerModule(mapModule);
+    }
+
+    static class MapSerializerModifier extends BeanSerializerModifier {
+        @Override
+        public JsonSerializer<?> modifyMapSerializer(
+                SerializationConfig config,
+                MapType valueType,
+                BeanDescription beanDesc,
+                JsonSerializer serializer) {
+            if (valueType.getKeyType().getRawClass().equals(String.class)
+                    && valueType.getContentType().getRawClass().equals(String.class)) {
+                return new MapSerializer();
+            }
+            return serializer;
+        }
+    }
+
+    static class MapSerializer extends JsonSerializer<Map<?, ?>> {
+
+        @Override
+        public void serialize(Map<?, ?> map, JsonGenerator gen, SerializerProvider serializers)
+                throws IOException {
+            gen.writeStartArray();
+
+            for (var entry : map.entrySet()) {
+                gen.writeStartObject();
+
+                gen.writePOJOField("key", entry.getKey());
+                gen.writePOJOField("value", entry.getValue());
+
+                gen.writeEndObject();
+            }
+
+            gen.writeEndArray();
+        }
+    }
+}

--- a/src/main/java/io/cryostat/graphql/RootNode.java
+++ b/src/main/java/io/cryostat/graphql/RootNode.java
@@ -43,7 +43,7 @@ public class RootNode {
             "Get target nodes that are descendants of this node. That is, get the set of leaf nodes"
                     + " from anywhere below this node's subtree.")
     public List<DiscoveryNode> descendantTargets(
-            @Source DiscoveryNode discoveryNode, DescendantTargetsFilterInput filter) {
+            @Source DiscoveryNode discoveryNode, DiscoveryNodeFilterInput filter) {
         // TODO do this filtering at the database query level as much as possible. As is, this will
         // load the entire discovery tree out of the database, then perform the filtering at the
         // application level.
@@ -64,7 +64,7 @@ public class RootNode {
         return result;
     }
 
-    public static class DescendantTargetsFilterInput implements Predicate<DiscoveryNode> {
+    public static class DiscoveryNodeFilterInput implements Predicate<DiscoveryNode> {
         public @Nullable Long id;
         public @Nullable String name;
         public @Nullable List<String> names;

--- a/src/main/java/io/cryostat/graphql/RootNode.java
+++ b/src/main/java/io/cryostat/graphql/RootNode.java
@@ -24,13 +24,12 @@ import java.util.function.Predicate;
 import io.cryostat.discovery.DiscoveryNode;
 import io.cryostat.graphql.matchers.LabelSelectorMatcher;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.smallrye.graphql.api.Nullable;
 import org.eclipse.microprofile.graphql.Description;
 import org.eclipse.microprofile.graphql.GraphQLApi;
 import org.eclipse.microprofile.graphql.Query;
 import org.eclipse.microprofile.graphql.Source;
-
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 @GraphQLApi
 public class RootNode {

--- a/src/main/java/io/cryostat/graphql/RootNode.java
+++ b/src/main/java/io/cryostat/graphql/RootNode.java
@@ -30,6 +30,8 @@ import org.eclipse.microprofile.graphql.GraphQLApi;
 import org.eclipse.microprofile.graphql.Query;
 import org.eclipse.microprofile.graphql.Source;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
 @GraphQLApi
 public class RootNode {
 
@@ -64,6 +66,7 @@ public class RootNode {
         return result;
     }
 
+    @SuppressFBWarnings(value = "URF_UNREAD_PUBLIC_OR_PROTECTED_FIELD")
     public static class DiscoveryNodeFilter implements Predicate<DiscoveryNode> {
         public @Nullable Long id;
         public @Nullable String name;

--- a/src/main/java/io/cryostat/graphql/RootNode.java
+++ b/src/main/java/io/cryostat/graphql/RootNode.java
@@ -43,7 +43,7 @@ public class RootNode {
             "Get target nodes that are descendants of this node. That is, get the set of leaf nodes"
                     + " from anywhere below this node's subtree.")
     public List<DiscoveryNode> descendantTargets(
-            @Source DiscoveryNode discoveryNode, DiscoveryNodeFilterInput filter) {
+            @Source DiscoveryNode discoveryNode, DiscoveryNodeFilter filter) {
         // TODO do this filtering at the database query level as much as possible. As is, this will
         // load the entire discovery tree out of the database, then perform the filtering at the
         // application level.
@@ -64,7 +64,7 @@ public class RootNode {
         return result;
     }
 
-    public static class DiscoveryNodeFilterInput implements Predicate<DiscoveryNode> {
+    public static class DiscoveryNodeFilter implements Predicate<DiscoveryNode> {
         public @Nullable Long id;
         public @Nullable String name;
         public @Nullable List<String> names;

--- a/src/main/java/io/cryostat/graphql/TargetNodes.java
+++ b/src/main/java/io/cryostat/graphql/TargetNodes.java
@@ -74,13 +74,6 @@ public class TargetNodes {
                 builder, RecordingState.class, "Running state of an active Flight Recording");
     }
 
-    public GraphQLSchema.Builder registerTemplateTypeEnum(@Observes GraphQLSchema.Builder builder) {
-        return createEnumType(
-                builder,
-                TemplateType.class,
-                "Source where a given event template will be loaded from");
-    }
-
     private static GraphQLSchema.Builder createEnumType(
             GraphQLSchema.Builder builder, Class<? extends Enum<?>> klazz, String description) {
         return builder.additionalType(

--- a/src/main/java/io/cryostat/graphql/TargetNodes.java
+++ b/src/main/java/io/cryostat/graphql/TargetNodes.java
@@ -160,6 +160,23 @@ public class TargetNodes {
         return out;
     }
 
+    public ArchivedRecordings archived(
+            @Source Recordings recordings, ArchivedRecordingsFilter filter) {
+        var out = new ArchivedRecordings();
+        out.data = new ArrayList<>();
+        out.aggregate = new AggregateInfo();
+
+        var in = recordings.archived;
+        if (in != null && in.data != null) {
+            out.data =
+                    in.data.stream().filter(r -> filter == null ? true : filter.test(r)).toList();
+            out.aggregate.size = 0;
+            out.aggregate.count = out.data.size();
+        }
+
+        return out;
+    }
+
     @Blocking
     @Transactional
     @Description("Start a new Flight Recording on the specified Target")
@@ -184,23 +201,6 @@ public class TargetNodes {
     public Uni<ActiveRecording> doSnapshot(@Source Target target) {
         var fTarget = Target.<Target>findById(target.id);
         return recordingHelper.createSnapshot(fTarget);
-    }
-
-    public ArchivedRecordings archived(
-            @Source Recordings recordings, ArchivedRecordingsFilter filter) {
-        var out = new ArchivedRecordings();
-        out.data = new ArrayList<>();
-        out.aggregate = new AggregateInfo();
-
-        var in = recordings.archived;
-        if (in != null && in.data != null) {
-            out.data =
-                    in.data.stream().filter(r -> filter == null ? true : filter.test(r)).toList();
-            out.aggregate.size = 0;
-            out.aggregate.count = out.data.size();
-        }
-
-        return out;
     }
 
     @SuppressFBWarnings(value = "URF_UNREAD_PUBLIC_OR_PROTECTED_FIELD")

--- a/src/main/java/io/cryostat/graphql/TargetNodes.java
+++ b/src/main/java/io/cryostat/graphql/TargetNodes.java
@@ -25,7 +25,7 @@ import java.util.function.Function;
 import java.util.function.Predicate;
 
 import io.cryostat.discovery.DiscoveryNode;
-import io.cryostat.graphql.RootNode.DiscoveryNodeFilterInput;
+import io.cryostat.graphql.RootNode.DiscoveryNodeFilter;
 import io.cryostat.graphql.matchers.LabelSelectorMatcher;
 import io.cryostat.recordings.ActiveRecording;
 import io.cryostat.recordings.RecordingHelper;
@@ -74,7 +74,7 @@ public class TargetNodes {
 
     @Query("targetNodes")
     @Description("Get the Target discovery nodes, i.e. the leaf nodes of the discovery tree")
-    public List<DiscoveryNode> getTargetNodes(DiscoveryNodeFilterInput filter) {
+    public List<DiscoveryNode> getTargetNodes(DiscoveryNodeFilter filter) {
         // TODO do this filtering at the database query level as much as possible. As is, this will
         // load the entire discovery tree out of the database, then perform the filtering at the
         // application level.
@@ -118,8 +118,7 @@ public class TargetNodes {
         return recordings;
     }
 
-    public ActiveRecordings active(
-            @Source Recordings recordings, ActiveRecordingsFilterInput filter) {
+    public ActiveRecordings active(@Source Recordings recordings, ActiveRecordingsFilter filter) {
         var out = new ActiveRecordings();
         out.data = new ArrayList<>();
         out.aggregate = new AggregateInfo();
@@ -136,7 +135,7 @@ public class TargetNodes {
     }
 
     public ArchivedRecordings archived(
-            @Source Recordings recordings, ArchivedRecordingsFilterInput filter) {
+            @Source Recordings recordings, ArchivedRecordingsFilter filter) {
         var out = new ArchivedRecordings();
         out.data = new ArrayList<>();
         out.aggregate = new AggregateInfo();
@@ -174,7 +173,7 @@ public class TargetNodes {
                 size;
     }
 
-    public static class ActiveRecordingsFilterInput implements Predicate<ActiveRecording> {
+    public static class ActiveRecordingsFilter implements Predicate<ActiveRecording> {
 
         public @Nullable String name;
         public @Nullable List<String> names;
@@ -233,7 +232,7 @@ public class TargetNodes {
         }
     }
 
-    public static class ArchivedRecordingsFilterInput implements Predicate<ArchivedRecording> {
+    public static class ArchivedRecordingsFilter implements Predicate<ArchivedRecording> {
 
         public @Nullable String name;
         public @Nullable List<String> names;

--- a/src/main/java/io/cryostat/graphql/TargetNodes.java
+++ b/src/main/java/io/cryostat/graphql/TargetNodes.java
@@ -36,11 +36,9 @@ import io.cryostat.recordings.ActiveRecording;
 import io.cryostat.recordings.RecordingHelper;
 import io.cryostat.recordings.RecordingHelper.RecordingOptions;
 import io.cryostat.recordings.RecordingHelper.RecordingReplace;
-import io.cryostat.recordings.RecordingOptionsBuilderFactory;
 import io.cryostat.recordings.Recordings.ArchivedRecording;
 import io.cryostat.recordings.Recordings.Metadata;
 import io.cryostat.targets.Target;
-import io.cryostat.targets.TargetConnectionManager;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import graphql.schema.DataFetchingEnvironment;
@@ -60,15 +58,11 @@ import org.eclipse.microprofile.graphql.GraphQLApi;
 import org.eclipse.microprofile.graphql.NonNull;
 import org.eclipse.microprofile.graphql.Query;
 import org.eclipse.microprofile.graphql.Source;
-import org.jboss.logging.Logger;
 
 @GraphQLApi
 public class TargetNodes {
 
     @Inject RecordingHelper recordingHelper;
-    @Inject TargetConnectionManager connectionManager;
-    @Inject RecordingOptionsBuilderFactory recordingOptionsBuilderFactory;
-    @Inject Logger logger;
 
     public GraphQLSchema.Builder registerRecordingStateEnum(
             @Observes GraphQLSchema.Builder builder) {

--- a/src/main/java/io/cryostat/graphql/TargetNodes.java
+++ b/src/main/java/io/cryostat/graphql/TargetNodes.java
@@ -44,6 +44,7 @@ import io.cryostat.recordings.Recordings.Metadata;
 import io.cryostat.targets.Target;
 import io.cryostat.targets.TargetConnectionManager;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import graphql.schema.DataFetchingEnvironment;
 import graphql.schema.GraphQLEnumType;
 import graphql.schema.GraphQLEnumValueDefinition;
@@ -245,21 +246,25 @@ public class TargetNodes {
         return out;
     }
 
+    @SuppressFBWarnings(value = "URF_UNREAD_PUBLIC_OR_PROTECTED_FIELD")
     public static class Recordings {
         public @NonNull ActiveRecordings active;
         public @NonNull ArchivedRecordings archived;
     }
 
+    @SuppressFBWarnings(value = "URF_UNREAD_PUBLIC_OR_PROTECTED_FIELD")
     public static class ActiveRecordings {
         public @NonNull List<ActiveRecording> data;
         public @NonNull AggregateInfo aggregate;
     }
 
+    @SuppressFBWarnings(value = "URF_UNREAD_PUBLIC_OR_PROTECTED_FIELD")
     public static class ArchivedRecordings {
         public @NonNull List<ArchivedRecording> data;
         public @NonNull AggregateInfo aggregate;
     }
 
+    @SuppressFBWarnings(value = "URF_UNREAD_PUBLIC_OR_PROTECTED_FIELD")
     public static class AggregateInfo {
         public @NonNull @Description("The number of elements in this collection") long count;
         public @NonNull @Description(
@@ -267,8 +272,8 @@ public class TargetNodes {
                 size;
     }
 
+    @SuppressFBWarnings(value = "URF_UNREAD_PUBLIC_OR_PROTECTED_FIELD")
     public static class ActiveRecordingsFilter implements Predicate<ActiveRecording> {
-
         public @Nullable String name;
         public @Nullable List<String> names;
         public @Nullable List<String> labels;
@@ -326,8 +331,8 @@ public class TargetNodes {
         }
     }
 
+    @SuppressFBWarnings(value = "URF_UNREAD_PUBLIC_OR_PROTECTED_FIELD")
     public static class ArchivedRecordingsFilter implements Predicate<ArchivedRecording> {
-
         public @Nullable String name;
         public @Nullable List<String> names;
         public @Nullable List<String> labels;
@@ -377,6 +382,7 @@ public class TargetNodes {
         }
     }
 
+    @SuppressFBWarnings(value = "URF_UNREAD_PUBLIC_OR_PROTECTED_FIELD")
     public static class RecordingSettings {
         public @NonNull String name;
         public @NonNull String template;

--- a/src/main/java/io/cryostat/graphql/TargetNodes.java
+++ b/src/main/java/io/cryostat/graphql/TargetNodes.java
@@ -169,6 +169,7 @@ public class TargetNodes {
 
     @Blocking
     @Transactional
+    @Description("Start a new Flight Recording on the specified Target")
     public Uni<ActiveRecording> doStartRecording(
             @Source Target target, @NonNull RecordingSettings settings) {
         var fTarget = Target.<Target>findById(target.id);
@@ -218,6 +219,7 @@ public class TargetNodes {
 
     @Blocking
     @Transactional
+    @Description("Create a new Flight Recorder Snapshot on the specified Target")
     public Uni<ActiveRecording> doSnapshot(@Source Target target) {
         var fTarget = Target.<Target>findById(target.id);
         return connectionManager.executeConnectedTaskUni(

--- a/src/main/java/io/cryostat/graphql/TargetNodes.java
+++ b/src/main/java/io/cryostat/graphql/TargetNodes.java
@@ -176,6 +176,8 @@ public class TargetNodes {
         return connectionManager.executeConnectedTaskUni(
                 target,
                 conn -> {
+                    // TODO refactor, this is almost identical to the implementation in
+                    // Recordings.java . This should be extracted to the RecordingHelper
                     RecordingOptionsBuilder optionsBuilder =
                             recordingOptionsBuilderFactory
                                     .create(conn.getService())

--- a/src/main/java/io/cryostat/graphql/TargetNodes.java
+++ b/src/main/java/io/cryostat/graphql/TargetNodes.java
@@ -27,6 +27,8 @@ import java.util.function.Predicate;
 
 import org.openjdk.jmc.common.unit.QuantityConversionException;
 
+import io.cryostat.core.net.JFRConnection;
+import io.cryostat.core.net.MBeanMetrics;
 import io.cryostat.core.templates.Template;
 import io.cryostat.core.templates.TemplateType;
 import io.cryostat.discovery.DiscoveryNode;
@@ -39,6 +41,7 @@ import io.cryostat.recordings.RecordingHelper.RecordingReplace;
 import io.cryostat.recordings.Recordings.ArchivedRecording;
 import io.cryostat.recordings.Recordings.Metadata;
 import io.cryostat.targets.Target;
+import io.cryostat.targets.TargetConnectionManager;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import graphql.schema.DataFetchingEnvironment;
@@ -63,6 +66,7 @@ import org.eclipse.microprofile.graphql.Source;
 public class TargetNodes {
 
     @Inject RecordingHelper recordingHelper;
+    @Inject TargetConnectionManager connectionManager;
 
     public GraphQLSchema.Builder registerRecordingStateEnum(
             @Observes GraphQLSchema.Builder builder) {
@@ -175,6 +179,12 @@ public class TargetNodes {
         }
 
         return out;
+    }
+
+    @Blocking
+    @Description("Get live MBean metrics snapshot from the specified Target")
+    public Uni<MBeanMetrics> mbeanMetrics(@Source Target target) {
+        return connectionManager.executeConnectedTaskUni(target, JFRConnection::getMBeanMetrics);
     }
 
     @Blocking

--- a/src/main/java/io/cryostat/graphql/TargetNodes.java
+++ b/src/main/java/io/cryostat/graphql/TargetNodes.java
@@ -251,16 +251,13 @@ public class TargetNodes {
                     n -> name == null || Objects.equals(name, n.name);
             Predicate<ActiveRecording> matchesNames = n -> names == null || names.contains(n.name);
             Predicate<ActiveRecording> matchesLabels =
-                    n -> {
-                        if (labels == null) {
-                            return true;
-                        }
-                        var allMatch = true;
-                        for (var l : labels) {
-                            allMatch &= LabelSelectorMatcher.parse(l).test(n.metadata.labels());
-                        }
-                        return allMatch;
-                    };
+                    n ->
+                            labels == null
+                                    || labels.stream()
+                                            .allMatch(
+                                                    label ->
+                                                            LabelSelectorMatcher.parse(label)
+                                                                    .test(n.metadata.labels()));
             Predicate<ActiveRecording> matchesState = n -> state == null || n.state.equals(state);
             Predicate<ActiveRecording> matchesContinuous =
                     n -> continuous == null || continuous.equals(n.continuous);
@@ -308,16 +305,13 @@ public class TargetNodes {
             Predicate<ArchivedRecording> matchesNames =
                     n -> names == null || names.contains(n.name());
             Predicate<ArchivedRecording> matchesLabels =
-                    n -> {
-                        if (labels == null) {
-                            return true;
-                        }
-                        var allMatch = true;
-                        for (var l : labels) {
-                            allMatch &= LabelSelectorMatcher.parse(l).test(n.metadata().labels());
-                        }
-                        return allMatch;
-                    };
+                    n ->
+                            labels == null
+                                    || labels.stream()
+                                            .allMatch(
+                                                    label ->
+                                                            LabelSelectorMatcher.parse(label)
+                                                                    .test(n.metadata().labels()));
             Predicate<ArchivedRecording> matchesSizeGte =
                     n -> sizeBytesGreaterThanEqual == null || sizeBytesGreaterThanEqual >= n.size();
             Predicate<ArchivedRecording> matchesSizeLte =

--- a/src/main/java/io/cryostat/graphql/TargetNodes.java
+++ b/src/main/java/io/cryostat/graphql/TargetNodes.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright The Cryostat Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.cryostat.graphql;
+
+import java.util.List;
+
+import io.cryostat.discovery.DiscoveryNode;
+import io.cryostat.graphql.RootNode.DiscoveryNodeFilterInput;
+import io.cryostat.targets.Target;
+
+import org.eclipse.microprofile.graphql.Description;
+import org.eclipse.microprofile.graphql.GraphQLApi;
+import org.eclipse.microprofile.graphql.Query;
+
+@GraphQLApi
+public class TargetNodes {
+
+    @Query("targetNodes")
+    @Description("Get the Target discovery nodes, i.e. the leaf nodes of the discovery tree")
+    public List<DiscoveryNode> getTargetNodes(DiscoveryNodeFilterInput filter) {
+        // TODO do this filtering at the database query level as much as possible. As is, this will
+        // load the entire discovery tree out of the database, then perform the filtering at the
+        // application level.
+        return Target.<Target>findAll().stream()
+                .map(t -> t.discoveryNode)
+                .filter(n -> filter == null ? true : filter.test(n))
+                .toList();
+    }
+}

--- a/src/main/java/io/cryostat/graphql/TargetNodes.java
+++ b/src/main/java/io/cryostat/graphql/TargetNodes.java
@@ -54,12 +54,25 @@ public class TargetNodes {
 
     public GraphQLSchema.Builder registerRecordingStateEnum(
             @Observes GraphQLSchema.Builder builder) {
-        GraphQLEnumType recordingState =
+        return createEnumType(
+                builder, RecordingState.class, "Running state of an active Flight Recording");
+    }
+
+    public GraphQLSchema.Builder registerTemplateTypeEnum(@Observes GraphQLSchema.Builder builder) {
+        return createEnumType(
+                builder,
+                TemplateType.class,
+                "Source where a given event template will be loaded from");
+    }
+
+    private static GraphQLSchema.Builder createEnumType(
+            GraphQLSchema.Builder builder, Class<? extends Enum<?>> klazz, String description) {
+        return builder.additionalType(
                 GraphQLEnumType.newEnum()
-                        .name("RecordingState")
-                        .description("Running state of an active Flight Recording")
+                        .name(klazz.getSimpleName())
+                        .description(description)
                         .values(
-                                Arrays.asList(RecordingState.values()).stream()
+                                Arrays.asList(klazz.getEnumConstants()).stream()
                                         .map(
                                                 s ->
                                                         new GraphQLEnumValueDefinition.Builder()
@@ -68,8 +81,7 @@ public class TargetNodes {
                                                                 .description(s.name())
                                                                 .build())
                                         .toList())
-                        .build();
-        return builder.additionalType(recordingState);
+                        .build());
     }
 
     @Query("targetNodes")

--- a/src/main/java/io/cryostat/graphql/TargetNodes.java
+++ b/src/main/java/io/cryostat/graphql/TargetNodes.java
@@ -16,17 +16,29 @@
 package io.cryostat.graphql;
 
 import java.util.List;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Function;
+import java.util.function.Predicate;
 
 import io.cryostat.discovery.DiscoveryNode;
 import io.cryostat.graphql.RootNode.DiscoveryNodeFilterInput;
+import io.cryostat.recordings.RecordingHelper;
+import io.cryostat.recordings.Recordings.ArchivedRecording;
 import io.cryostat.targets.Target;
 
+import jakarta.inject.Inject;
+import org.apache.commons.lang3.StringUtils;
 import org.eclipse.microprofile.graphql.Description;
 import org.eclipse.microprofile.graphql.GraphQLApi;
+import org.eclipse.microprofile.graphql.NonNull;
 import org.eclipse.microprofile.graphql.Query;
+import org.eclipse.microprofile.graphql.Source;
 
 @GraphQLApi
 public class TargetNodes {
+
+    @Inject RecordingHelper recordingHelper;
 
     @Query("targetNodes")
     @Description("Get the Target discovery nodes, i.e. the leaf nodes of the discovery tree")
@@ -35,8 +47,42 @@ public class TargetNodes {
         // load the entire discovery tree out of the database, then perform the filtering at the
         // application level.
         return Target.<Target>findAll().stream()
+                .filter(distinctWith(t -> t.jvmId))
                 .map(t -> t.discoveryNode)
                 .filter(n -> filter == null ? true : filter.test(n))
                 .toList();
+    }
+
+    private static <T> Predicate<T> distinctWith(Function<? super T, ?> fn) {
+        Set<Object> observed = ConcurrentHashMap.newKeySet();
+        return t -> observed.add(fn.apply(t));
+    }
+
+    @Description("Get the active and archived recordings belonging to this target")
+    public Recordings recordings(@Source Target target) {
+        var recordings = new Recordings();
+
+        recordings.archived = new ArchivedRecordings();
+        recordings.archived.data = recordingHelper.listArchivedRecordings(target);
+        recordings.archived.aggregate = new AggregateInfo();
+        recordings.archived.aggregate.count = recordings.archived.data.size();
+        recordings.archived.aggregate.size =
+                recordings.archived.data.stream().mapToLong(ArchivedRecording::size).sum();
+
+        return recordings;
+    }
+
+    public static class Recordings {
+        public @NonNull ArchivedRecordings archived;
+    }
+
+    public static class ArchivedRecordings {
+        public @NonNull List<ArchivedRecording> data;
+        public @NonNull AggregateInfo aggregate;
+    }
+
+    public static class AggregateInfo {
+        public @NonNull long count;
+        public @NonNull long size;
     }
 }

--- a/src/main/java/io/cryostat/recordings/RecordingHelper.java
+++ b/src/main/java/io/cryostat/recordings/RecordingHelper.java
@@ -39,11 +39,13 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import org.openjdk.jmc.common.unit.IConstrainedMap;
+import org.openjdk.jmc.common.unit.QuantityConversionException;
 import org.openjdk.jmc.flightrecorder.configuration.events.EventOptionID;
 import org.openjdk.jmc.flightrecorder.configuration.recording.RecordingOptionsBuilder;
 import org.openjdk.jmc.rjmx.services.jfr.IEventTypeInfo;
@@ -193,109 +195,140 @@ public class RecordingHelper {
         }
     }
 
-    @Blocking
-    public ActiveRecording startRecording(
+    public Uni<ActiveRecording> startRecording(
             Target target,
-            IConstrainedMap<String> recordingOptions,
-            Template eventTemplate,
-            Metadata metadata,
             RecordingReplace replace,
-            JFRConnection connection)
-            throws Exception {
-        String recordingName = (String) recordingOptions.get(RecordingOptionsBuilder.KEY_NAME);
-        getDescriptorByName(connection, recordingName)
-                .ifPresent(
-                        previous -> {
-                            RecordingState previousState = mapState(previous);
-                            boolean restart =
-                                    shouldRestartRecording(replace, previousState, recordingName);
-                            if (!restart) {
-                                throw new EntityExistsException("Recording", recordingName);
-                            }
-                            if (!ActiveRecording.deleteFromTarget(target, recordingName)) {
-                                logger.warnf(
-                                        "Could not delete recording %s from target %s",
-                                        recordingName, target.alias);
-                            }
-                        });
+            Template template,
+            RecordingOptions options,
+            Map<String, String> rawLabels)
+            throws QuantityConversionException {
+        return connectionManager.executeConnectedTaskUni(
+                target,
+                conn -> {
+                    RecordingOptionsBuilder optionsBuilder =
+                            recordingOptionsBuilderFactory
+                                    .create(conn.getService())
+                                    .name(options.name());
+                    if (options.duration().isPresent()) {
+                        optionsBuilder =
+                                optionsBuilder.duration(
+                                        TimeUnit.SECONDS.toMillis(options.duration().get()));
+                    }
+                    if (options.toDisk().isPresent()) {
+                        optionsBuilder = optionsBuilder.toDisk(options.toDisk().get());
+                    }
+                    if (options.maxAge().isPresent()) {
+                        optionsBuilder = optionsBuilder.maxAge(options.maxAge().get());
+                    }
+                    if (options.maxSize().isPresent()) {
+                        optionsBuilder = optionsBuilder.maxSize(options.maxSize().get());
+                    }
+                    IConstrainedMap<String> recordingOptions = optionsBuilder.build();
+                    getDescriptorByName(conn, options.name())
+                            .ifPresent(
+                                    previous -> {
+                                        RecordingState previousState = mapState(previous);
+                                        boolean restart =
+                                                shouldRestartRecording(
+                                                        replace, previousState, options.name());
+                                        if (!restart) {
+                                            throw new EntityExistsException(
+                                                    "Recording", options.name());
+                                        }
+                                        if (!ActiveRecording.deleteFromTarget(
+                                                target, options.name())) {
+                                            logger.warnf(
+                                                    "Could not delete recording %s from target %s",
+                                                    options.name(), target.alias);
+                                        }
+                                    });
 
-        IRecordingDescriptor desc =
-                connection
-                        .getService()
-                        .start(recordingOptions, enableEvents(target, eventTemplate));
+                    IRecordingDescriptor desc =
+                            conn.getService()
+                                    .start(recordingOptions, enableEvents(target, template));
 
-        Map<String, String> labels = metadata.labels();
-        labels.put("template.name", eventTemplate.getName());
-        labels.put("template.type", eventTemplate.getType().toString());
-        Metadata meta = new Metadata(labels);
+                    Map<String, String> labels = new HashMap<>(rawLabels);
+                    labels.put("template.name", template.getName());
+                    labels.put("template.type", template.getType().toString());
+                    Metadata meta = new Metadata(labels);
 
-        ActiveRecording recording = ActiveRecording.from(target, desc, meta);
-        recording.persist();
+                    ActiveRecording recording = ActiveRecording.from(target, desc, meta);
+                    recording.persist();
 
-        target.activeRecordings.add(recording);
-        target.persist();
+                    target.activeRecordings.add(recording);
+                    target.persist();
 
-        logger.tracev("Started recording: {0} {1}", target.connectUrl, target.activeRecordings);
-
-        return recording;
+                    logger.tracev(
+                            "Started recording: {0} {1}",
+                            target.connectUrl, target.activeRecordings);
+                    return recording;
+                });
     }
 
     @Blocking
-    public ActiveRecording createSnapshot(Target target, JFRConnection connection)
-            throws Exception {
-        IRecordingDescriptor desc = connection.getService().getSnapshotRecording();
+    public Uni<ActiveRecording> createSnapshot(Target target) {
+        return connectionManager.executeConnectedTaskUni(
+                target,
+                connection -> {
+                    IRecordingDescriptor desc = connection.getService().getSnapshotRecording();
 
-        String rename = String.format("%s-%d", desc.getName().toLowerCase(), desc.getId());
+                    String rename =
+                            String.format("%s-%d", desc.getName().toLowerCase(), desc.getId());
 
-        RecordingOptionsBuilder recordingOptionsBuilder =
-                recordingOptionsBuilderFactory.create(connection.getService());
-        recordingOptionsBuilder.name(rename);
+                    RecordingOptionsBuilder recordingOptionsBuilder =
+                            recordingOptionsBuilderFactory.create(connection.getService());
+                    recordingOptionsBuilder.name(rename);
 
-        connection.getService().updateRecordingOptions(desc, recordingOptionsBuilder.build());
+                    connection
+                            .getService()
+                            .updateRecordingOptions(desc, recordingOptionsBuilder.build());
 
-        Optional<IRecordingDescriptor> updatedDescriptor = getDescriptorByName(connection, rename);
+                    Optional<IRecordingDescriptor> updatedDescriptor =
+                            getDescriptorByName(connection, rename);
 
-        if (updatedDescriptor.isEmpty()) {
-            throw new IllegalStateException(
-                    "The most recent snapshot of the recording cannot be"
-                            + " found after renaming.");
-        }
+                    if (updatedDescriptor.isEmpty()) {
+                        throw new IllegalStateException(
+                                "The most recent snapshot of the recording cannot be"
+                                        + " found after renaming.");
+                    }
 
-        desc = updatedDescriptor.get();
+                    desc = updatedDescriptor.get();
 
-        try (InputStream snapshot = remoteRecordingStreamFactory.open(connection, target, desc)) {
-            if (!snapshotIsReadable(target, snapshot)) {
-                connection.getService().close(desc);
-                throw new SnapshotCreationException(
-                        "Snapshot was not readable - are there any source recordings?");
-            }
-        }
+                    try (InputStream snapshot =
+                            remoteRecordingStreamFactory.open(connection, target, desc)) {
+                        if (!snapshotIsReadable(target, snapshot)) {
+                            connection.getService().close(desc);
+                            throw new SnapshotCreationException(
+                                    "Snapshot was not readable - are there any source recordings?");
+                        }
+                    }
 
-        ActiveRecording recording =
-                ActiveRecording.from(
-                        target,
-                        desc,
-                        new Metadata(
-                                Map.of(
-                                        "jvmId",
-                                        target.jvmId,
-                                        "connectUrl",
-                                        target.connectUrl.toString())));
-        recording.persist();
+                    ActiveRecording recording =
+                            ActiveRecording.from(
+                                    target,
+                                    desc,
+                                    new Metadata(
+                                            Map.of(
+                                                    "jvmId",
+                                                    target.jvmId,
+                                                    "connectUrl",
+                                                    target.connectUrl.toString())));
+                    recording.persist();
 
-        target.activeRecordings.add(recording);
-        target.persist();
+                    target.activeRecordings.add(recording);
+                    target.persist();
 
-        var event =
-                new ActiveRecordingEvent(
-                        Recordings.RecordingEventCategory.SNAPSHOT_CREATED,
-                        ActiveRecordingEvent.Payload.of(this, recording));
-        bus.publish(event.category().category(), event.payload().recording());
-        bus.publish(
-                MessagingServer.class.getName(),
-                new Notification(event.category().category(), event.payload()));
+                    var event =
+                            new ActiveRecordingEvent(
+                                    Recordings.RecordingEventCategory.SNAPSHOT_CREATED,
+                                    ActiveRecordingEvent.Payload.of(this, recording));
+                    bus.publish(event.category().category(), event.payload().recording());
+                    bus.publish(
+                            MessagingServer.class.getName(),
+                            new Notification(event.category().category(), event.payload()));
 
-        return recording;
+                    return recording;
+                });
     }
 
     @Blocking
@@ -401,7 +434,7 @@ public class RecordingHelper {
 
     @Blocking
     public Template getPreferredTemplate(
-            Target target, String templateName, TemplateType templateType) throws Exception {
+            Target target, String templateName, TemplateType templateType) {
         Objects.requireNonNull(target);
         Objects.requireNonNull(templateName);
         if (templateName.equals(EventTemplates.ALL_EVENTS_TEMPLATE.getName())) {
@@ -990,6 +1023,14 @@ public class RecordingHelper {
                             }
                         });
     }
+
+    public record RecordingOptions(
+            String name,
+            Optional<Boolean> toDisk,
+            Optional<Boolean> archiveOnStop,
+            Optional<Long> duration,
+            Optional<Long> maxSize,
+            Optional<Long> maxAge) {}
 
     public enum RecordingReplace {
         ALWAYS,

--- a/src/main/java/io/cryostat/recordings/RecordingHelper.java
+++ b/src/main/java/io/cryostat/recordings/RecordingHelper.java
@@ -199,7 +199,6 @@ public class RecordingHelper {
             IConstrainedMap<String> recordingOptions,
             Template eventTemplate,
             Metadata metadata,
-            boolean archiveOnStop,
             RecordingReplace replace,
             JFRConnection connection)
             throws Exception {

--- a/src/main/java/io/cryostat/recordings/Recordings.java
+++ b/src/main/java/io/cryostat/recordings/Recordings.java
@@ -631,7 +631,6 @@ public class Recordings {
                                     recordingOptions,
                                     template,
                                     new Metadata(labels),
-                                    archiveOnStop.orElse(false),
                                     replacement,
                                     connection);
                         });

--- a/src/main/java/io/cryostat/recordings/Recordings.java
+++ b/src/main/java/io/cryostat/recordings/Recordings.java
@@ -176,29 +176,7 @@ public class Recordings {
     @Path("/api/v1/recordings")
     @RolesAllowed("read")
     public List<ArchivedRecording> listArchivesV1() {
-        var result = new ArrayList<ArchivedRecording>();
-        recordingHelper
-                .listArchivedRecordingObjects()
-                .forEach(
-                        item -> {
-                            String path = item.key().strip();
-                            String[] parts = path.split("/");
-                            String jvmId = parts[0];
-                            String filename = parts[1];
-                            Metadata metadata =
-                                    recordingHelper
-                                            .getArchivedRecordingMetadata(jvmId, filename)
-                                            .orElseGet(Metadata::empty);
-                            result.add(
-                                    new ArchivedRecording(
-                                            filename,
-                                            recordingHelper.downloadUrl(jvmId, filename),
-                                            recordingHelper.reportUrl(jvmId, filename),
-                                            metadata,
-                                            item.size(),
-                                            item.lastModified().getEpochSecond()));
-                        });
-        return result;
+        return recordingHelper.listArchivedRecordings();
     }
 
     @POST

--- a/src/main/java/io/cryostat/recordings/Recordings.java
+++ b/src/main/java/io/cryostat/recordings/Recordings.java
@@ -51,6 +51,7 @@ import io.cryostat.core.sys.Clock;
 import io.cryostat.core.templates.Template;
 import io.cryostat.core.templates.TemplateType;
 import io.cryostat.recordings.ActiveRecording.Listener.ArchivedRecordingEvent;
+import io.cryostat.recordings.RecordingHelper.RecordingOptions;
 import io.cryostat.recordings.RecordingHelper.RecordingReplace;
 import io.cryostat.recordings.RecordingHelper.SnapshotCreationException;
 import io.cryostat.targets.Target;
@@ -503,9 +504,8 @@ public class Recordings {
     @RolesAllowed("write")
     public Uni<Response> createSnapshotV1(@RestPath URI connectUrl) throws Exception {
         Target target = Target.getTargetByConnectUrl(connectUrl);
-        return connectionManager
-                .executeConnectedTaskUni(
-                        target, connection -> recordingHelper.createSnapshot(target, connection))
+        return recordingHelper
+                .createSnapshot(target)
                 .onItem()
                 .transform(
                         recording ->
@@ -520,9 +520,8 @@ public class Recordings {
     @RolesAllowed("write")
     public Uni<Response> createSnapshotV2(@RestPath URI connectUrl) throws Exception {
         Target target = Target.getTargetByConnectUrl(connectUrl);
-        return connectionManager
-                .executeConnectedTaskUni(
-                        target, connection -> recordingHelper.createSnapshot(target, connection))
+        return recordingHelper
+                .createSnapshot(target)
                 .onItem()
                 .transform(
                         recording ->
@@ -545,9 +544,8 @@ public class Recordings {
     @RolesAllowed("write")
     public Uni<Response> createSnapshot(@RestPath long id) throws Exception {
         Target target = Target.find("id", id).singleResult();
-        return connectionManager
-                .executeConnectedTaskUni(
-                        target, connection -> recordingHelper.createSnapshot(target, connection))
+        return recordingHelper
+                .createSnapshot(target)
                 .onItem()
                 .transform(
                         recording ->
@@ -591,49 +589,32 @@ public class Recordings {
         Template template =
                 recordingHelper.getPreferredTemplate(target, pair.getKey(), pair.getValue());
 
+        Map<String, String> labels = new HashMap<>();
+        if (rawMetadata.isPresent()) {
+            labels.putAll(mapper.readValue(rawMetadata.get(), Metadata.class).labels);
+        }
+        RecordingReplace replacement = RecordingReplace.NEVER;
+        if (replace.isPresent()) {
+            replacement = RecordingReplace.fromString(replace.get());
+        } else if (restart.isPresent()) {
+            replacement = restart.get() ? RecordingReplace.ALWAYS : RecordingReplace.NEVER;
+        }
         ActiveRecording recording =
-                connectionManager.executeConnectedTask(
-                        target,
-                        connection -> {
-                            RecordingOptionsBuilder optionsBuilder =
-                                    recordingOptionsBuilderFactory
-                                            .create(connection.getService())
-                                            .name(recordingName);
-                            if (duration.isPresent()) {
-                                optionsBuilder.duration(TimeUnit.SECONDS.toMillis(duration.get()));
-                            }
-                            if (toDisk.isPresent()) {
-                                optionsBuilder.toDisk(toDisk.get());
-                            }
-                            if (maxAge.isPresent()) {
-                                optionsBuilder.maxAge(maxAge.get());
-                            }
-                            if (maxSize.isPresent()) {
-                                optionsBuilder.maxSize(maxSize.get());
-                            }
-                            Map<String, String> labels = new HashMap<>();
-                            if (rawMetadata.isPresent()) {
-                                labels.putAll(
-                                        mapper.readValue(rawMetadata.get(), Metadata.class).labels);
-                            }
-                            RecordingReplace replacement = RecordingReplace.NEVER;
-                            if (replace.isPresent()) {
-                                replacement = RecordingReplace.fromString(replace.get());
-                            } else if (restart.isPresent()) {
-                                replacement =
-                                        restart.get()
-                                                ? RecordingReplace.ALWAYS
-                                                : RecordingReplace.NEVER;
-                            }
-                            IConstrainedMap<String> recordingOptions = optionsBuilder.build();
-                            return recordingHelper.startRecording(
-                                    target,
-                                    recordingOptions,
-                                    template,
-                                    new Metadata(labels),
-                                    replacement,
-                                    connection);
-                        });
+                recordingHelper
+                        .startRecording(
+                                target,
+                                replacement,
+                                template,
+                                new RecordingOptions(
+                                        recordingName,
+                                        toDisk,
+                                        archiveOnStop,
+                                        duration,
+                                        maxSize,
+                                        maxAge),
+                                labels)
+                        .await()
+                        .atMost(Duration.ofSeconds(10));
 
         if (recording.duration > 0) {
             scheduler.schedule(

--- a/src/main/java/io/cryostat/rules/RuleService.java
+++ b/src/main/java/io/cryostat/rules/RuleService.java
@@ -159,7 +159,6 @@ public class RuleService {
                                     recordingOptions,
                                     template,
                                     meta,
-                                    false,
                                     RecordingReplace.ALWAYS,
                                     connection);
                         });

--- a/src/main/java/io/cryostat/ws/MessagingServer.java
+++ b/src/main/java/io/cryostat/ws/MessagingServer.java
@@ -47,11 +47,11 @@ public class MessagingServer {
 
     private static final String CLIENT_ACTIVITY_CATEGORY = "WsClientActivity";
 
+    @Inject ObjectMapper mapper;
     @Inject Logger logger;
     private final ExecutorService executor = Executors.newSingleThreadExecutor();
     private final BlockingQueue<Notification> msgQ;
     private final Set<Session> sessions = new CopyOnWriteArraySet<>();
-    private final ObjectMapper mapper = new ObjectMapper();
 
     MessagingServer(@ConfigProperty(name = "cryostat.messaging.queue.size") int capacity) {
         this.msgQ = new ArrayBlockingQueue<>(capacity);

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -41,6 +41,7 @@ quarkus.smallrye-openapi.info-contact-url=https://cryostat.io
 quarkus.smallrye-openapi.info-license-name=Apache 2.0
 quarkus.smallrye-openapi.info-license-url=https://github.com/cryostatio/cryostat3/blob/main/LICENSE
 
+quarkus.smallrye-graphql.events.enabled=true
 quarkus.smallrye-graphql.root-path=/api/v3/graphql
 quarkus.smallrye-graphql.http.get.enabled=true
 quarkus.smallrye-graphql.print-data-fetcher-exception=true

--- a/src/test/java/itest/CustomTargetsTest.java
+++ b/src/test/java/itest/CustomTargetsTest.java
@@ -16,6 +16,7 @@
 package itest;
 
 import java.net.UnknownHostException;
+import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.CountDownLatch;
@@ -224,16 +225,21 @@ public class CustomTargetsTest extends StandardSelfTest {
         MatcherAssert.assertThat(item.getString("jvmId"), Matchers.equalTo(itestJvmId));
         MatcherAssert.assertThat(item.getString("alias"), Matchers.equalTo(alias));
         MatcherAssert.assertThat(item.getString("connectUrl"), Matchers.equalTo(SELF_JMX_URL));
-        MatcherAssert.assertThat(item.getJsonObject("labels"), Matchers.equalTo(new JsonObject()));
+        MatcherAssert.assertThat(item.getJsonArray("labels"), Matchers.equalTo(new JsonArray()));
         MatcherAssert.assertThat(
                 item.getJsonObject("annotations"),
                 Matchers.equalTo(
                         new JsonObject(
                                 Map.of(
                                         "platform",
-                                        Map.of(),
+                                        List.of(),
                                         "cryostat",
-                                        Map.of("REALM", "Custom Targets")))));
+                                        List.of(
+                                                Map.of(
+                                                        "key",
+                                                        "REALM",
+                                                        "value",
+                                                        "Custom Targets"))))));
     }
 
     @Test


### PR DESCRIPTION
# Welcome to Cryostat3! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat3/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] [Signed all commits using a GPG signature](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#gpg-commit-signature-verification)

**To recreate commits with GPG signature** `git fetch upstream && git rebase --force --gpg-sign upstream/main`
_______________________________________________

Based on https://github.com/cryostatio/cryostat3/pull/294
Depends on https://github.com/cryostatio/cryostat-core/pull/357
Depends on https://github.com/cryostatio/cryostat-core/pull/358
Depends on https://github.com/cryostatio/cryostat3/pull/310

## Description of the change:
*This change allows an environment variable to be configured so that...*

## Motivation for the change:
*This change is helpful because users may want to...*

## How to manually test:
1. *Run CRYOSTAT_IMAGE=quay.io... bash smoketest.bash...*
2. `$ http --follow -v --auth=user:pass :8080/api/v3/graphql/schema.graphql` and ensure new schema contains top-level query and subqueries
3. Open web UI, select `localhost:0` target, archive both recordings. Wait a short while, then archive both again.
4. `$ http --follow -v --auth=user:pass :8080/api/v2.2/graphql query='query { targetNodes { target { connectUrl jvmId recordings { active { aggregate { count } data { name } } archived { aggregate { count size } data { name } } } } } }'`

```
$ http --follow -v --auth=user:pass :8080/api/v2.2/graphql query='query { targetNodes { target { connectUrl jvmId recordings { active { aggregate { count } data { name } } archived { aggregate { count size } data { name size } } } } } }'
POST /api/v2.2/graphql HTTP/1.1
Accept: application/json, */*;q=0.5
Accept-Encoding: gzip, deflate, br
Authorization: Basic dXNlcjpwYXNz
Connection: keep-alive
Content-Length: 183
Content-Type: application/json
Host: localhost:8080
User-Agent: HTTPie/3.2.2

{
    "query": "query { targetNodes { target { connectUrl jvmId recordings { active { aggregate { count } data { name } } archived { aggregate { count size } data { name size } } } } } }"
}


HTTP/1.1 308 Permanent Redirect
Content-Encoding: identity
Content-Length: 0
Date: Tue, 27 Feb 2024 19:53:00 GMT
Gap-Auth: user
Location: http://localhost:8080/api/v3/graphql



POST /api/v3/graphql HTTP/1.1
Accept: application/json, */*;q=0.5
Accept-Encoding: gzip, deflate, br
Authorization: Basic dXNlcjpwYXNz
Connection: keep-alive
Content-Length: 183
Content-Type: application/json
Host: localhost:8080
User-Agent: HTTPie/3.2.2

{
    "query": "query { targetNodes { target { connectUrl jvmId recordings { active { aggregate { count } data { name } } archived { aggregate { count size } data { name size } } } } } }"
}


HTTP/1.1 200 OK
Content-Length: 870
Content-Type: application/json
Date: Tue, 27 Feb 2024 19:53:00 GMT
Gap-Auth: user

{
    "data": {
        "targetNodes": [
            {
                "target": {
                    "connectUrl": "service:jmx:rmi:///jndi/rmi://localhost:0/jmxrmi",
                    "jvmId": "l7nbjOnSzkgpICnAWAsJ3T4nnNUHL1fLkEwFImQW1OQ=",
                    "recordings": {
                        "active": {
                            "aggregate": {
                                "count": 2
                            },
                            "data": [
                                {
                                    "name": "onstart"
                                },
                                {
                                    "name": "startup"
                                }
                            ]
                        },
                        "archived": {
                            "aggregate": {
                                "count": 4,
                                "size": 15707814
                            },
                            "data": [
                                {
                                    "name": "compose-cryostat-1_onstart_20240227T195230Z.jfr",
                                    "size": 3841100
                                },
                                {
                                    "name": "compose-cryostat-1_onstart_20240227T195239Z.jfr",
                                    "size": 4791696
                                },
                                {
                                    "name": "compose-cryostat-1_startup_20240227T195230Z.jfr",
                                    "size": 3537509
                                },
                                {
                                    "name": "compose-cryostat-1_startup_20240227T195239Z.jfr",
                                    "size": 3537509
                                }
                            ]
                        }
                    }
                }
            },
            {
                "target": {
                    "connectUrl": "service:jmx:rmi:///jndi/rmi://jfr-datasource:11223/jmxrmi",
                    "jvmId": "AJUhBprW6p1h8oaU2hGToT0ejRahSC_jplYUzIxCsa0=",
                    "recordings": {
                        "active": {
                            "aggregate": {
                                "count": 0
                            },
                            "data": []
                        },
                        "archived": {
                            "aggregate": {
                                "count": 0,
                                "size": 0
                            },
                            "data": []
                        }
                    }
                }
            }
        ]
    }
}
```

----

```
$ http --follow -v --auth=user:pass :8080/api/v2.2/graphql query='query { targetNodes { target { connectUrl jvmId recordings { active(filter: { names: ["onstart"] }) { aggregate { count } data { name startTime id remoteId metadata { labels { key value } } } } archived { aggregate { count size } data { name size } } } } } }'
POST /api/v2.2/graphql HTTP/1.1
Accept: application/json, */*;q=0.5
Accept-Encoding: gzip, deflate, br
Authorization: Basic dXNlcjpwYXNz
Connection: keep-alive
Content-Length: 273
Content-Type: application/json
Host: localhost:8080
User-Agent: HTTPie/3.2.2

{
    "query": "query { targetNodes { target { connectUrl jvmId recordings { active(filter: { names: [\"onstart\"] }) { aggregate { count } data { name startTime id remoteId metadata { labels { key value } } } } archived { aggregate { count size } data { name size } } } } } }"
}


HTTP/1.1 308 Permanent Redirect
Content-Encoding: identity
Content-Length: 0
Date: Tue, 27 Feb 2024 20:26:33 GMT
Gap-Auth: user
Location: http://localhost:8080/api/v3/graphql



POST /api/v3/graphql HTTP/1.1
Accept: application/json, */*;q=0.5
Accept-Encoding: gzip, deflate, br
Authorization: Basic dXNlcjpwYXNz
Connection: keep-alive
Content-Length: 273
Content-Type: application/json
Host: localhost:8080
User-Agent: HTTPie/3.2.2

{
    "query": "query { targetNodes { target { connectUrl jvmId recordings { active(filter: { names: [\"onstart\"] }) { aggregate { count } data { name startTime id remoteId metadata { labels { key value } } } } archived { aggregate { count size } data { name size } } } } } }"
}


HTTP/1.1 200 OK
Content-Length: 620
Content-Type: application/json
Date: Tue, 27 Feb 2024 20:26:33 GMT
Gap-Auth: user

{
    "data": {
        "targetNodes": [
            {
                "target": {
                    "connectUrl": "service:jmx:rmi:///jndi/rmi://jfr-datasource:11223/jmxrmi",
                    "jvmId": "EAN-0a170eS7CZfGI1zeBY3pECQvKF8BXc3_3hzlLl8=",
                    "recordings": {
                        "active": {
                            "aggregate": {
                                "count": 0
                            },
                            "data": []
                        },
                        "archived": {
                            "aggregate": {
                                "count": 0,
                                "size": 0
                            },
                            "data": []
                        }
                    }
                }
            },
            {
                "target": {
                    "connectUrl": "service:jmx:rmi:///jndi/rmi://localhost:0/jmxrmi",
                    "jvmId": "RG5KydIvRsZ3lJV57s5TZ5duoXZFWwDt2kS25C9FehU=",
                    "recordings": {
                        "active": {
                            "aggregate": {
                                "count": 1
                            },
                            "data": [
                                {
                                    "id": 1,
                                    "metadata": {
                                        "labels": []
                                    },
                                    "name": "onstart",
                                    "remoteId": 1,
                                    "startTime": 1709065431004
                                }
                            ]
                        },
                        "archived": {
                            "aggregate": {
                                "count": 0,
                                "size": 0
                            },
                            "data": []
                        }
                    }
                }
            }
        ]
    }
}
```
