### PR TITLE
build(arch): use build arch profiles for native dependency classification

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,6 +16,9 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
+    <build.os>linux</build.os>
+    <build.arch>amd64</build.arch>
+
     <io.cryostat.core.version>2.30.1</io.cryostat.core.version>
 
     <org.apache.commons.codec.version>1.16.1</org.apache.commons.codec.version>
@@ -31,6 +34,7 @@
     <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
     <quarkus.platform.version>3.2.9.Final</quarkus.platform.version>
     <quarkus-quinoa.version>2.3.6</quarkus-quinoa.version>
+    <io.netty.version>4.1.101.Final</io.netty.version>
     <org.codehaus.mojo.build.helper.plugin.version>3.5.0</org.codehaus.mojo.build.helper.plugin.version>
 
     <com.github.spotbugs.version>4.8.4</com.github.spotbugs.version>
@@ -45,6 +49,13 @@
   </properties>
   <dependencyManagement>
     <dependencies>
+      <dependency>
+        <groupId>io.netty</groupId>
+        <artifactId>netty-bom</artifactId>
+        <version>${io.netty.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
       <dependency>
         <groupId>${quarkus.platform.group-id}</groupId>
         <artifactId>${quarkus.platform.artifact-id}</artifactId>
@@ -189,16 +200,6 @@
     <dependency>
       <groupId>io.quarkus</groupId>
       <artifactId>quarkus-quartz</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>io.netty</groupId>
-      <artifactId>netty-transport-native-epoll</artifactId>
-      <classifier>linux-x86_64</classifier>
-    </dependency>
-    <dependency>
-      <groupId>io.netty</groupId>
-      <artifactId>netty-transport-native-kqueue</artifactId>
-      <classifier>osx-x86_64</classifier>
     </dependency>
     <dependency>
       <groupId>com.google.googlejavaformat</groupId>
@@ -421,5 +422,85 @@
         <quarkus.package.type>native</quarkus.package.type>
       </properties>
     </profile>
+
+    <profile>
+      <id>default-arch</id>
+      <activation>
+        <property>
+          <name>!build.arch</name>
+        </property>
+      </activation>
+      <properties>
+        <io.netty.netty-transport-native-epoll.classifier>${build.os}-x86_64</io.netty.netty-transport-native-epoll.classifier>
+        <io.netty.netty-transport-native-epoll.scope>compile</io.netty.netty-transport-native-epoll.scope>
+      </properties>
+    </profile>
+    <profile>
+      <id>amd64</id>
+      <activation>
+        <property>
+          <name>build.arch</name>
+          <value>amd64</value>
+        </property>
+      </activation>
+      <properties>
+        <io.netty.netty-transport-native-epoll.classifier>${build.os}-x86_64</io.netty.netty-transport-native-epoll.classifier>
+        <io.netty.netty-transport-native-epoll.scope>compile</io.netty.netty-transport-native-epoll.scope>
+      </properties>
+    </profile>
+    <profile>
+      <id>arm64</id>
+      <activation>
+        <property>
+          <name>build.arch</name>
+          <value>arm64</value>
+        </property>
+      </activation>
+      <properties>
+        <io.netty.netty-transport-native-epoll.classifier>${build.os}-aarch_64</io.netty.netty-transport-native-epoll.classifier>
+        <io.netty.netty-transport-native-epoll.scope>compile</io.netty.netty-transport-native-epoll.scope>
+      </properties>
+    </profile>
+    <profile>
+      <id>with-epoll</id>
+      <activation>
+        <property>
+          <name>!build.exclude-epoll</name>
+        </property>
+      </activation>
+      <properties>
+        <io.netty.netty-transport-native-epoll.scope>compile</io.netty.netty-transport-native-epoll.scope>
+      </properties>
+      <dependencies>
+        <dependency>
+          <groupId>io.netty</groupId>
+          <artifactId>netty-transport-native-epoll</artifactId>
+          <version>${io.netty.version}</version>
+          <classifier>${io.netty.netty-transport-native-epoll.classifier}</classifier>
+          <scope>${io.netty.netty-transport-native-epoll.scope}</scope>
+        </dependency>
+      </dependencies>
+    </profile>
+    <profile>
+      <id>no-epoll</id>
+      <activation>
+        <property>
+          <name>build.exclude-epoll</name>
+        </property>
+      </activation>
+      <properties>
+        <io.netty.netty-transport-native-epoll.classifier>${build.os}-x86_64</io.netty.netty-transport-native-epoll.classifier>
+        <io.netty.netty-transport-native-epoll.scope>provided</io.netty.netty-transport-native-epoll.scope>
+      </properties>
+      <dependencies>
+        <dependency>
+          <groupId>io.netty</groupId>
+          <artifactId>netty-transport-native-epoll</artifactId>
+          <classifier>${io.netty.netty-transport-native-epoll.classifier}</classifier>
+          <scope>${io.netty.netty-transport-native-epoll.scope}</scope>
+        </dependency>
+      </dependencies>
+    </profile>
+
   </profiles>
 </project>


### PR DESCRIPTION
# Welcome to Cryostat3! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat3/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] [Signed all commits using a GPG signature](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#gpg-commit-signature-verification)

**To recreate commits with GPG signature** `git fetch upstream && git rebase --force --gpg-sign upstream/main`
_______________________________________________

Fixes: #369

## Description of the change:
Adds Maven build profiles for build arch (ex. amd64, arm64) and for including or excluding `epoll`. `epoll` is used for Unix domain sockets, which we use in `ContainerDiscovery` for Docker/Podman API discovery of potential target containers.

## Motivation for the change:
Since the Netty `epoll` is a native dependency, ie contains compiled code rather than Java bytecode, the correct architecture for this dependency must be selected at build time to match the architecture of the machine that the container will run upon. Before this PR the dependency is hardcoded to `amd64`, so container discovery cannot function on other architectures such as `arm64`.

## How to manually test:
1. *Run CRYOSTAT_IMAGE=quay.io... bash smoketest.bash...*
2. Ensure Docker/Podman discovery is still working
3. If an ARM64 machine is available, try a rebuild with `./mvnw -Dbuild.arch=arm64 ...` and re-run the smoketest. Docker/Podman discovery should also work here. See https://github.com/cryostatio/cryostat/pull/1548

Still TODO: ensure that the upstream CI builds multiarch images with the correct `epoll` pulled in for each image within the multiarch manifest
