### PR TITLE
feat(graphql): add top-level query for environmentNodes

### DIFF
--- a/src/main/java/io/cryostat/graphql/EnvironmentNodeGraphQL.java
+++ b/src/main/java/io/cryostat/graphql/EnvironmentNodeGraphQL.java
@@ -1,0 +1,133 @@
+package io.cryostat.graphql;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+import org.eclipse.microprofile.graphql.Description;
+import org.eclipse.microprofile.graphql.GraphQLApi;
+import org.eclipse.microprofile.graphql.Query;
+
+import io.cryostat.discovery.DiscoveryNode;
+import io.smallrye.graphql.api.Nullable;
+
+@GraphQLApi
+public class EnvironmentNodeGraphQL {
+
+    public static class EnvironmentNodeFilterInput {
+        @Nullable
+        public Long id;
+        @Nullable
+        public String name;
+        @Nullable
+        public List<String> names;
+        @Nullable
+        public String nodeType;
+        @Nullable
+        public List<String> labels;
+
+    }
+
+    public static class EnvironmentNode {
+        private Long id;
+        private String name;
+        private List<String> labels;
+        private String nodeType;
+        private List<EnvironmentNode> children;
+
+        public Long getId(){
+            return this.id;
+        }
+
+        public String getName(){
+            return this.name;
+        }
+
+        public List<String> getLabels(){
+            return this.labels;
+        }
+
+        public String getNodeType(){
+            return this.nodeType;
+        }
+
+        public List<EnvironmentNode> getChildren(){
+            return this.children;
+        }
+
+        public void setId(Long id) {
+            this.id = id;
+        }
+
+        public void setName(String name) {
+            this.name = name;
+        }
+
+        public void setLabels(List<String> labels) {
+            this.labels = labels;
+        }
+
+        public void setNodeType(String nodeType) {
+            this.nodeType = nodeType;
+        }
+
+        public void addChild(EnvironmentNode child) {
+            if (this.children == null) {
+                this.children = new ArrayList<>();
+            }
+            this.children.add(child);
+        }
+    }
+
+    @Query("environmentNodes")
+    @Description("Get all environment nodes in the discovery tree with optional filtering")
+    public List<EnvironmentNode> environmentNodes(EnvironmentNodeFilterInput filter) {
+        DiscoveryNode rootNode = DiscoveryNode.getUniverse();
+        return filterAndTraverse(rootNode, filter).stream()
+            .map(EnvironmentNodeGraphQL::convertDiscoveryNodeToEnvironmentNode)
+            .collect(Collectors.toList());
+    }
+
+    private List<DiscoveryNode> filterAndTraverse(DiscoveryNode node, EnvironmentNodeFilterInput filter) {
+        List<DiscoveryNode> filteredNodes = new ArrayList<>();
+        if (matchesFilter(node, filter)) {
+            filteredNodes.add(node);
+        }
+        if (node.children != null) {
+            for (DiscoveryNode child : node.children) {
+                filteredNodes.addAll(filterAndTraverse(child, filter));
+            }
+        }
+        return filteredNodes;
+    }
+
+    private static boolean matchesFilter(DiscoveryNode node, EnvironmentNodeFilterInput filter) {
+        if (filter == null) return true;
+
+        boolean matchesId = filter.id == null || filter.id.equals(node.id);
+        boolean matchesName = filter.name == null || Objects.equals(filter.name, node.name);
+        boolean matchesNames = filter.names == null || filter.names.contains(node.name);
+        boolean matchesLabels = filter.labels == null || filter.labels.stream().allMatch(label -> node.labels.containsKey(label));
+        boolean matchesNodeType = filter.nodeType == null || filter.nodeType.equals(node.nodeType);
+
+        return matchesId && matchesName && matchesNames && matchesLabels && matchesNodeType;
+    }
+
+    private static EnvironmentNode convertDiscoveryNodeToEnvironmentNode(DiscoveryNode discoveryNode) {
+        EnvironmentNode envNode = new EnvironmentNode();
+        envNode.setId(discoveryNode.id);
+        envNode.setName(discoveryNode.name);
+        List<String> labelsList = discoveryNode.labels.entrySet().stream()
+        .map(entry -> entry.getKey() + "=" + entry.getValue())
+        .collect(Collectors.toList());
+        envNode.setLabels(labelsList);
+        envNode.setNodeType(discoveryNode.nodeType);
+        if (discoveryNode.children != null) {
+            for (DiscoveryNode child : discoveryNode.children) {
+                envNode.addChild(convertDiscoveryNodeToEnvironmentNode(child));
+            }
+        }
+        return envNode;
+    }
+}

