### PR TITLE
fix(jmx): restore error codes for auth and TLS connection failures

### DIFF
--- a/src/main/java/io/cryostat/ExceptionMappers.java
+++ b/src/main/java/io/cryostat/ExceptionMappers.java
@@ -92,14 +92,12 @@ public class ExceptionMappers {
     @ServerExceptionMapper
     public RestResponse<Void> mapJmxConnectionException(ConnectionException ex) {
         logger.warn(ex);
-        logger.warn("ServerExceptionMapper ConnectionException", ex);
         return RestResponse.status(HttpResponseStatus.BAD_GATEWAY.code());
     }
 
     @ServerExceptionMapper
     public RestResponse<Void> mapFlightRecorderException(
             org.openjdk.jmc.rjmx.services.jfr.FlightRecorderException ex) {
-        logger.warn("ServerExceptionMapper FlightRecorderException", ex);
         if (TargetConnectionManager.isJmxAuthFailure(ex)) {
             return RestResponse.status(HttpResponseStatus.FORBIDDEN.code());
         }

--- a/src/main/java/io/cryostat/ExceptionMappers.java
+++ b/src/main/java/io/cryostat/ExceptionMappers.java
@@ -92,13 +92,14 @@ public class ExceptionMappers {
     @ServerExceptionMapper
     public RestResponse<Void> mapJmxConnectionException(ConnectionException ex) {
         logger.warn(ex);
+        logger.warn("ServerExceptionMapper ConnectionException", ex);
         return RestResponse.status(HttpResponseStatus.BAD_GATEWAY.code());
     }
 
     @ServerExceptionMapper
     public RestResponse<Void> mapFlightRecorderException(
             org.openjdk.jmc.rjmx.services.jfr.FlightRecorderException ex) {
-        logger.warn(ex);
+        logger.warn("ServerExceptionMapper FlightRecorderException", ex);
         if (TargetConnectionManager.isJmxAuthFailure(ex)) {
             return RestResponse.status(HttpResponseStatus.FORBIDDEN.code());
         }

--- a/src/main/java/io/cryostat/ExceptionMappers.java
+++ b/src/main/java/io/cryostat/ExceptionMappers.java
@@ -19,9 +19,6 @@ import java.util.NoSuchElementException;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.ExecutionException;
 
-import org.openjdk.jmc.rjmx.ConnectionException;
-
-import io.cryostat.targets.TargetConnectionManager;
 import io.cryostat.util.EntityExistsException;
 
 import com.nimbusds.jwt.proc.BadJWTException;
@@ -87,21 +84,6 @@ public class ExceptionMappers {
     public RestResponse<Void> mapIllegalArgumentException(IllegalArgumentException ex) {
         logger.warn(ex);
         return RestResponse.status(HttpResponseStatus.BAD_REQUEST.code());
-    }
-
-    @ServerExceptionMapper
-    public RestResponse<Void> mapJmxConnectionException(ConnectionException ex) {
-        logger.warn(ex);
-        return RestResponse.status(HttpResponseStatus.BAD_GATEWAY.code());
-    }
-
-    @ServerExceptionMapper
-    public RestResponse<Void> mapFlightRecorderException(
-            org.openjdk.jmc.rjmx.services.jfr.FlightRecorderException ex) {
-        if (TargetConnectionManager.isJmxAuthFailure(ex)) {
-            return RestResponse.status(HttpResponseStatus.FORBIDDEN.code());
-        }
-        return RestResponse.status(HttpResponseStatus.BAD_GATEWAY.code());
     }
 
     @ServerExceptionMapper

--- a/src/main/java/io/cryostat/recordings/RecordingHelper.java
+++ b/src/main/java/io/cryostat/recordings/RecordingHelper.java
@@ -957,7 +957,7 @@ public class RecordingHelper {
         }
     }
 
-    static class SnapshotCreationException extends Exception {
+    public static class SnapshotCreationException extends Exception {
         public SnapshotCreationException(String message) {
             super(message);
         }

--- a/src/main/java/io/cryostat/targets/TargetConnectionManager.java
+++ b/src/main/java/io/cryostat/targets/TargetConnectionManager.java
@@ -208,7 +208,9 @@ public class TargetConnectionManager {
                 .onFailure(t -> !(t instanceof HttpException))
                 .retry()
                 .withBackOff(failedBackoff)
-                .expireIn(failedTimeout.plusMillis(System.currentTimeMillis()).toMillis());
+                .expireIn(failedTimeout.plusMillis(System.currentTimeMillis()).toMillis())
+                .onFailure(this::isTargetConnectionFailure)
+                .transform(t -> new HttpException(504, t));
     }
 
     public <T> T executeConnectedTask(Target target, ConnectedTask<T> task) {

--- a/src/main/java/io/cryostat/targets/TargetConnectionManager.java
+++ b/src/main/java/io/cryostat/targets/TargetConnectionManager.java
@@ -393,6 +393,10 @@ public class TargetConnectionManager {
         int depth = 0;
         Throwable cause = t;
         while (klazz.isInstance(t) && depth++ < maxDepth) {
+            var c = cause.getCause();
+            if (c == null) {
+                break;
+            }
             cause = cause.getCause();
         }
         return cause;

--- a/src/main/java/io/cryostat/targets/TargetConnectionManager.java
+++ b/src/main/java/io/cryostat/targets/TargetConnectionManager.java
@@ -41,6 +41,7 @@ import io.cryostat.core.net.JFRConnection;
 import io.cryostat.core.net.JFRConnectionToolkit;
 import io.cryostat.credentials.Credential;
 import io.cryostat.expressions.MatchExpressionEvaluator;
+import io.cryostat.recordings.RecordingHelper.SnapshotCreationException;
 import io.cryostat.targets.Target.EventKind;
 import io.cryostat.targets.Target.TargetDiscovery;
 
@@ -205,7 +206,10 @@ public class TargetConnectionManager {
                 .transform(t -> new HttpException(502, t))
                 .onFailure(this::isServiceTypeFailure)
                 .transform(t -> new HttpException(504, t))
-                .onFailure(t -> !(t instanceof HttpException))
+                .onFailure(
+                        t ->
+                                !(t instanceof HttpException)
+                                        && !(t instanceof SnapshotCreationException))
                 .retry()
                 .withBackOff(failedBackoff)
                 .expireIn(failedTimeout.plusMillis(System.currentTimeMillis()).toMillis())
@@ -237,7 +241,10 @@ public class TargetConnectionManager {
                 .transform(t -> new HttpException(502, t))
                 .onFailure(this::isServiceTypeFailure)
                 .transform(t -> new HttpException(504, t))
-                .onFailure(t -> !(t instanceof HttpException))
+                .onFailure(
+                        t ->
+                                !(t instanceof HttpException)
+                                        && !(t instanceof SnapshotCreationException))
                 .retry()
                 .withBackOff(failedBackoff)
                 .expireIn(failedTimeout.plusMillis(System.currentTimeMillis()).toMillis())

--- a/src/main/java/io/cryostat/targets/TargetConnectionManager.java
+++ b/src/main/java/io/cryostat/targets/TargetConnectionManager.java
@@ -413,7 +413,10 @@ public class TargetConnectionManager {
                 || ExceptionUtils.indexOfType(e, FlightRecorderException.class) >= 0;
     }
 
-    /** Check if the exception happened because the connection required authentication, and we had no credentials to present. */
+    /**
+     * Check if the exception happened because the connection required authentication, and we had no
+     * credentials to present.
+     */
     private boolean isJmxAuthFailure(Throwable t) {
         if (!(t instanceof Exception)) {
             return false;
@@ -425,7 +428,10 @@ public class TargetConnectionManager {
                 || ExceptionUtils.indexOfType(e, SaslException.class) >= 0;
     }
 
-    /** Check if the exception happened because the connection presented an SSL/TLS cert which we don't trust. */
+    /**
+     * Check if the exception happened because the connection presented an SSL/TLS cert which we
+     * don't trust.
+     */
     private boolean isJmxSslFailure(Throwable t) {
         if (!(t instanceof Exception)) {
             return false;

--- a/src/test/java/itest/TargetEventsGetTest.java
+++ b/src/test/java/itest/TargetEventsGetTest.java
@@ -114,7 +114,7 @@ public class TargetEventsGetTest extends StandardSelfTest {
         LinkedHashMap<String, Object> expectedResults = new LinkedHashMap<String, Object>();
         expectedResults.put("name", "Target Connection Opened");
         expectedResults.put(
-                "typeId", "io.cryostat.net.TargetConnectionManager.TargetConnectionOpened");
+                "typeId", "io.cryostat.targets.TargetConnectionManager.TargetConnectionOpened");
         expectedResults.put("description", "");
         expectedResults.put("category", List.of("Cryostat"));
         expectedResults.put(


### PR DESCRIPTION
# Welcome to Cryostat3! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat3/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] [Signed all commits using a GPG signature](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#gpg-commit-signature-verification)

**To recreate commits with GPG signature** `git fetch upstream && git rebase --force --gpg-sign upstream/main`
_______________________________________________

Fixes: #348

## Description of the change:
Adds exception handling to the TargetConnectionManager's internal `Uni` pipeline, to catch and transform particular types of connection exceptions into `HttpException` with the correct status codes that the previous API defined and which the UI expects.

## Motivation for the change:
This re-enables the ability for the UI to display the JMX auth and cert warning modals when attempting to connect to targets for which there are no correct stored credentials or which present an untrusted cert.

## How to manually test:
1. Check out and build PR, `smoketest.bash -Ot`
2. Select `9093` sample app, go to Events view. Templates and types should load.
3. Select `9094` sample app, go to Events view. Connection should fail and UI should display auth modal.
4. Select `9095` sample app, go to Events view. Connection should fail and UI should display cert modal.

Current "bugs":
- modal does not appear on the Recordings view when listing active recordings, but will appear if you click the "Create" button because the recording creation form will cause a query for event templates (triggering the same behaviour as the manual test above). This is because the `GET /api/v3/targets/{id}/recordings` endpoint for Cryostat 3.0 no longer initiates a direct JMX connection to the target as it did in previous releases. Instead, this endpoint only queries Cryostat's database for known ActiveRecordings. The JMX auth/cert failures would have been detected in the background when Cryostat discovered the target and attempted to connect. Related to #342 (some of the refactoring done to do more synchronization of "external" active recordings) and #71 (where targets' connection URLs would have a "connectable" state which could be used to flag and detect these cases).
