### PR TITLE
fix(recordingOptions): scope customizers to each Target

### DIFF
--- a/src/main/java/io/cryostat/recordings/RecordingHelper.java
+++ b/src/main/java/io/cryostat/recordings/RecordingHelper.java
@@ -246,7 +246,7 @@ public class RecordingHelper {
         String rename = String.format("%s-%d", desc.getName().toLowerCase(), desc.getId());
 
         RecordingOptionsBuilder recordingOptionsBuilder =
-                recordingOptionsBuilderFactory.create(connection.getService());
+                recordingOptionsBuilderFactory.create(target);
         recordingOptionsBuilder.name(rename);
 
         connection.getService().updateRecordingOptions(desc, recordingOptionsBuilder.build());

--- a/src/main/java/io/cryostat/recordings/RecordingOptionsBuilderFactory.java
+++ b/src/main/java/io/cryostat/recordings/RecordingOptionsBuilderFactory.java
@@ -17,9 +17,27 @@ package io.cryostat.recordings;
 
 import org.openjdk.jmc.common.unit.QuantityConversionException;
 import org.openjdk.jmc.flightrecorder.configuration.recording.RecordingOptionsBuilder;
-import org.openjdk.jmc.rjmx.services.jfr.IFlightRecorderService;
 
-public interface RecordingOptionsBuilderFactory {
-    RecordingOptionsBuilder create(IFlightRecorderService service)
-            throws QuantityConversionException;
+import io.cryostat.targets.Target;
+import io.cryostat.targets.TargetConnectionManager;
+
+import io.smallrye.common.annotation.Blocking;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+
+@ApplicationScoped
+public class RecordingOptionsBuilderFactory {
+
+    @Inject RecordingOptionsCustomizerFactory customizerFactory;
+    @Inject TargetConnectionManager connectionManager;
+
+    @Blocking
+    public RecordingOptionsBuilder create(Target target) throws QuantityConversionException {
+        return connectionManager.executeConnectedTask(
+                target,
+                conn ->
+                        customizerFactory
+                                .create(target)
+                                .apply(new RecordingOptionsBuilder(conn.getService())));
+    }
 }

--- a/src/main/java/io/cryostat/recordings/RecordingOptionsCustomizerFactory.java
+++ b/src/main/java/io/cryostat/recordings/RecordingOptionsCustomizerFactory.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright The Cryostat Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.cryostat.recordings;
+
+import java.util.HashMap;
+
+import io.cryostat.core.RecordingOptionsCustomizer;
+import io.cryostat.targets.Target;
+import io.cryostat.targets.Target.EventKind;
+import io.cryostat.targets.Target.TargetDiscovery;
+
+import io.quarkus.vertx.ConsumeEvent;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import org.jboss.logging.Logger;
+
+@ApplicationScoped
+public class RecordingOptionsCustomizerFactory {
+
+    @Inject Logger logger;
+
+    private final HashMap<Target, RecordingOptionsCustomizer> customizers = new HashMap<>();
+
+    @ConsumeEvent(Target.TARGET_JVM_DISCOVERY)
+    void onMessage(TargetDiscovery event) {
+        if (EventKind.LOST.equals(event.kind())) {
+            customizers.remove(event.serviceRef());
+        }
+    }
+
+    public RecordingOptionsCustomizer create(Target target) {
+        return customizers.computeIfAbsent(
+                target, (t) -> new RecordingOptionsCustomizer(logger::debug));
+    }
+}

--- a/src/main/java/io/cryostat/recordings/Recordings.java
+++ b/src/main/java/io/cryostat/recordings/Recordings.java
@@ -113,7 +113,7 @@ public class Recordings {
     @Inject TargetConnectionManager connectionManager;
     @Inject EventBus bus;
     @Inject RecordingOptionsBuilderFactory recordingOptionsBuilderFactory;
-    @Inject RecordingOptionsCustomizer recordingOptionsCustomizer;
+    @Inject RecordingOptionsCustomizerFactory recordingOptionsCustomizerFactory;
     @Inject EventOptionsBuilder.Factory eventOptionsBuilderFactory;
     @Inject Clock clock;
     @Inject S3Client storage;
@@ -604,7 +604,7 @@ public class Recordings {
                         connection -> {
                             RecordingOptionsBuilder optionsBuilder =
                                     recordingOptionsBuilderFactory
-                                            .create(connection.getService())
+                                            .create(target)
                                             .name(recordingName);
                             if (duration.isPresent()) {
                                 optionsBuilder.duration(TimeUnit.SECONDS.toMillis(duration.get()));
@@ -884,8 +884,7 @@ public class Recordings {
         return connectionManager.executeConnectedTask(
                 target,
                 connection -> {
-                    RecordingOptionsBuilder builder =
-                            recordingOptionsBuilderFactory.create(connection.getService());
+                    RecordingOptionsBuilder builder = recordingOptionsBuilderFactory.create(target);
                     return getRecordingOptions(connection.getService(), builder);
                 });
     }
@@ -906,6 +905,9 @@ public class Recordings {
     @Blocking
     @Path("/api/v3/targets/{id}/recordingOptions")
     @RolesAllowed("read")
+    @SuppressFBWarnings(
+            value = "UC_USELESS_OBJECT",
+            justification = "SpotBugs thinks the options map is unused, but it is used")
     public Map<String, Object> patchRecordingOptions(
             @RestPath long id,
             @RestForm String toDisk,
@@ -914,20 +916,20 @@ public class Recordings {
             throws Exception {
         final String unsetKeyword = "unset";
 
-        Map<String, String> form = new HashMap<>();
+        Map<String, String> options = new HashMap<>();
         Pattern bool = Pattern.compile("true|false|" + unsetKeyword);
         if (toDisk != null) {
             Matcher m = bool.matcher(toDisk);
             if (!m.matches()) {
                 throw new BadRequestException("Invalid options");
             }
-            form.put("toDisk", toDisk);
+            options.put("toDisk", toDisk);
         }
         if (maxAge != null) {
             if (!unsetKeyword.equals(maxAge)) {
                 try {
                     Long.parseLong(maxAge);
-                    form.put("maxAge", maxAge);
+                    options.put("maxAge", maxAge);
                 } catch (NumberFormatException e) {
                     throw new BadRequestException("Invalid options");
                 }
@@ -937,31 +939,28 @@ public class Recordings {
             if (!unsetKeyword.equals(maxSize)) {
                 try {
                     Long.parseLong(maxSize);
-                    form.put("maxSize", maxSize);
+                    options.put("maxSize", maxSize);
                 } catch (NumberFormatException e) {
                     throw new BadRequestException("Invalid options");
                 }
             }
         }
-        form.entrySet()
-                .forEach(
-                        e -> {
-                            RecordingOptionsCustomizer.OptionKey optionKey =
-                                    RecordingOptionsCustomizer.OptionKey.fromOptionName(e.getKey())
-                                            .get();
-                            if ("unset".equals(e.getValue())) {
-                                recordingOptionsCustomizer.unset(optionKey);
-                            } else {
-                                recordingOptionsCustomizer.set(optionKey, e.getValue());
-                            }
-                        });
-
         Target target = Target.find("id", id).singleResult();
+        for (var entry : options.entrySet()) {
+            RecordingOptionsCustomizer.OptionKey optionKey =
+                    RecordingOptionsCustomizer.OptionKey.fromOptionName(entry.getKey()).get();
+            var recordingOptionsCustomizer = recordingOptionsCustomizerFactory.create(target);
+            if (unsetKeyword.equals(entry.getValue())) {
+                recordingOptionsCustomizer.unset(optionKey);
+            } else {
+                recordingOptionsCustomizer.set(optionKey, entry.getValue());
+            }
+        }
+
         return connectionManager.executeConnectedTask(
                 target,
                 connection -> {
-                    RecordingOptionsBuilder builder =
-                            recordingOptionsBuilderFactory.create(connection.getService());
+                    var builder = recordingOptionsBuilderFactory.create(target);
                     return getRecordingOptions(connection.getService(), builder);
                 });
     }

--- a/src/main/java/io/cryostat/recordings/RecordingsModule.java
+++ b/src/main/java/io/cryostat/recordings/RecordingsModule.java
@@ -15,37 +15,17 @@
  */
 package io.cryostat.recordings;
 
-import org.openjdk.jmc.flightrecorder.configuration.recording.RecordingOptionsBuilder;
-
 import io.cryostat.core.EventOptionsBuilder;
-import io.cryostat.core.RecordingOptionsCustomizer;
 
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.inject.Produces;
 import jakarta.inject.Singleton;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 @Singleton
 public class RecordingsModule {
-
-    @Produces
-    @ApplicationScoped
-    public RecordingOptionsBuilderFactory provideRecordingOptionsBuilderFactory(
-            RecordingOptionsCustomizer customizer) {
-        return service -> customizer.apply(new RecordingOptionsBuilder(service));
-    }
-
     @Produces
     @ApplicationScoped
     public EventOptionsBuilder.Factory provideEventOptionsBuilderFactory() {
         return new EventOptionsBuilder.Factory();
-    }
-
-    @Produces
-    @ApplicationScoped
-    public RecordingOptionsCustomizer provideRecordingOptionsCustomizer() {
-        Logger log = LoggerFactory.getLogger(RecordingOptionsCustomizer.class);
-        return new RecordingOptionsCustomizer(log::debug);
     }
 }

--- a/src/main/java/io/cryostat/rules/RuleService.java
+++ b/src/main/java/io/cryostat/rules/RuleService.java
@@ -32,7 +32,6 @@ import org.openjdk.jmc.flightrecorder.configuration.recording.RecordingOptionsBu
 import org.openjdk.jmc.rjmx.ConnectionException;
 import org.openjdk.jmc.rjmx.ServiceNotAvailableException;
 
-import io.cryostat.core.net.JFRConnection;
 import io.cryostat.core.templates.Template;
 import io.cryostat.core.templates.TemplateType;
 import io.cryostat.expressions.MatchExpressionEvaluator;
@@ -143,7 +142,7 @@ public class RuleService {
                 connectionManager.executeConnectedTask(
                         target,
                         connection -> {
-                            var recordingOptions = createRecordingOptions(rule, connection);
+                            var recordingOptions = createRecordingOptions(rule, target);
 
                             Pair<String, TemplateType> pair =
                                     recordingHelper.parseEventSpecifier(rule.eventSpecifier);
@@ -173,15 +172,13 @@ public class RuleService {
         }
     }
 
-    private IConstrainedMap<String> createRecordingOptions(Rule rule, JFRConnection connection)
+    private IConstrainedMap<String> createRecordingOptions(Rule rule, Target target)
             throws ConnectionException,
                     QuantityConversionException,
                     IOException,
                     ServiceNotAvailableException {
         RecordingOptionsBuilder optionsBuilder =
-                recordingOptionsBuilderFactory
-                        .create(connection.getService())
-                        .name(rule.getRecordingName());
+                recordingOptionsBuilderFactory.create(target).name(rule.getRecordingName());
         if (rule.maxAgeSeconds > 0) {
             optionsBuilder.maxAge(rule.maxAgeSeconds);
         }


### PR DESCRIPTION
# Welcome to Cryostat3! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat3/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] [Signed all commits using a GPG signature](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#gpg-commit-signature-verification)

**To recreate commits with GPG signature** `git fetch upstream && git rebase --force --gpg-sign upstream/main`
_______________________________________________

Fixes: #184

## Description of the change:
Refactors the `RecordingOptionsCustomizer` implementation so that there is an internal in-memory cache `Map<Target, RecordingOptionsCustomizer>`. This way, the `PATCH /api/v1/:connectUrl/recordingOptions` request can set recording options defaults (for the "advanced options" of `maxAge`/`maxSize`/`toDisk`) for each target. Cache entries are evicted if the target is lost. These settings are only held in-memory and not persisted.

## Motivation for the change:
Usually, clients do not actually set defaults on targets like this, instead simply setting these options on each recording in the same request as creating the recording. However, the API does expose this endpoint for setting per-target defaults, and so the implementation should actually respect this and ensure that the defaults are per-target rather than global to the server.

## How to manually test:
1. *Run CRYOSTAT_IMAGE=quay.io... bash smoketest.bash...*
2. Nothing should visibly change in the UI on its own, because the web-client never calls this `PATCH` endpoint. 
 
However, using `curl` or `http` you can make a manual request to this `PATCH` and the corresponding `GET` to see that the changes are reflected. If you do make such a `PATCH` then the default settings displayed in the UI under Recordings > Create should match the updated defaults you set.

```
 http -v --auth=user:pass :8080/api/v3/targets/1/recordingOptions
GET /api/v3/targets/1/recordingOptions HTTP/1.1
Accept: */*
Accept-Encoding: gzip, deflate, br
Authorization: Basic dXNlcjpwYXNz
Connection: keep-alive
Host: localhost:8080
User-Agent: HTTPie/3.2.2



HTTP/1.1 200 OK
Cache-Control: no-cache
Content-Encoding: gzip
Content-Length: 61
Content-Type: application/json;charset=UTF-8
Date: Fri, 22 Mar 2024 18:27:09 GMT
Gap-Auth: user

{
    "maxAge": 0,
    "maxSize": 0,
    "toDisk": false
}

$ http -v --auth=user:pass -f PATCH :8080/api/v3/targets/1/recordingOptions maxAge=90 maxSize=1000000
PATCH /api/v3/targets/1/recordingOptions HTTP/1.1
Accept: */*
Accept-Encoding: gzip, deflate, br
Authorization: Basic dXNlcjpwYXNz
Connection: keep-alive
Content-Length: 25
Content-Type: application/x-www-form-urlencoded; charset=utf-8
Host: localhost:8080
User-Agent: HTTPie/3.2.2

maxAge=90&maxSize=1000000

HTTP/1.1 200 OK
Content-Length: 46
Content-Type: application/json;charset=UTF-8
Date: Fri, 22 Mar 2024 18:27:58 GMT
Gap-Auth: user

{
    "maxAge": 90,
    "maxSize": 1000000,
    "toDisk": false
}

$ http -v --auth=user:pass :8080/api/v3/targets/1/recordingOptions
GET /api/v3/targets/1/recordingOptions HTTP/1.1
Accept: */*
Accept-Encoding: gzip, deflate, br
Authorization: Basic dXNlcjpwYXNz
Connection: keep-alive
Host: localhost:8080
User-Agent: HTTPie/3.2.2



HTTP/1.1 200 OK
Cache-Control: no-cache
Content-Encoding: gzip
Content-Length: 65
Content-Type: application/json;charset=UTF-8
Date: Fri, 22 Mar 2024 18:28:06 GMT
Gap-Auth: user

{
    "maxAge": 90,
    "maxSize": 1000000,
    "toDisk": false
}
```

This would previously already work, however the difference is that the updated `PATCH` settings would previously end up applying to all targets (despite the connectUrl or targetId in the request path), whereas now they apply to individual targets.