### PR TITLE
fix(jmxauth): tolerate JMX auth failures at discovery, re-attempt if new matching Credentials added

### DIFF
--- a/src/main/java/io/cryostat/JsonRequestFilter.java
+++ b/src/main/java/io/cryostat/JsonRequestFilter.java
@@ -33,7 +33,8 @@ import jakarta.ws.rs.ext.Provider;
 public class JsonRequestFilter implements ContainerRequestFilter {
 
     static final Set<String> disallowedFields = Set.of("id");
-    static final Set<String> allowedPaths = Set.of("/api/v2.2/discovery");
+    static final Set<String> allowedPaths =
+            Set.of("/api/v2.2/discovery", "/api/beta/matchexpressions");
 
     private final ObjectMapper objectMapper = new ObjectMapper();
 

--- a/src/main/java/io/cryostat/targets/Target.java
+++ b/src/main/java/io/cryostat/targets/Target.java
@@ -244,11 +244,7 @@ public class Target extends PanacheEntity {
                                 .await()
                                 .atMost(Duration.ofSeconds(10));
             } catch (Exception e) {
-                // TODO tolerate this in the condition that the connection failed because of JMX
-                // auth. In that instance then persist the entity with a null jvmId, but listen for
-                // new Credentials and test them against any targets with null jvmIds to see if we
-                // can populate them.
-                throw new JvmIdException(e);
+                logger.info(e);
             }
         }
 

--- a/src/main/java/io/cryostat/targets/Targets.java
+++ b/src/main/java/io/cryostat/targets/Targets.java
@@ -16,17 +16,61 @@
 package io.cryostat.targets;
 
 import java.net.URI;
+import java.time.Duration;
 import java.util.List;
+import java.util.Optional;
 
+import io.cryostat.credentials.Credential;
+import io.cryostat.expressions.MatchExpressionEvaluator;
+
+import io.quarkus.vertx.ConsumeEvent;
 import jakarta.annotation.security.RolesAllowed;
+import jakarta.inject.Inject;
+import jakarta.transaction.Transactional;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.core.Response;
+import org.jboss.logging.Logger;
 import org.jboss.resteasy.reactive.RestPath;
 import org.jboss.resteasy.reactive.RestResponse;
+import org.projectnessie.cel.tools.ScriptException;
 
 @Path("")
 public class Targets {
+
+    @Inject MatchExpressionEvaluator matchExpressionEvaluator;
+    @Inject TargetConnectionManager connectionManager;
+    @Inject Logger logger;
+
+    @ConsumeEvent(value = Credential.CREDENTIALS_STORED, blocking = true)
+    @Transactional
+    void updateCredential(Credential credential) {
+        Target.<Target>find("jvmId", (String) null)
+                .list()
+                .forEach(
+                        t -> {
+                            try {
+                                if (matchExpressionEvaluator.applies(
+                                        credential.matchExpression, t)) {
+                                    t.jvmId =
+                                            connectionManager
+                                                    .executeDirect(
+                                                            t,
+                                                            Optional.empty(),
+                                                            conn ->
+                                                                    conn.getJvmIdentifier()
+                                                                            .getHash())
+                                                    .await()
+                                                    .atMost(Duration.ofSeconds(10));
+                                    t.persist();
+                                }
+                            } catch (ScriptException e) {
+                                logger.error(e);
+                            } catch (Exception e) {
+                                logger.warn(e);
+                            }
+                        });
+    }
 
     @GET
     @Path("/api/v1/targets")


### PR DESCRIPTION
# Welcome to Cryostat3! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat3/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] [Signed all commits using a GPG signature](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#gpg-commit-signature-verification)

**To recreate commits with GPG signature** `git fetch upstream && git rebase --force --gpg-sign upstream/main`
_______________________________________________

Related to #2
Related to #71
Depends on #337

## Description of the change:
Cryostat 3 tolerates connection failures when attempting to determine newly discovered targets' JVM IDs. When new Credentials are added, Cryostat looks in the database for any targets with null JVM IDs (signifying the initial connection failure), checks if the new credential matches the target, and then re-attempts to determine the JVM hash ID and persist this update to the database.

## Motivation for the change:
Prior to this change, Cryostat 3 would always try to connect to newly discovered JVMs to determine their hash IDs. If this connection attempt failed for any reason then the discovery would be ignored and the JVM would not be registered in the target database. This means that target JVMs which require JMX authentication, and/or which use JMX with TLS, may not be discoverable unless Cryostat 3 is pre-configured with the correct credentials and certificates.

JMX SSL/TLS cert handling is not implemented here. See #330.

## How to manually test:
1. *Run CRYOSTAT_IMAGE=quay.io... bash smoketest.bash -Ot ...*
2. Wait for everything to start up and discovery to settle. The `sample-app-2` and `sample-app-3` JDP targets should now appear with ports `9094` and `9095` respectively.
3. Go to Recordings or Events views and select either of the two aforementioned sample apps. Both should fail with a Gateway Timeout after ~10 seconds.
4. Go to Security and define a new credential. Use the match expression `target.alias.contains('andrew')` and credentials `admin:adminpass123`.
5. Go back to Recordings or Events view and select the new targets again. `sample-app-2:9094` should now be connectable and usable in all the usual ways. `sample-app-3:9095` still will not be since it also requires SSL/TLS.
