### PR TITLE
fix(archives): accept and delete recording uploads, emit event with correct size

### DIFF
--- a/src/main/java/io/cryostat/recordings/ActiveRecording.java
+++ b/src/main/java/io/cryostat/recordings/ActiveRecording.java
@@ -308,17 +308,18 @@ public class ActiveRecording extends PanacheEntity {
 
             // FIXME the target connectUrl URI may no longer be known if the target
             // has disappeared and we are emitting an event regarding an archived recording
-            // originally
-            // sourced from that target.
+            // originally sourced from that target, or if we are accepting a recording upload from a
+            // client.
             // This should embed the target jvmId and optionally the database ID.
             public record Payload(String target, ArchivedRecording recording) {
                 public Payload {
-                    Objects.requireNonNull(target);
                     Objects.requireNonNull(recording);
                 }
 
                 public static Payload of(URI connectUrl, ArchivedRecording recording) {
-                    return new Payload(connectUrl.toString(), recording);
+                    return new Payload(
+                            Optional.ofNullable(connectUrl).map(URI::toString).orElse(null),
+                            recording);
                 }
             }
         }


### PR DESCRIPTION
# Welcome to Cryostat3! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat3/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] [Signed all commits using a GPG signature](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#gpg-commit-signature-verification)

**To recreate commits with GPG signature** `git fetch upstream && git rebase --force --gpg-sign upstream/main`
_______________________________________________

Related to #2
Depends on https://github.com/cryostatio/cryostat-web/pull/1221

## Description of the change:
1. Inserts the correct archived recording filesize into the WebSocket notification emitted when recordings are uploaded into archival storage
2. Corrects handling of archives to allow null JVM IDs, which is the case for client uploads
3. Corrects handling of archived recording deletion to accept `"uploads"` as a pseudo-"JVM ID", since that is how they are stored when uploaded

## Motivation for the change:
*This change is helpful because users may want to...*

## How to manually test:
1. *Run CRYOSTAT_IMAGE=quay.io... bash smoketest.bash...*
2. *...*