--- a/src/main/java/io/cryostat/graphql/EnvironmentNodes.java
+++ b/src/main/java/io/cryostat/graphql/EnvironmentNodes.java
@@ -20,6 +20,7 @@ import java.util.List;
 import java.util.Objects;
 
 import io.cryostat.discovery.DiscoveryNode;
+import io.cryostat.graphql.matchers.LabelSelectorMatcher;
 
 import io.smallrye.graphql.api.Nullable;
 import org.eclipse.microprofile.graphql.Description;
@@ -67,7 +68,11 @@ public class EnvironmentNodes {
         boolean matchesNames = filter.names == null || filter.names.contains(node.name);
         boolean matchesLabels =
                 filter.labels == null
-                        || filter.labels.stream().allMatch(label -> node.labels.containsKey(label));
+                        || filter.labels.stream()
+                                .allMatch(
+                                        label ->
+                                                LabelSelectorMatcher.parse(label)
+                                                        .test(node.labels));
         boolean matchesNodeType = filter.nodeType == null || filter.nodeType.equals(node.nodeType);
 
         return matchesId && matchesName && matchesNames && matchesLabels && matchesNodeType;

--- a/src/main/java/io/cryostat/graphql/EnvironmentNodes.java
+++ b/src/main/java/io/cryostat/graphql/EnvironmentNodes.java
@@ -1,95 +1,51 @@
+/*
+ * Copyright The Cryostat Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.cryostat.graphql;
 
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
-import java.util.stream.Collectors;
 
+import io.cryostat.discovery.DiscoveryNode;
+
+import io.smallrye.graphql.api.Nullable;
 import org.eclipse.microprofile.graphql.Description;
 import org.eclipse.microprofile.graphql.GraphQLApi;
 import org.eclipse.microprofile.graphql.Query;
-
-import io.cryostat.discovery.DiscoveryNode;
-import io.smallrye.graphql.api.Nullable;
 
 @GraphQLApi
 public class EnvironmentNodes {
 
     public static class EnvironmentNodeFilterInput {
-        @Nullable
-        public Long id;
-        @Nullable
-        public String name;
-        @Nullable
-        public List<String> names;
-        @Nullable
-        public String nodeType;
-        @Nullable
-        public List<String> labels;
-
-    }
-
-    public static class EnvironmentNode {
-        private Long id;
-        private String name;
-        private List<String> labels;
-        private String nodeType;
-        private List<EnvironmentNode> children;
-
-        public Long getId(){
-            return this.id;
-        }
-
-        public String getName(){
-            return this.name;
-        }
-
-        public List<String> getLabels(){
-            return this.labels;
-        }
-
-        public String getNodeType(){
-            return this.nodeType;
-        }
-
-        public List<EnvironmentNode> getChildren(){
-            return this.children;
-        }
-
-        public void setId(Long id) {
-            this.id = id;
-        }
-
-        public void setName(String name) {
-            this.name = name;
-        }
-
-        public void setLabels(List<String> labels) {
-            this.labels = labels;
-        }
-
-        public void setNodeType(String nodeType) {
-            this.nodeType = nodeType;
-        }
-
-        public void addChild(EnvironmentNode child) {
-            if (this.children == null) {
-                this.children = new ArrayList<>();
-            }
-            this.children.add(child);
-        }
+        @Nullable public Long id;
+        @Nullable public String name;
+        @Nullable public List<String> names;
+        @Nullable public String nodeType;
+        @Nullable public List<String> labels;
     }
 
     @Query("environmentNodes")
     @Description("Get all environment nodes in the discovery tree with optional filtering")
-    public List<EnvironmentNode> environmentNodes(EnvironmentNodeFilterInput filter) {
+    public List<DiscoveryNode> environmentNodes(EnvironmentNodeFilterInput filter) {
         DiscoveryNode rootNode = DiscoveryNode.getUniverse();
-        return filterAndTraverse(rootNode, filter).stream()
-            .map(EnvironmentNodes::convertDiscoveryNodeToEnvironmentNode)
-            .collect(Collectors.toList());
+        return filterAndTraverse(rootNode, filter);
     }
 
-    private List<DiscoveryNode> filterAndTraverse(DiscoveryNode node, EnvironmentNodeFilterInput filter) {
+    private List<DiscoveryNode> filterAndTraverse(
+            DiscoveryNode node, EnvironmentNodeFilterInput filter) {
         List<DiscoveryNode> filteredNodes = new ArrayList<>();
         if (matchesFilter(node, filter)) {
             filteredNodes.add(node);
@@ -103,31 +59,17 @@ public class EnvironmentNodes {
     }
 
     private static boolean matchesFilter(DiscoveryNode node, EnvironmentNodeFilterInput filter) {
+        if (node.target != null) return false;
         if (filter == null) return true;
 
         boolean matchesId = filter.id == null || filter.id.equals(node.id);
         boolean matchesName = filter.name == null || Objects.equals(filter.name, node.name);
         boolean matchesNames = filter.names == null || filter.names.contains(node.name);
-        boolean matchesLabels = filter.labels == null || filter.labels.stream().allMatch(label -> node.labels.containsKey(label));
+        boolean matchesLabels =
+                filter.labels == null
+                        || filter.labels.stream().allMatch(label -> node.labels.containsKey(label));
         boolean matchesNodeType = filter.nodeType == null || filter.nodeType.equals(node.nodeType);
 
         return matchesId && matchesName && matchesNames && matchesLabels && matchesNodeType;
-    }
-
-    private static EnvironmentNode convertDiscoveryNodeToEnvironmentNode(DiscoveryNode discoveryNode) {
-        EnvironmentNode envNode = new EnvironmentNode();
-        envNode.setId(discoveryNode.id);
-        envNode.setName(discoveryNode.name);
-        List<String> labelsList = discoveryNode.labels.entrySet().stream()
-        .map(entry -> entry.getKey() + "=" + entry.getValue())
-        .collect(Collectors.toList());
-        envNode.setLabels(labelsList);
-        envNode.setNodeType(discoveryNode.nodeType);
-        if (discoveryNode.children != null) {
-            for (DiscoveryNode child : discoveryNode.children) {
-                envNode.addChild(convertDiscoveryNodeToEnvironmentNode(child));
-            }
-        }
-        return envNode;
     }
 }

--- a/src/main/java/io/cryostat/graphql/EnvironmentNodes.java
+++ b/src/main/java/io/cryostat/graphql/EnvironmentNodes.java
@@ -13,7 +13,7 @@ import io.cryostat.discovery.DiscoveryNode;
 import io.smallrye.graphql.api.Nullable;
 
 @GraphQLApi
-public class EnvironmentNodeGraphQL {
+public class EnvironmentNodes {
 
     public static class EnvironmentNodeFilterInput {
         @Nullable
@@ -85,7 +85,7 @@ public class EnvironmentNodeGraphQL {
     public List<EnvironmentNode> environmentNodes(EnvironmentNodeFilterInput filter) {
         DiscoveryNode rootNode = DiscoveryNode.getUniverse();
         return filterAndTraverse(rootNode, filter).stream()
-            .map(EnvironmentNodeGraphQL::convertDiscoveryNodeToEnvironmentNode)
+            .map(EnvironmentNodes::convertDiscoveryNodeToEnvironmentNode)
             .collect(Collectors.toList());
     }
 


### PR DESCRIPTION
# Welcome to Cryostat3! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat3/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] [Signed all commits using a GPG signature](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#gpg-commit-signature-verification)

**To recreate commits with GPG signature** `git fetch upstream && git rebase --force --gpg-sign upstream/main`
_______________________________________________

Based on: #294 

## Description of the change:
*This change allows an environment variable to be configured so that...*

## Motivation for the change:
*This change is helpful because users may want to...*

## How to manually test:
1. *Run CRYOSTAT_IMAGE=quay.io... bash smoketest.bash -O...*
2. `$ http --follow -v --auth=user:pass :8080/api/v3/graphql/schema.graphql` and ensure new schema contains top-level query and subqueries.
3. ` http --follow -v --auth=user:pass :8080/api/v2.2/graphql query='query { environmentNodes(filter: { nodeType: "Realm" }) { id name nodeType labels { key value } children { id name nodeType labels { key value } } } }'` change the filter to filter by name i.e ` http --follow -v --auth=user:pass :8080/api/v2.2/graphql query='query { environmentNodes(filter: { name: "JDP" }) { id name nodeType labels { key value } children { id name nodeType labels { key value } } } }'` . If a match is not found you should get empty array for `environmentNodes`

- Example of filter by `nodeType`

```❯ http --follow -v --auth=user:pass :8080/api/v2.2/graphql query='query { environmentNodes(filter: { nodeType: "Real" }) { id name nodeType labels { key value } children { id name nodeType labels { key value } } } }'

POST /api/v2.2/graphql HTTP/1.1
Accept: application/json, */*;q=0.5
Accept-Encoding: gzip, deflate
Authorization: Basic dXNlcjpwYXNz
Connection: keep-alive
Content-Length: 164
Content-Type: application/json
Host: localhost:8080
User-Agent: HTTPie/3.2.2

{
    "query": "query { environmentNodes(filter: { nodeType: \"Real\" }) { id name nodeType labels { key value } children { id name nodeType labels { key value } } } }"
}


HTTP/1.1 308 Permanent Redirect
Content-Encoding: identity
Content-Length: 0
Date: Thu, 29 Feb 2024 02:08:27 GMT
Gap-Auth: user
Location: http://localhost:8080/api/v3/graphql



POST /api/v3/graphql HTTP/1.1
Accept: application/json, */*;q=0.5
Accept-Encoding: gzip, deflate
Authorization: Basic dXNlcjpwYXNz
Connection: keep-alive
Content-Length: 164
Content-Type: application/json
Host: localhost:8080
User-Agent: HTTPie/3.2.2

{
    "query": "query { environmentNodes(filter: { nodeType: \"Real\" }) { id name nodeType labels { key value } children { id name nodeType labels { key value } } } }"
}


HTTP/1.1 200 OK
Content-Length: 32
Content-Type: application/json
Date: Thu, 29 Feb 2024 02:08:27 GMT
Gap-Auth: user

{
    "data": {
        "environmentNodes": []
    }
}
```
```
❯ http --follow -v --auth=user:pass :8080/api/v2.2/graphql query='query { environmentNodes(filter: { nodeType: "Realm" }) { id name nodeType labels { key value } children { id name nodeType labels { key value } } } }'

POST /api/v2.2/graphql HTTP/1.1
Accept: application/json, */*;q=0.5
Accept-Encoding: gzip, deflate
Authorization: Basic dXNlcjpwYXNz
Connection: keep-alive
Content-Length: 165
Content-Type: application/json
Host: localhost:8080
User-Agent: HTTPie/3.2.2

{
    "query": "query { environmentNodes(filter: { nodeType: \"Realm\" }) { id name nodeType labels { key value } children { id name nodeType labels { key value } } } }"
}


HTTP/1.1 308 Permanent Redirect
Content-Encoding: identity
Content-Length: 0
Date: Thu, 29 Feb 2024 02:08:39 GMT
Gap-Auth: user
Location: http://localhost:8080/api/v3/graphql



POST /api/v3/graphql HTTP/1.1
Accept: application/json, */*;q=0.5
Accept-Encoding: gzip, deflate
Authorization: Basic dXNlcjpwYXNz
Connection: keep-alive
Content-Length: 165
Content-Type: application/json
Host: localhost:8080
User-Agent: HTTPie/3.2.2

{
    "query": "query { environmentNodes(filter: { nodeType: \"Realm\" }) { id name nodeType labels { key value } children { id name nodeType labels { key value } } } }"
}


HTTP/1.1 200 OK
Content-Length: 6318
Content-Type: application/json
Date: Thu, 29 Feb 2024 02:08:39 GMT
Gap-Auth: user

{
    "data": {
        "environmentNodes": [
            {
                "children": [],
                "id": 2,
                "labels": [],
                "name": "Custom Targets",
                "nodeType": "Realm"
            },
            {
                "children": [
                    {
                        "id": 6,
                        "labels": [],
                        "name": "service:jmx:rmi:///jndi/rmi://cryostat3:9091/jmxrmi",
                        "nodeType": "JVM"
                    }
                ],
                "id": 3,
                "labels": [],
                "name": "JDP",
                "nodeType": "Realm"
            },
            {
                "children": [
                    {
                        "id": 5,
                        "labels": [
                            {
                                "key": "org.jboss.product.openjdk.version",
                                "value": "17"
                            },
                            {
                                "key": "usage",
                                "value": "https://jboss-container-images.github.io/openjdk/"
                            },
                            {
                                "key": "release",
                                "value": "2.1705573231"
                            },
                            {
                                "key": "com.docker.compose.oneoff",
                                "value": "False"
                            },
                            {
                                "key": "io.openshift.tags",
                                "value": "java"
                            },
                            {
                                "key": "io.buildah.version",
                                "value": "1.23.1"
                            },
                            {
                                "key": "io.cryostat.jmxHost",
                                "value": "jfr-datasource"
                            },
                            {
                                "key": "com.docker.compose.config-hash",
                                "value": "33a2a2654afef38517379db3c1afa639b914220a233223bd56bea69cf6923e4e"
                            },
                            {
                                "key": "com.docker.compose.project.config_files",
                                "value": "/home/atali/Desktop/workStation/cryostat3/compose/cryostat.yml,/home/atali/Desktop/workStation/cryostat3/compose/db.yml,/home/atali/Desktop/workStation/cryostat3/compose/cryostat-grafana.yml,/home/atali/Desktop/workStation/cryostat3/compose/jfr-datasource.yml,/home/atali/Desktop/workStation/cryostat3/compose/auth_proxy.yml,/home/atali/Desktop/workStation/cryostat3/compose/s3-seaweed.yml"
                            },
                            {
                                "key": "com.redhat.component",
                                "value": "openjdk-17-runtime-ubi8-container"
                            },
                            {
                                "key": "distribution-scope",
                                "value": "public"
                            },
                            {
                                "key": "com.docker.compose.version",
                                "value": "1.29.2"
                            },
                            {
                                "key": "summary",
                                "value": "Image for Red Hat OpenShift providing OpenJDK 17 runtime"
                            },
                            {
                                "key": "io.openshift.expose-services",
                                "value": ""
                            },
                            {
                                "key": "version",
                                "value": "1.18"
                            },
                            {
                                "key": "name",
                                "value": "ubi8/openjdk-17-runtime"
                            },
                            {
                                "key": "com.docker.compose.container-number",
                                "value": "1"
                            },
                            {
                                "key": "maintainer",
                                "value": "Red Hat OpenJDK <openjdk@redhat.com>"
                            },
                            {
                                "key": "org.jboss.product.version",
                                "value": "17"
                            },
                            {
                                "key": "url",
                                "value": "https://access.redhat.com/containers/#/registry.access.redhat.com/ubi8/openjdk-17-runtime/images/1.18-2.1705573231"
                            },
                            {
                                "key": "com.docker.compose.project.working_dir",
                                "value": "/home/atali/Desktop/workStation/cryostat3/compose"
                            },
                            {
                                "key": "vendor",
                                "value": "Red Hat, Inc."
                            },
                            {
                                "key": "architecture",
                                "value": "x86_64"
                            },
                            {
                                "key": "io.k8s.display-name",
                                "value": "Java Applications"
                            },
                            {
                                "key": "org.jboss.product",
                                "value": "openjdk"
                            },
                            {
                                "key": "io.cekit.version",
                                "value": "4.9.1"
                            },
                            {
                                "key": "description",
                                "value": "Image for Red Hat OpenShift providing OpenJDK 17 runtime"
                            },
                            {
                                "key": "io.k8s.description",
                                "value": "Platform for running plain Java applications (fat-jar and flat classpath)"
                            },
                            {
                                "key": "vcs-ref",
                                "value": "12aac04fffa038f171574a2c3f057a2c253f5c27"
                            },
                            {
                                "key": "vcs-type",
                                "value": "git"
                            },
                            {
                                "key": "org.opencontainers.image.documentation",
                                "value": "https://jboss-container-images.github.io/openjdk/"
                            },
                            {
                                "key": "kompose.service.expose",
                                "value": "jfr-datasource"
                            },
                            {
                                "key": "com.redhat.license_terms",
                                "value": "https://www.redhat.com/en/about/red-hat-end-user-license-agreements#UBI"
                            },
                            {
                                "key": "com.docker.compose.project",
                                "value": "compose"
                            },
                            {
                                "key": "com.docker.compose.service",
                                "value": "jfr-datasource"
                            },
                            {
                                "key": "build-date",
                                "value": "2024-01-18T10:36:52"
                            },
                            {
                                "key": "io.cryostat.jmxPort",
                                "value": "11223"
                            },
                            {
                                "key": "io.cryostat.discovery",
                                "value": "true"
                            }
                        ],
                        "name": "service:jmx:rmi:///jndi/rmi://jfr-datasource:11223/jmxrmi",
                        "nodeType": "JVM"
                    },
                    {
                        "id": 7,
                        "labels": [
                            {
                                "key": "maintainer",
                                "value": "Red Hat OpenJDK <openjdk@redhat.com>"
                            },
                            {
                                "key": "org.jboss.product.version",
                                "value": "17"
                            },
                            {
                                "key": "distribution-scope",
                                "value": "public"
                            },
                            {
                                "key": "io.cryostat.jmxHost",
                                "value": "localhost"
                            },
                            {
                                "key": "vendor",
                                "value": "Red Hat, Inc."
                            },
                            {
                                "key": "description",
                                "value": "Image for Red Hat OpenShift providing OpenJDK 17 runtime"
                            },
                            {
                                "key": "org.jboss.product",
                                "value": "openjdk"
                            },
                            {
                                "key": "vcs-type",
                                "value": "git"
                            },
                            {
                                "key": "com.docker.compose.oneoff",
                                "value": "False"
                            },
                            {
                                "key": "name",
                                "value": "ubi8/openjdk-17-runtime"
                            },
                            {
                                "key": "io.openshift.expose-services",
                                "value": ""
                            },
                            {
                                "key": "io.cryostat.jmxUrl",
                                "value": "service:jmx:rmi:///jndi/rmi://localhost:0/jmxrmi"
                            },
                            {
                                "key": "com.redhat.component",
                                "value": "openjdk-17-runtime-ubi8-container"
                            },
                            {
                                "key": "com.docker.compose.config-hash",
                                "value": "7f5dc61b0d3d865d31e751ba97fee9634472c754802e78484f4ed61c23d6b43b"
                            },
                            {
                                "key": "url",
                                "value": "https://access.redhat.com/containers/#/registry.access.redhat.com/ubi8/openjdk-17-runtime/images/1.18-2.1705573231"
                            },
                            {
                                "key": "com.docker.compose.project",
                                "value": "compose"
                            },
                            {
                                "key": "com.docker.compose.project.working_dir",
                                "value": "/home/atali/Desktop/workStation/cryostat3/compose"
                            },
                            {
                                "key": "summary",
                                "value": "Image for Red Hat OpenShift providing OpenJDK 17 runtime"
                            },
                            {
                                "key": "release",
                                "value": "2.1705573231"
                            },
                            {
                                "key": "io.cryostat.jmxPort",
                                "value": "0"
                            },
                            {
                                "key": "usage",
                                "value": "https://jboss-container-images.github.io/openjdk/"
                            },
                            {
                                "key": "kompose.service.expose",
                                "value": "cryostat3"
                            },
                            {
                                "key": "io.k8s.description",
                                "value": "Platform for running plain Java applications (fat-jar and flat classpath)"
                            },
                            {
                                "key": "io.k8s.display-name",
                                "value": "Java Applications"
                            },
                            {
                                "key": "architecture",
                                "value": "x86_64"
                            },
                            {
                                "key": "version",
                                "value": "1.18"
                            },
                            {
                                "key": "io.openshift.tags",
                                "value": "java"
                            },
                            {
                                "key": "org.jboss.product.openjdk.version",
                                "value": "17"
                            },
                            {
                                "key": "com.docker.compose.container-number",
                                "value": "1"
                            },
                            {
                                "key": "build-date",
                                "value": "2024-01-18T10:36:52"
                            },
                            {
                                "key": "io.cryostat.discovery",
                                "value": "true"
                            },
                            {
                                "key": "com.docker.compose.project.config_files",
                                "value": "/home/atali/Desktop/workStation/cryostat3/compose/cryostat.yml,/home/atali/Desktop/workStation/cryostat3/compose/db.yml,/home/atali/Desktop/workStation/cryostat3/compose/cryostat-grafana.yml,/home/atali/Desktop/workStation/cryostat3/compose/jfr-datasource.yml,/home/atali/Desktop/workStation/cryostat3/compose/auth_proxy.yml,/home/atali/Desktop/workStation/cryostat3/compose/s3-seaweed.yml"
                            },
                            {
                                "key": "com.redhat.license_terms",
                                "value": "https://www.redhat.com/en/about/red-hat-end-user-license-agreements#UBI"
                            },
                            {
                                "key": "com.docker.compose.service",
                                "value": "cryostat"
                            },
                            {
                                "key": "io.buildah.version",
                                "value": "1.33.5"
                            },
                            {
                                "key": "vcs-ref",
                                "value": "12aac04fffa038f171574a2c3f057a2c253f5c27"
                            },
                            {
                                "key": "io.cekit.version",
                                "value": "4.9.1"
                            },
                            {
                                "key": "org.opencontainers.image.documentation",
                                "value": "https://jboss-container-images.github.io/openjdk/"
                            },
                            {
                                "key": "io.cryostat.component",
                                "value": "cryostat3"
                            },
                            {
                                "key": "com.docker.compose.version",
                                "value": "1.29.2"
                            }
                        ],
                        "name": "service:jmx:rmi:///jndi/rmi://localhost:0/jmxrmi",
                        "nodeType": "JVM"
                    }
                ],
                "id": 4,
                "labels": [],
                "name": "Podman",
                "nodeType": "Realm"
            }
        ]
    }
}
```
