### PR TITLE
fix(id-filter): allow JSON 'id' key on particular endpoints only

### DIFF
--- a/src/main/java/io/cryostat/JsonRequestFilter.java
+++ b/src/main/java/io/cryostat/JsonRequestFilter.java
@@ -41,7 +41,8 @@ public class JsonRequestFilter implements ContainerRequestFilter {
     public void filter(ContainerRequestContext requestContext) throws IOException {
         if (requestContext.getMediaType() != null
                 && requestContext.getMediaType().isCompatible(MediaType.APPLICATION_JSON_TYPE)
-                && !allowedPaths.contains(requestContext.getUriInfo().getPath())) {
+                && (requestContext.getUriInfo() != null
+                        && !allowedPaths.contains(requestContext.getUriInfo().getPath()))) {
             try (InputStream stream = requestContext.getEntityStream()) {
                 JsonNode rootNode = objectMapper.readTree(stream);
 

--- a/src/main/java/io/cryostat/JsonRequestFilter.java
+++ b/src/main/java/io/cryostat/JsonRequestFilter.java
@@ -33,8 +33,7 @@ import jakarta.ws.rs.ext.Provider;
 public class JsonRequestFilter implements ContainerRequestFilter {
 
     static final Set<String> disallowedFields = Set.of("id");
-    static final Set<String> allowedPaths =
-            Set.of("/api/v2.2/graphql", "/api/v3/graphql", "/api/v2.2/discovery");
+    static final Set<String> allowedPaths = Set.of("/api/v2.2/discovery");
 
     private final ObjectMapper objectMapper = new ObjectMapper();
 

--- a/src/test/java/io/cryostat/JsonRequestFilterTest.java
+++ b/src/test/java/io/cryostat/JsonRequestFilterTest.java
@@ -25,9 +25,11 @@ import java.util.stream.Stream;
 import jakarta.ws.rs.container.ContainerRequestContext;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.core.UriInfo;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.Mockito;
 
 public class JsonRequestFilterTest {
     private JsonRequestFilter filter;
@@ -76,6 +78,9 @@ public class JsonRequestFilterTest {
                 new ByteArrayInputStream(jsonPayload.getBytes(StandardCharsets.UTF_8));
         when(requestContext.getEntityStream()).thenReturn(payloadStream);
         when(requestContext.getMediaType()).thenReturn(MediaType.APPLICATION_JSON_TYPE);
+        UriInfo uriInfo = Mockito.mock(UriInfo.class);
+        Mockito.when(uriInfo.getPath()).thenReturn("/some/path");
+        when(requestContext.getUriInfo()).thenReturn(uriInfo);
         filter.filter(requestContext);
     }
 }


### PR DESCRIPTION
# Welcome to Cryostat3! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat3/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] [Signed all commits using a GPG signature](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#gpg-commit-signature-verification)

**To recreate commits with GPG signature** `git fetch upstream && git rebase --force --gpg-sign upstream/main`
_______________________________________________

Related to #291

This is a partial cherry-pick of a patch included in #294. This fixes the current breakage on `main` where discovery plugins (ex. Cryostat Agents) are unable to register.
