### PR TITLE
fix(grafana): add redirecting endpoint for archived recordings

### DIFF
--- a/src/main/java/io/cryostat/recordings/Recordings.java
+++ b/src/main/java/io/cryostat/recordings/Recordings.java
@@ -833,10 +833,25 @@ public class Recordings {
     }
 
     @POST
+    @Path("/api/beta/recordings/{connectUrl}/{filename}/upload")
+    @RolesAllowed("write")
+    public Response uploadArchivedToGrafanaBeta(
+            @RestPath String connectUrl, @RestPath String filename) throws Exception {
+        var jvmId = Target.getTargetByConnectUrl(URI.create(connectUrl)).jvmId;
+        return Response.status(RestResponse.Status.PERMANENT_REDIRECT)
+                .location(
+                        URI.create(
+                                String.format(
+                                        "/api/v3/grafana/%s",
+                                        recordingHelper.encodedKey(jvmId, filename))))
+                .build();
+    }
+
+    @POST
     @Path("/api/beta/fs/recordings/{jvmId}/{filename}/upload")
     @RolesAllowed("write")
-    public Response uploadArchivedToGrafanaBeta(@RestPath String jvmId, @RestPath String filename)
-            throws Exception {
+    public Response uploadArchivedToGrafanaFromPath(
+            @RestPath String jvmId, @RestPath String filename) throws Exception {
         return Response.status(RestResponse.Status.PERMANENT_REDIRECT)
                 .location(
                         URI.create(


### PR DESCRIPTION
# Welcome to Cryostat3! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat3/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] [Signed all commits using a GPG signature](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#gpg-commit-signature-verification)

**To recreate commits with GPG signature** `git fetch upstream && git rebase --force --gpg-sign upstream/main`
_______________________________________________

Based on #315

## Description of the change:
Adds a missing endpoint. This implementation mirrors the other similar one in that it simply redirects the client to a new API endpoint.

## Motivation for the change:
This re-enables the "View in Grafana" action in the UI for the "Recordings > Archived" and "Archives > All Targets" views.

## How to manually test:
1. *Run CRYOSTAT_IMAGE=quay.io... bash smoketest.bash...*
2. *...*
