### PR TITLE
fix(oauth): enable signout redirect

### DIFF
--- a/src/main/java/io/cryostat/security/Auth.java
+++ b/src/main/java/io/cryostat/security/Auth.java
@@ -15,6 +15,7 @@
  */
 package io.cryostat.security;
 
+import java.net.URI;
 import java.util.Map;
 
 import io.cryostat.V2Response;
@@ -27,6 +28,7 @@ import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.Context;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
+import org.jboss.resteasy.reactive.RestResponse;
 
 @Path("")
 public class Auth {
@@ -36,7 +38,9 @@ public class Auth {
     @PermitAll
     @Produces(MediaType.APPLICATION_JSON)
     public Response logout(@Context RoutingContext context) {
-        return Response.noContent().build();
+        return Response.status(RestResponse.Status.PERMANENT_REDIRECT)
+                .location(URI.create("/oauth2/sign_out"))
+                .build();
     }
 
     @POST


### PR DESCRIPTION
# Welcome to Cryostat3! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat3/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] [Signed all commits using a GPG signature](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#gpg-commit-signature-verification)

**To recreate commits with GPG signature** `git fetch upstream && git rebase --force --gpg-sign upstream/main`
_______________________________________________

Related to #365
Depends on https://github.com/cryostatio/cryostat-web/pull/1236

## Description of the change:
When clicking the "logout" button in the application masthead, the web-client sends a request to the Cryostat server at `/api/v2.1/logout`. The current implementation just treats this as a no-op and returns HTTP 204. This new implementation responds with a redirect instructing the client to go to `/oauth2/sign_out`, which triggers the logout flow of the auth proxy.

## Motivation for the change:
Re-enables the ability for the user to log out.

## How to manually test:
1. Check out this PR
2. `./mvnw clean package ; podman image prune -f ; ./smoketest.bash -O`
3. Open UI, log in with `user:pass`, go to UI. Then click user icon and "logout" on the masthead. You should be returned back to the authproxy login screen. If you refresh here you should still be on the login screen (not re-entered into the Cryostat UI).
