### PR TITLE
feat(jmx): custom entrypoint to support copying TLS certs into truststore for JMX

### DIFF
--- a/compose/cryostat.yml
+++ b/compose/cryostat.yml
@@ -14,6 +14,7 @@ services:
     image: ${CRYOSTAT_IMAGE:-quay.io/cryostat/cryostat:3.0.0-snapshot}
     volumes:
       - ${XDG_RUNTIME_DIR}/podman/podman.sock:/run/user/1000/podman/podman.sock:Z
+      - jmxtls_cfg:/truststore:U
     security_opt:
       - label:disable
     hostname: cryostat3
@@ -39,3 +40,7 @@ services:
       retries: 3
       start_period: 30s
       timeout: 5s
+
+volumes:
+  jmxtls_cfg:
+    external: true

--- a/schema/openapi.yaml
+++ b/schema/openapi.yaml
@@ -2184,6 +2184,19 @@ paths:
         - SecurityScheme: []
       tags:
         - Reports
+  /api/v3/tls/certs:
+    get:
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                items:
+                  type: string
+                type: array
+          description: OK
+      tags:
+        - Trust Store
   /health:
     get:
       responses:

--- a/smoketest.bash
+++ b/smoketest.bash
@@ -180,6 +180,8 @@ cleanup() {
         ${container_engine} rm localstack_cfg_helper || true
         ${container_engine} volume rm localstack_cfg || true
     fi
+    ${container_engine} rm jmxtls_cfg_helper || true
+    ${container_engine} volume rm jmxtls_cfg || true
     truncate -s 0 "${HOSTSFILE}"
     for i in "${PIDS[@]}"; do
         kill -0 "${i}" && kill "${i}"
@@ -211,6 +213,13 @@ createLocalstackCfgVolume() {
 if [ "${s3}" = "localstack" ]; then
     createLocalstackCfgVolume
 fi
+
+createJmxTlsCertVolume() {
+    "${container_engine}" volume create jmxtls_cfg
+    "${container_engine}" container create --name jmxtls_cfg_helper -v jmxtls_cfg:/truststore busybox
+    "${container_engine}" cp "${DIR}/truststore" jmxtls_cfg_helper:/truststore
+}
+createJmxTlsCertVolume
 
 setupUserHosts() {
     # This requires https://github.com/figiel/hosts to work. See README.

--- a/src/main/docker/Dockerfile.jvm
+++ b/src/main/docker/Dockerfile.jvm
@@ -88,11 +88,26 @@ LABEL io.cryostat.component=cryostat3
 ENV JAVA_OPTS_APPEND="-Dquarkus.http.host=0.0.0.0 -Djava.util.logging.manager=org.jboss.logmanager.LogManager"
 ENV JAVA_APP_JAR="/deployments/quarkus-run.jar"
 
-ENTRYPOINT [ "/opt/jboss/container/java/run/run-java.sh" ]
+ENTRYPOINT [ "/deployments/app/entrypoint.bash", "/opt/jboss/container/java/run/run-java.sh" ]
 
 # We make distinct layers so if there are application changes the library layers can be re-used
 COPY --chown=185 src/main/docker/include/cryostat.jfc /usr/lib/jvm/jre/lib/jfr/
+COPY --chown=185 src/main/docker/include/genpass.bash /deployments/app/
+COPY --chown=185 src/main/docker/include/entrypoint.bash /deployments/app/
+COPY --chown=185 src/main/docker/include/truststore-setup.bash /deployments/app/
 COPY --chown=185 target/quarkus-app/lib/ /deployments/lib/
 COPY --chown=185 target/quarkus-app/*.jar /deployments/
 COPY --chown=185 target/quarkus-app/app/ /deployments/app/
 COPY --chown=185 target/quarkus-app/quarkus/ /deployments/quarkus/
+
+ENV CONF_DIR=/opt/cryostat.d
+ENV SSL_TRUSTSTORE=$CONF_DIR/truststore.p12 \
+    SSL_TRUSTSTORE_PASS_FILE=$CONF_DIR/truststore.pass
+
+USER root
+RUN mkdir -p $CONF_DIR \
+    && chmod -R g=u $CONF_DIR \
+    && chown jboss:root $CONF_DIR
+USER 185
+
+RUN /deployments/app/truststore-setup.bash

--- a/src/main/docker/include/entrypoint.bash
+++ b/src/main/docker/include/entrypoint.bash
@@ -1,0 +1,83 @@
+#!/bin/bash
+
+set -e
+
+DIR="$(dirname "$(realpath "$0")")"
+source "${DIR}/genpass.bash"
+
+function banner() {
+    echo   "+------------------------------------------+"
+    printf "| %-40s |\n" "$(date)"
+    echo   "|                                          |"
+    printf "| %-40s |\n" "$@"
+    echo   "+------------------------------------------+"
+}
+
+USRFILE="/tmp/jmxremote.access"
+PWFILE="/tmp/jmxremote.password"
+function createJmxCredentials() {
+    if [ -z "$CRYOSTAT_RJMX_USER" ]; then
+        CRYOSTAT_RJMX_USER="cryostat"
+    fi
+    if [ -z "$CRYOSTAT_RJMX_PASS" ]; then
+        CRYOSTAT_RJMX_PASS="$(genpass)"
+    fi
+
+    echo -n "$CRYOSTAT_RJMX_USER $CRYOSTAT_RJMX_PASS" > "$PWFILE"
+    chmod 400 "$PWFILE"
+    echo -n "$CRYOSTAT_RJMX_USER readwrite" > "$USRFILE"
+    chmod 400 "$USRFILE"
+}
+
+function importTrustStores() {
+    echo "Running as id:$(id -u) group:$(id -g)"
+    if [ -z "$CONF_DIR" ]; then
+        CONF_DIR="/opt/cryostat.d"
+    fi
+    if [ -z "$SSL_TRUSTSTORE_DIR" ]; then
+        SSL_TRUSTSTORE_DIR="/truststore"
+    fi
+
+    if [ ! -d "$SSL_TRUSTSTORE_DIR" ]; then
+        banner "$SSL_TRUSTSTORE_DIR does not exist; no certificates to import"
+        return 0
+    elif [ ! "$(ls -A "$SSL_TRUSTSTORE_DIR")" ]; then
+        banner "$SSL_TRUSTSTORE_DIR is empty; no certificates to import"
+        return 0
+    fi
+
+    SSL_TRUSTSTORE_PASS="$(cat "${SSL_TRUSTSTORE_PASS_FILE:-$CONF_DIR/truststore.pass}")"
+
+    find "$SSL_TRUSTSTORE_DIR" -type f | while IFS= read -r cert; do
+        echo "Importing certificate $cert ..."
+
+        keytool -importcert -v \
+            -noprompt \
+            -alias "imported-$(basename "$cert")" \
+            -trustcacerts \
+            -keystore "${SSL_TRUSTSTORE:-$CONF_DIR/truststore.p12}" \
+            -file "$cert"\
+            -storepass "$SSL_TRUSTSTORE_PASS"
+    done
+
+    FLAGS+=(
+        "-Djavax.net.ssl.trustStore=$SSL_TRUSTSTORE"
+        "-Djavax.net.ssl.trustStorePassword=$SSL_TRUSTSTORE_PASS"
+    )
+}
+
+FLAGS=()
+importTrustStores
+
+if [ "$CRYOSTAT_DISABLE_JMX_AUTH" = "true" ]; then
+    banner "JMX Auth Disabled"
+    FLAGS+=("-Dcom.sun.management.jmxremote.authenticate=false")
+else
+    createJmxCredentials
+    FLAGS+=("-Dcom.sun.management.jmxremote.authenticate=true")
+    FLAGS+=("-Dcom.sun.management.jmxremote.password.file=$PWFILE")
+    FLAGS+=("-Dcom.sun.management.jmxremote.access.file=$USRFILE")
+fi
+
+export JAVA_OPTS_APPEND="${JAVA_OPTS_APPEND} ${FLAGS[*]}"
+exec $1

--- a/src/main/docker/include/entrypoint.bash
+++ b/src/main/docker/include/entrypoint.bash
@@ -30,7 +30,6 @@ function createJmxCredentials() {
 }
 
 function importTrustStores() {
-    echo "Running as id:$(id -u) group:$(id -g)"
     if [ -z "$CONF_DIR" ]; then
         CONF_DIR="/opt/cryostat.d"
     fi

--- a/src/main/docker/include/entrypoint.bash
+++ b/src/main/docker/include/entrypoint.bash
@@ -13,8 +13,8 @@ function banner() {
     echo   "+------------------------------------------+"
 }
 
-USRFILE="/tmp/jmxremote.access"
 PWFILE="/tmp/jmxremote.password"
+USRFILE="/tmp/jmxremote.access"
 function createJmxCredentials() {
     if [ -z "$CRYOSTAT_RJMX_USER" ]; then
         CRYOSTAT_RJMX_USER="cryostat"

--- a/src/main/docker/include/genpass.bash
+++ b/src/main/docker/include/genpass.bash
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+genpass() {
+    < /dev/urandom tr -dc _A-Z-a-z-0-9 | head -c32
+}

--- a/src/main/docker/include/truststore-setup.bash
+++ b/src/main/docker/include/truststore-setup.bash
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+set -e
+
+DIR="$(dirname "$(realpath "$0")")"
+source "${DIR}/genpass.bash"
+
+SSL_TRUSTSTORE_PASS="$(genpass)"
+
+echo "$SSL_TRUSTSTORE_PASS" > "$SSL_TRUSTSTORE_PASS_FILE"
+
+trap "cd -" EXIT
+cd "$CONF_DIR"
+
+keytool -importkeystore \
+    -noprompt \
+    -storetype PKCS12 \
+    -srckeystore /usr/lib/jvm/jre-17-openjdk/lib/security/cacerts \
+    -srcstorepass changeit \
+    -destkeystore "$SSL_TRUSTSTORE" \
+    -deststorepass "$SSL_TRUSTSTORE_PASS"
+
+chmod 664 "${SSL_TRUSTSTORE}"
+chmod 640 "${SSL_TRUSTSTORE_PASS_FILE}"

--- a/src/main/java/io/cryostat/ConfigProperties.java
+++ b/src/main/java/io/cryostat/ConfigProperties.java
@@ -51,4 +51,6 @@ public class ConfigProperties {
     public static final String STORAGE_TRANSIENT_ARCHIVES_ENABLED =
             "storage.transient-archives.enabled";
     public static final String STORAGE_TRANSIENT_ARCHIVES_TTL = "storage.transient-archives.ttl";
+
+    public static final String SSL_TRUSTSTORE_DIR = "ssl.truststore.dir";
 }

--- a/src/main/java/io/cryostat/security/TrustStore.java
+++ b/src/main/java/io/cryostat/security/TrustStore.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright The Cryostat Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.cryostat.security;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.util.List;
+
+import io.cryostat.ConfigProperties;
+
+import io.smallrye.common.annotation.Blocking;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.jboss.logging.Logger;
+
+@Path("/api/v3")
+public class TrustStore {
+
+    @ConfigProperty(name = ConfigProperties.SSL_TRUSTSTORE_DIR)
+    java.nio.file.Path trustStoreDir;
+
+    @Inject Logger logger;
+
+    @Blocking
+    @GET
+    @Path("tls/certs")
+    @Produces(MediaType.APPLICATION_JSON)
+    public List<String> listCerts() throws IOException {
+        return Files.walk(trustStoreDir)
+                .map(java.nio.file.Path::toFile)
+                .filter(File::isFile)
+                .map(File::getPath)
+                .toList();
+    }
+}

--- a/src/main/java/io/cryostat/security/TrustStore.java
+++ b/src/main/java/io/cryostat/security/TrustStore.java
@@ -31,7 +31,7 @@ import jakarta.ws.rs.core.MediaType;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.jboss.logging.Logger;
 
-@Path("/api/v3")
+@Path("")
 public class TrustStore {
 
     @ConfigProperty(name = ConfigProperties.SSL_TRUSTSTORE_DIR)
@@ -41,7 +41,7 @@ public class TrustStore {
 
     @Blocking
     @GET
-    @Path("tls/certs")
+    @Path("/api/v3/tls/certs")
     @Produces(MediaType.APPLICATION_JSON)
     public List<String> listCerts() throws IOException {
         return Files.walk(trustStoreDir)

--- a/src/main/resources/application-dev.properties
+++ b/src/main/resources/application-dev.properties
@@ -6,7 +6,7 @@ quarkus.http.cors=true
 # quarkus.http.cors.origins=http://localhost:9000,http://0.0.0.0:9000
 quarkus.http.cors.origins=http://localhost:9000
 quarkus.http.cors.access-control-allow-credentials=true
-quarkus.http.cors.exposed-headers=X-JMX-Authorization,X-JMX-Authenticate,X-WWW-Authenticate
+quarkus.http.cors.exposed-headers=X-WWW-Authenticate
 # quarkus.http.cors.methods=GET,PUT,POST,PATCH,OPTIONS
 # quarkus.http.cors.access-control-max-age=1s
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -32,6 +32,11 @@ cryostat.http.proxy.host=${quarkus.http.host}
 cryostat.http.proxy.port=${quarkus.http.port}
 cryostat.http.proxy.path=/
 
+conf-dir=/opt/cryostat.d
+ssl.truststore=${conf-dir}/truststore.p12
+ssl.truststore.dir=/truststore
+ssl.truststore.pass-file=${conf-dir}/truststore.pass
+
 quarkus.http.auth.proactive=false
 quarkus.http.host=0.0.0.0
 quarkus.http.port=8181


### PR DESCRIPTION
# Welcome to Cryostat3! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat3/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] [Signed all commits using a GPG signature](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#gpg-commit-signature-verification)

**To recreate commits with GPG signature** `git fetch upstream && git rebase --force --gpg-sign upstream/main`
_______________________________________________

Based on #329
Related to #2
Related to #71

## Description of the change:
Copies a simplified version of Cryostat 2.4's `entrypoint.bash` and `truststore-setup.sh` into the container build, sets up the container to initialize with the truststore copy and the entrypoint to copy in any additional user-supplied certificates into this truststore, before finally launching the server JVM.

## Motivation for the change:
This allows users (the ones who deploy Cryostat, not the ones who interact with the UI and API) to supply TLS certificates that their target applications present for JMX connections. This restores Cryostat 3's ability to connect to such JMX/TLS-enabled targets.

## How to manually test:
1. `mkdir truststore` in the project directory
2. Copy https://github.com/andrewazores/vertx-fib-demo/blob/master/src/main/extras/app/resources/vertx-fib-demo.cer into this new `truststore`
3. See #329. `sample-app-3:9095` should now work as normal too. `smoketest.bash` will copy the local project directory `truststore` into a test volume and mount that to the Cryostat container. The Cryostat container should then see the new certificate and import it into its runtime truststore, then start the JVM which will now trust the certificate presented by `sample-app-3`.
