### PR TITLE
fix(rules): ensure archived recordings are sorted by age before pruning

### DIFF
--- a/src/main/java/io/cryostat/rules/ScheduledArchiveJob.java
+++ b/src/main/java/io/cryostat/rules/ScheduledArchiveJob.java
@@ -16,7 +16,6 @@
 package io.cryostat.rules;
 
 import java.util.ArrayDeque;
-import java.util.Comparator;
 import java.util.Objects;
 import java.util.Queue;
 import java.util.regex.Matcher;

--- a/src/main/java/io/cryostat/rules/ScheduledArchiveJob.java
+++ b/src/main/java/io/cryostat/rules/ScheduledArchiveJob.java
@@ -16,6 +16,7 @@
 package io.cryostat.rules;
 
 import java.util.ArrayDeque;
+import java.util.Comparator;
 import java.util.Objects;
 import java.util.Queue;
 import java.util.regex.Matcher;
@@ -69,7 +70,8 @@ class ScheduledArchiveJob implements Job {
 
     @Transactional
     void initPreviousRecordings(Target target, Rule rule, Queue<String> previousRecordings) {
-        recordingHelper.listArchivedRecordingObjects().parallelStream()
+        recordingHelper.listArchivedRecordingObjects().stream()
+                .sorted((a, b) -> a.lastModified().compareTo(b.lastModified()))
                 .forEach(
                         item -> {
                             String path = item.key().strip();


### PR DESCRIPTION
# Welcome to Cryostat3! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat3/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] [Signed all commits using a GPG signature](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#gpg-commit-signature-verification)

**To recreate commits with GPG signature** `git fetch upstream && git rebase --force --gpg-sign upstream/main`
_______________________________________________

Fixes: #357
Depends on #356

## Description of the change:
*This change allows an environment variable to be configured so that...*

## Motivation for the change:
*This change is helpful because users may want to...*

## How to manually test:
1. *Run CRYOSTAT_IMAGE=quay.io... bash smoketest.bash...*
2. *...*
