### PR TITLE
feat(jmcagent): JMC Agent Feature Parity

### DIFF
--- a/schema/openapi.yaml
+++ b/schema/openapi.yaml
@@ -1242,6 +1242,46 @@ paths:
           description: OK
       tags:
         - Discovery
+  /api/v2/probes:
+    get:
+      responses:
+        "200":
+          description: OK
+      tags:
+        - JMC Agent
+  /api/v2/probes/{probeTemplateName}:
+    delete:
+      parameters:
+        - in: path
+          name: probeTemplateName
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: OK
+      tags:
+        - JMC Agent
+    post:
+      parameters:
+        - in: path
+          name: probeTemplateName
+          required: true
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              properties:
+                probeTemplate:
+                  $ref: '#/components/schemas/FileUpload'
+              type: object
+      responses:
+        "200":
+          description: OK
+      tags:
+        - JMC Agent
   /api/v2/rules:
     get:
       responses:
@@ -1519,6 +1559,52 @@ paths:
         - SecurityScheme: []
       tags:
         - Events
+  /api/v2/targets/{connectUrl}/probes:
+    delete:
+      parameters:
+        - in: path
+          name: connectUrl
+          required: true
+          schema:
+            format: uri
+            type: string
+      responses:
+        "200":
+          description: OK
+      tags:
+        - JMC Agent
+    get:
+      parameters:
+        - in: path
+          name: connectUrl
+          required: true
+          schema:
+            format: uri
+            type: string
+      responses:
+        "200":
+          description: OK
+      tags:
+        - JMC Agent
+  /api/v2/targets/{connectUrl}/probes/{probeTemplateName}:
+    post:
+      parameters:
+        - in: path
+          name: connectUrl
+          required: true
+          schema:
+            format: uri
+            type: string
+        - in: path
+          name: probeTemplateName
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: OK
+      tags:
+        - JMC Agent
   /api/v2/targets/{connectUrl}/snapshot:
     post:
       parameters:
@@ -1723,6 +1809,50 @@ paths:
         - SecurityScheme: []
       tags:
         - Recordings
+  /api/v3/probes:
+    get:
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/V2Response'
+          description: OK
+      tags:
+        - JMC Agent
+  /api/v3/probes/{probeTemplateName}:
+    delete:
+      parameters:
+        - in: path
+          name: probeTemplateName
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: OK
+      tags:
+        - JMC Agent
+    post:
+      parameters:
+        - in: path
+          name: probeTemplateName
+          required: true
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              properties:
+                probeTemplate:
+                  $ref: '#/components/schemas/FileUpload'
+              type: object
+      responses:
+        "200":
+          description: OK
+      tags:
+        - JMC Agent
   /api/v3/reports/{encodedKey}:
     get:
       parameters:
@@ -1896,6 +2026,56 @@ paths:
         - SecurityScheme: []
       tags:
         - Events
+  /api/v3/targets/{id}/probes:
+    delete:
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            format: int64
+            type: integer
+      responses:
+        "200":
+          description: OK
+      tags:
+        - JMC Agent
+    get:
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            format: int64
+            type: integer
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/V2Response'
+          description: OK
+      tags:
+        - JMC Agent
+  /api/v3/targets/{id}/probes/{probeTemplateName}:
+    post:
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            format: int64
+            type: integer
+        - in: path
+          name: probeTemplateName
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: OK
+      tags:
+        - JMC Agent
   /api/v3/targets/{id}/recordingOptions:
     get:
       parameters:

--- a/smoketest.bash
+++ b/smoketest.bash
@@ -16,7 +16,7 @@ PULL_IMAGES=${PULL_IMAGES:-true}
 KEEP_VOLUMES=${KEEP_VOLUMES:-false}
 OPEN_TABS=${OPEN_TABS:-false}
 
-PRECREATE_BUCKETS=${PRECREATE_BUCKETS:-archivedrecordings,archivedreports,eventtemplates}
+PRECREATE_BUCKETS=${PRECREATE_BUCKETS:-archivedrecordings,archivedreports,eventtemplates,probes}
 
 CRYOSTAT_HTTP_PORT=${CRYOSTAT_HTTP_PORT:-8080}
 USE_PROXY=${USE_PROXY:-true}

--- a/src/main/java/io/cryostat/ConfigProperties.java
+++ b/src/main/java/io/cryostat/ConfigProperties.java
@@ -19,6 +19,8 @@ public class ConfigProperties {
     public static final String AWS_BUCKET_NAME_ARCHIVES = "storage.buckets.archives.name";
     public static final String AWS_BUCKET_NAME_EVENT_TEMPLATES =
             "storage.buckets.event-templates.name";
+    public static final String AWS_BUCKET_NAME_PROBE_TEMPLATES =
+            "storage.buckets.probe-templates.name";
     public static final String AWS_OBJECT_EXPIRATION_LABELS =
             "storage.buckets.archives.expiration-label";
 

--- a/src/main/java/io/cryostat/jmcagent/JMCAgent.java
+++ b/src/main/java/io/cryostat/jmcagent/JMCAgent.java
@@ -63,7 +63,6 @@ public class JMCAgent {
     @POST
     @Path("/api/v3/targets/{id}/probes/{probeTemplateName}")
     public Response postProbe(@RestPath long id, @RestPath String probeTemplateName) {
-        logger.info("Did we get here? postProbe");
         try {
             Target target = Target.getTargetById(id);
             return connectionManager.executeConnectedTask(
@@ -107,7 +106,6 @@ public class JMCAgent {
     @DELETE
     @Path("/api/v3/targets/{id}/probes")
     public Response deleteProbe(@RestPath long id) {
-        logger.info("Did we get here? deleteProbe");
         try {
             Target target = Target.getTargetById(id);
             return connectionManager.executeConnectedTask(
@@ -192,7 +190,6 @@ public class JMCAgent {
     @GET
     @Path("/api/v3/probes")
     public List<ProbeTemplate> getProbeTemplates() {
-        logger.info("Did we get here? getProbeTemplates");
         try {
             return service.getTemplates();
         } catch (Exception e) {
@@ -214,7 +211,6 @@ public class JMCAgent {
     @DELETE
     @Path("/api/v3/probes/{probeTemplateName}")
     public Response deleteProbeTemplate(@RestPath String probeTemplateName) {
-        logger.info("Did we get here? deleteProbeTemplate");
         try {
             service.deleteTemplate(probeTemplateName);
             return Response.status(RestResponse.Status.OK).build();
@@ -238,7 +234,6 @@ public class JMCAgent {
     @Path("/api/v3/probes/{probeTemplateName}")
     public Response uploadProbeTemplate(
             @RestForm("probeTemplate") FileUpload body, @RestPath String probeTemplateName) {
-        logger.info("Did we get here? uploadProbeTemplate");
         if (body == null || body.filePath() == null || !"probeTemplate".equals(body.name())) {
             throw new BadRequestException();
         }

--- a/src/main/java/io/cryostat/jmcagent/JMCAgent.java
+++ b/src/main/java/io/cryostat/jmcagent/JMCAgent.java
@@ -179,11 +179,7 @@ public class JMCAgent {
     public Response getProbesv2(@RestPath URI connectUrl) {
         Target target = Target.getTargetByConnectUrl(connectUrl);
         return Response.status(RestResponse.Status.PERMANENT_REDIRECT)
-                .location(
-                        URI.create(
-                                String.format(
-                                        "/api/v3/targets/%d/probes",
-                                        target.id)))
+                .location(URI.create(String.format("/api/v3/targets/%d/probes", target.id)))
                 .build();
     }
 

--- a/src/main/java/io/cryostat/jmcagent/JMCAgent.java
+++ b/src/main/java/io/cryostat/jmcagent/JMCAgent.java
@@ -143,29 +143,29 @@ public class JMCAgent {
     @Blocking
     @GET
     @Path("/api/v3/targets/{id}/probes")
-    public List<String> getProbes(@RestPath long id) {
+    public List<Event> getProbes(@RestPath long id) {
         try {
             Target target = Target.getTargetById(id);
             return connectionManager.executeConnectedTask(
                     target,
                     connection -> {
-                        List<String> response = new ArrayList<String>();
                         AgentJMXHelper helper = new AgentJMXHelper(connection.getHandle());
+                        List<Event> result = new ArrayList<>();
+                        String probes = helper.retrieveEventProbes();
                         try {
-                            String probes = helper.retrieveEventProbes();
                             if (probes != null && !probes.isBlank()) {
                                 ProbeTemplate template = new ProbeTemplate();
                                 template.deserialize(
                                         new ByteArrayInputStream(
                                                 probes.getBytes(StandardCharsets.UTF_8)));
                                 for (Event e : template.getEvents()) {
-                                    response.add(e.toString());
+                                    result.add(e);
                                 }
                             }
+                            return result;
                         } catch (Exception e) {
                             throw new BadRequestException(e);
                         }
-                        return response;
                     });
         } catch (Exception e) {
             logger.warn("Caught exception" + e.toString(), e);

--- a/src/main/java/io/cryostat/jmcagent/JMCAgent.java
+++ b/src/main/java/io/cryostat/jmcagent/JMCAgent.java
@@ -69,19 +69,24 @@ public class JMCAgent {
             return connectionManager.executeConnectedTask(
                     target,
                     connection -> {
-                        AgentJMXHelper helper = new AgentJMXHelper(connection.getHandle());
-                        String templateContent = service.getTemplateContent(probeTemplateName);
-                        helper.defineEventProbes(templateContent);
-                        ProbeTemplate template = new ProbeTemplate();
-                        template.deserialize(
-                                new ByteArrayInputStream(
-                                        templateContent.getBytes(StandardCharsets.UTF_8)));
-                        bus.publish(
-                                MessagingServer.class.getName(),
-                                new Notification(
-                                        TEMPLATE_APPLIED_CATEGORY,
-                                        Map.of("probeTemplate", template.getFileName())));
-                        return Response.status(RestResponse.Status.OK).build();
+                        try {
+                            AgentJMXHelper helper = new AgentJMXHelper(connection.getHandle());
+                            String templateContent = service.getTemplateContent(probeTemplateName);
+                            helper.defineEventProbes(templateContent);
+                            ProbeTemplate template = new ProbeTemplate();
+                            template.deserialize(
+                                    new ByteArrayInputStream(
+                                            templateContent.getBytes(StandardCharsets.UTF_8)));
+                            bus.publish(
+                                    MessagingServer.class.getName(),
+                                    new Notification(
+                                            TEMPLATE_APPLIED_CATEGORY,
+                                            Map.of("probeTemplate", template.getFileName())));
+                            return Response.status(RestResponse.Status.OK).build();
+                        } catch (Exception e) {
+                            return Response.status(RestResponse.Status.INTERNAL_SERVER_ERROR)
+                                    .build();
+                        }
                     });
         } catch (Exception e) {
             logger.warn("Caught exception" + e.toString(), e);
@@ -112,15 +117,21 @@ public class JMCAgent {
             return connectionManager.executeConnectedTask(
                     target,
                     connection -> {
-                        AgentJMXHelper helper = new AgentJMXHelper(connection.getHandle());
-                        // The convention for removing probes in the agent controller mbean is to
-                        // call defineEventProbes with a null argument.
-                        helper.defineEventProbes(null);
-                        bus.publish(
-                                MessagingServer.class.getName(),
-                                new Notification(
-                                        PROBES_REMOVED_CATEGORY, Map.of("target", target.id)));
-                        return Response.status(RestResponse.Status.OK).build();
+                        try {
+                            AgentJMXHelper helper = new AgentJMXHelper(connection.getHandle());
+                            // The convention for removing probes in the agent controller mbean is
+                            // to
+                            // call defineEventProbes with a null argument.
+                            helper.defineEventProbes(null);
+                            bus.publish(
+                                    MessagingServer.class.getName(),
+                                    new Notification(
+                                            PROBES_REMOVED_CATEGORY, Map.of("target", target.id)));
+                            return Response.status(RestResponse.Status.OK).build();
+                        } catch (Exception e) {
+                            return Response.status(RestResponse.Status.INTERNAL_SERVER_ERROR)
+                                    .build();
+                        }
                     });
         } catch (Exception e) {
             logger.warn("Caught exception" + e.toString(), e);

--- a/src/main/java/io/cryostat/jmcagent/JMCAgent.java
+++ b/src/main/java/io/cryostat/jmcagent/JMCAgent.java
@@ -22,6 +22,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
+import io.cryostat.V2Response;
 import io.cryostat.core.agent.AgentJMXHelper;
 import io.cryostat.core.agent.Event;
 import io.cryostat.core.agent.ProbeTemplate;
@@ -143,7 +144,7 @@ public class JMCAgent {
     @Blocking
     @GET
     @Path("/api/v3/targets/{id}/probes")
-    public List<Event> getProbes(@RestPath long id) {
+    public V2Response getProbes(@RestPath long id) {
         try {
             Target target = Target.getTargetById(id);
             return connectionManager.executeConnectedTask(
@@ -162,7 +163,7 @@ public class JMCAgent {
                                     result.add(e);
                                 }
                             }
-                            return result;
+                            return V2Response.json(Response.Status.OK, result);
                         } catch (Exception e) {
                             throw new BadRequestException(e);
                         }
@@ -186,11 +187,13 @@ public class JMCAgent {
     @Blocking
     @GET
     @Path("/api/v3/probes")
-    public List<SerializableProbeTemplateInfo> getProbeTemplates() {
+    public V2Response getProbeTemplates() {
         try {
-            return service.getTemplates().stream()
-                    .map(SerializableProbeTemplateInfo::fromProbeTemplate)
-                    .toList();
+            return V2Response.json(
+                    Response.Status.OK,
+                    service.getTemplates().stream()
+                            .map(SerializableProbeTemplateInfo::fromProbeTemplate)
+                            .toList());
         } catch (Exception e) {
             logger.warn("Caught exception" + e.toString(), e);
             throw new BadRequestException(e);

--- a/src/main/java/io/cryostat/jmcagent/JMCAgent.java
+++ b/src/main/java/io/cryostat/jmcagent/JMCAgent.java
@@ -249,7 +249,7 @@ public class JMCAgent {
     @Blocking
     @POST
     @Path("/api/v2/probes")
-    public Response postProbeTemplatesv2(
+    public Response postProbeTemplatev2(
             @RestForm("probeTemplate") FileUpload body, @RestPath String probeTemplateName) {
         return Response.status(RestResponse.Status.PERMANENT_REDIRECT)
                 .location(URI.create(String.format("/api/v3/probes/%s", probeTemplateName)))

--- a/src/main/java/io/cryostat/jmcagent/JMCAgent.java
+++ b/src/main/java/io/cryostat/jmcagent/JMCAgent.java
@@ -24,6 +24,7 @@ import java.util.Map;
 
 import io.cryostat.V2Response;
 import io.cryostat.core.agent.AgentJMXHelper;
+import io.cryostat.core.agent.AgentJMXHelper.ProbeDefinitionException;
 import io.cryostat.core.agent.Event;
 import io.cryostat.core.agent.ProbeTemplate;
 import io.cryostat.core.sys.FileSystem;
@@ -84,7 +85,7 @@ public class JMCAgent {
                                             TEMPLATE_APPLIED_CATEGORY,
                                             Map.of("probeTemplate", template.getFileName())));
                             return Response.status(RestResponse.Status.OK).build();
-                        } catch (Exception e) {
+                        } catch (ProbeDefinitionException e) {
                             // Cleanup the probes if something went wrong, calling defineEventProbes
                             // with a null argument will remove any active probes.
                             helper.defineEventProbes(null);

--- a/src/main/java/io/cryostat/jmcagent/JMCAgent.java
+++ b/src/main/java/io/cryostat/jmcagent/JMCAgent.java
@@ -1,0 +1,149 @@
+/*
+ * Copyright The Cryostat Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.cryostat.jmcagent;
+
+import java.io.ByteArrayInputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+
+import io.cryostat.core.agent.AgentJMXHelper;
+import io.cryostat.core.agent.Event;
+import io.cryostat.core.agent.ProbeTemplate;
+import io.cryostat.core.sys.FileSystem;
+import io.cryostat.targets.Target;
+import io.cryostat.targets.TargetConnectionManager;
+
+import jakarta.inject.Inject;
+import jakarta.ws.rs.BadRequestException;
+import jakarta.ws.rs.DELETE;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.core.Response;
+import org.jboss.logging.Logger;
+import org.jboss.resteasy.reactive.RestForm;
+import org.jboss.resteasy.reactive.RestPath;
+import org.jboss.resteasy.reactive.RestResponse;
+import org.jboss.resteasy.reactive.multipart.FileUpload;
+
+@Path("")
+public class JMCAgent {
+
+    @Inject Logger logger;
+    @Inject TargetConnectionManager connectionManager;
+    @Inject S3ProbeTemplateService service;
+    @Inject FileSystem fs;
+
+    @POST
+    @Path("/api/v3/targets/{id}/probes/{probeTemplateName}")
+    public Response postProbe(@RestPath long id, @RestPath String probeTemplateName) {
+        try {
+            Target target = Target.find("id", id).singleResult();
+            return connectionManager.executeConnectedTask(
+                    target,
+                    connection -> {
+                        AgentJMXHelper helper = new AgentJMXHelper(connection.getHandle());
+                        String templateContent = service.getTemplateContent(probeTemplateName);
+                        helper.defineEventProbes(templateContent);
+                        ProbeTemplate template = new ProbeTemplate();
+                        template.deserialize(
+                                new ByteArrayInputStream(
+                                        templateContent.getBytes(StandardCharsets.UTF_8)));
+                        return Response.status(RestResponse.Status.OK).build();
+                    });
+        } catch (Exception e) {
+            throw new BadRequestException(e);
+        }
+    }
+
+    @DELETE
+    @Path("/api/v3/targets/{id}/probes")
+    public Response deleteProbe(@RestPath long id) {
+        try {
+            Target target = Target.find("id", id).singleResult();
+            return connectionManager.executeConnectedTask(
+                    target,
+                    connection -> {
+                        AgentJMXHelper helper = new AgentJMXHelper(connection.getHandle());
+                        // The convention for removing probes in the agent controller mbean is to
+                        // call defineEventProbes with a null argument.
+                        helper.defineEventProbes(null);
+                        return Response.status(RestResponse.Status.OK).build();
+                    });
+        } catch (Exception e) {
+            throw new BadRequestException(e);
+        }
+    }
+
+    @GET
+    @Path("/api/v3/targets/{id}/probes")
+    public List<Event> getProbes(@RestPath long id) {
+        try {
+            Target target = Target.find("id", id).singleResult();
+            return connectionManager.executeConnectedTask(
+                    target,
+                    connection -> {
+                        List<Event> response = new ArrayList<Event>();
+                        AgentJMXHelper helper = new AgentJMXHelper(connection.getHandle());
+                        try {
+                            String probes = helper.retrieveEventProbes();
+                            if (probes != null && !probes.isBlank()) {
+                                ProbeTemplate template = new ProbeTemplate();
+                                template.deserialize(
+                                        new ByteArrayInputStream(
+                                                probes.getBytes(StandardCharsets.UTF_8)));
+                                for (Event e : template.getEvents()) {
+                                    response.add(e);
+                                }
+                            }
+                        } catch (Exception e) {
+                            throw new BadRequestException(e);
+                        }
+                        return response;
+                    });
+        } catch (Exception e) {
+            throw new BadRequestException(e);
+        }
+    }
+
+    @DELETE
+    @Path("/api/v3/probes/{probeTemplateName}")
+    public Response deleteProbeTemplate(@RestPath String probeTemplateName) {
+        try {
+            service.deleteTemplate(probeTemplateName);
+            return Response.status(RestResponse.Status.OK).build();
+        } catch (Exception e) {
+            throw new BadRequestException(e);
+        }
+    }
+
+    @POST
+    @Path("/api/v3/probes/{probeTemplateName}")
+    public Response uploadProbeTemplate(
+            @RestForm("probeTemplate") FileUpload body, @RestPath String probeTemplateName) {
+        if (body == null || body.filePath() == null || !"probeTemplate".equals(body.name())) {
+            throw new BadRequestException();
+        }
+        try (var stream = fs.newInputStream(body.filePath())) {
+            service.addTemplate(stream, probeTemplateName);
+            return Response.status(RestResponse.Status.OK).build();
+        } catch (Exception e) {
+            logger.error(e.getMessage(), e);
+            throw new BadRequestException(e);
+        }
+    }
+}

--- a/src/main/java/io/cryostat/jmcagent/JMCAgent.java
+++ b/src/main/java/io/cryostat/jmcagent/JMCAgent.java
@@ -177,12 +177,13 @@ public class JMCAgent {
     @GET
     @Path("/api/v2/targets/{connectUrl}/probes")
     public Response getProbesv2(@RestPath URI connectUrl) {
+        Target target = Target.getTargetByConnectUrl(connectUrl);
         return Response.status(RestResponse.Status.PERMANENT_REDIRECT)
                 .location(
                         URI.create(
                                 String.format(
                                         "/api/v3/targets/%d/probes",
-                                        Target.getTargetByConnectUrl(connectUrl).id)))
+                                        target.id)))
                 .build();
     }
 
@@ -224,7 +225,7 @@ public class JMCAgent {
 
     @Blocking
     @DELETE
-    @Path("/api/v2/probes")
+    @Path("/api/v2/probes/{probeTemplateName}")
     public Response deleteProbeTemplatesv2(@RestPath String probeTemplateName) {
         return Response.status(RestResponse.Status.PERMANENT_REDIRECT)
                 .location(URI.create(String.format("/api/v3/probes/%s", probeTemplateName)))
@@ -250,7 +251,7 @@ public class JMCAgent {
 
     @Blocking
     @POST
-    @Path("/api/v2/probes")
+    @Path("/api/v2/probes/{probeTemplateName}")
     public Response postProbeTemplatev2(
             @RestForm("probeTemplate") FileUpload body, @RestPath String probeTemplateName) {
         return Response.status(RestResponse.Status.PERMANENT_REDIRECT)

--- a/src/main/java/io/cryostat/jmcagent/S3ProbeTemplateService.java
+++ b/src/main/java/io/cryostat/jmcagent/S3ProbeTemplateService.java
@@ -200,7 +200,8 @@ public class S3ProbeTemplateService implements ProbeTemplateService {
                     RequestBody.fromString(template.serialize()));
             bus.publish(
                     MessagingServer.class.getName(),
-                    new Notification(TEMPLATE_UPLOADED_CATEGORY, Map.of("probeTemplate", template)));
+                    new Notification(
+                            TEMPLATE_UPLOADED_CATEGORY, Map.of("probeTemplate", template)));
             return template;
         }
     }

--- a/src/main/java/io/cryostat/jmcagent/S3ProbeTemplateService.java
+++ b/src/main/java/io/cryostat/jmcagent/S3ProbeTemplateService.java
@@ -114,7 +114,7 @@ public class S3ProbeTemplateService implements ProbeTemplateService {
         if (storage.deleteObject(req).sdkHttpResponse().isSuccessful()) {
             bus.publish(
                     MessagingServer.class.getName(),
-                    new Notification(TEMPLATE_DELETED_CATEGORY, Map.of("probeTemplate", template)));
+                    new Notification(TEMPLATE_DELETED_CATEGORY, Map.of("probeTemplate", template.getFileName())));
         }
     }
 

--- a/src/main/java/io/cryostat/jmcagent/S3ProbeTemplateService.java
+++ b/src/main/java/io/cryostat/jmcagent/S3ProbeTemplateService.java
@@ -55,7 +55,7 @@ import software.amazon.awssdk.services.s3.model.Tagging;
 
 public class S3ProbeTemplateService implements ProbeTemplateService {
 
-    @ConfigProperty(name = ConfigProperties.AWS_BUCKET_NAME_EVENT_TEMPLATES)
+    @ConfigProperty(name = ConfigProperties.AWS_BUCKET_NAME_PROBE_TEMPLATES)
     String bucket;
 
     @Inject S3Client storage;

--- a/src/main/java/io/cryostat/jmcagent/S3ProbeTemplateService.java
+++ b/src/main/java/io/cryostat/jmcagent/S3ProbeTemplateService.java
@@ -201,7 +201,8 @@ public class S3ProbeTemplateService implements ProbeTemplateService {
             bus.publish(
                     MessagingServer.class.getName(),
                     new Notification(
-                            TEMPLATE_UPLOADED_CATEGORY, Map.of("probeTemplate", template)));
+                            TEMPLATE_UPLOADED_CATEGORY,
+                            Map.of("probeTemplate", template.getFileName())));
             return template;
         }
     }
@@ -210,7 +211,7 @@ public class S3ProbeTemplateService implements ProbeTemplateService {
             String templateName, String classPrefix, String allowToString, String allowConverter) {
         var map =
                 Map.of(
-                        "label",
+                        "fileName",
                         templateName,
                         "classPrefix",
                         classPrefix,

--- a/src/main/java/io/cryostat/jmcagent/S3ProbeTemplateService.java
+++ b/src/main/java/io/cryostat/jmcagent/S3ProbeTemplateService.java
@@ -200,7 +200,7 @@ public class S3ProbeTemplateService implements ProbeTemplateService {
                     RequestBody.fromString(template.serialize()));
             bus.publish(
                     MessagingServer.class.getName(),
-                    new Notification(TEMPLATE_UPLOADED_CATEGORY, Map.of("template", template)));
+                    new Notification(TEMPLATE_UPLOADED_CATEGORY, Map.of("probeTemplate", template)));
             return template;
         }
     }

--- a/src/main/java/io/cryostat/jmcagent/S3ProbeTemplateService.java
+++ b/src/main/java/io/cryostat/jmcagent/S3ProbeTemplateService.java
@@ -114,7 +114,9 @@ public class S3ProbeTemplateService implements ProbeTemplateService {
         if (storage.deleteObject(req).sdkHttpResponse().isSuccessful()) {
             bus.publish(
                     MessagingServer.class.getName(),
-                    new Notification(TEMPLATE_DELETED_CATEGORY, Map.of("probeTemplate", template.getFileName())));
+                    new Notification(
+                            TEMPLATE_DELETED_CATEGORY,
+                            Map.of("probeTemplate", template.getFileName())));
         }
     }
 

--- a/src/main/java/io/cryostat/jmcagent/S3ProbeTemplateService.java
+++ b/src/main/java/io/cryostat/jmcagent/S3ProbeTemplateService.java
@@ -1,0 +1,242 @@
+/*
+ * Copyright The Cryostat Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.cryostat.jmcagent;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+import io.cryostat.ConfigProperties;
+import io.cryostat.Producers;
+import io.cryostat.StorageBuckets;
+import io.cryostat.core.FlightRecorderException;
+import io.cryostat.core.agent.ProbeTemplate;
+import io.cryostat.core.agent.ProbeTemplateService;
+
+import io.quarkus.runtime.StartupEvent;
+import io.smallrye.common.annotation.Blocking;
+import io.vertx.core.eventbus.EventBus;
+import jakarta.enterprise.event.Observes;
+import jakarta.inject.Inject;
+import jakarta.inject.Named;
+import org.apache.commons.codec.binary.Base64;
+import org.apache.commons.lang3.tuple.Pair;
+import org.apache.hc.core5.http.ContentType;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.jboss.logging.Logger;
+import org.xml.sax.SAXException;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
+import software.amazon.awssdk.services.s3.model.GetObjectRequest;
+import software.amazon.awssdk.services.s3.model.GetObjectTaggingRequest;
+import software.amazon.awssdk.services.s3.model.ListObjectsV2Request;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+import software.amazon.awssdk.services.s3.model.S3Object;
+import software.amazon.awssdk.services.s3.model.Tag;
+import software.amazon.awssdk.services.s3.model.Tagging;
+
+public class S3ProbeTemplateService implements ProbeTemplateService {
+
+    @ConfigProperty(name = ConfigProperties.AWS_BUCKET_NAME_EVENT_TEMPLATES)
+    String bucket;
+
+    @Inject S3Client storage;
+    @Inject StorageBuckets storageBuckets;
+
+    @Inject EventBus bus;
+
+    @Inject
+    @Named(Producers.BASE64_URL)
+    Base64 base64Url;
+
+    @Inject Logger logger;
+
+    void onStart(@Observes StartupEvent evt) {
+        storageBuckets.createIfNecessary(bucket);
+    }
+
+    @Override
+    @Blocking
+    public List<ProbeTemplate> getTemplates() throws FlightRecorderException {
+        return getObjects().stream()
+                .map(
+                        t -> {
+                            try {
+                                return convertObject(t);
+                            } catch (Exception e) {
+                                logger.error(e);
+                                return null;
+                            }
+                        })
+                .filter(Objects::nonNull)
+                .toList();
+    }
+
+    @Blocking
+    public String getTemplateContent(String fileName) {
+        try (var stream = getModel(fileName)) {
+            ProbeTemplate template = new ProbeTemplate();
+            template.setFileName(fileName);
+            template.deserialize(stream);
+            return template.serialize();
+        } catch (Exception e) {
+            logger.error(e);
+            return null;
+        }
+    }
+
+    @Blocking
+    public void deleteTemplate(String templateName) {
+        try {
+            var template =
+                    getTemplates().stream()
+                            .filter(t -> t.getFileName().equals(templateName))
+                            .findFirst()
+                            .orElseThrow();
+            var req = DeleteObjectRequest.builder().bucket(bucket).key(templateName).build();
+        } catch (FlightRecorderException e) {
+            logger.error(e);
+        }
+    }
+
+    @Blocking
+    private InputStream getModel(String name) {
+        var req = GetObjectRequest.builder().bucket(bucket).key(name).build();
+        return storage.getObject(req);
+    }
+
+    @Blocking
+    private List<S3Object> getObjects() {
+        var builder = ListObjectsV2Request.builder().bucket(bucket);
+        return storage.listObjectsV2(builder.build()).contents();
+    }
+
+    @Blocking
+    private ProbeTemplate convertObject(S3Object object) throws Exception {
+        var req = GetObjectTaggingRequest.builder().bucket(bucket).key(object.key()).build();
+        var tagging = storage.getObjectTagging(req);
+        var list = tagging.tagSet();
+        if (!tagging.hasTagSet() || list.isEmpty()) {
+            throw new Exception("No metadata found");
+        }
+        var decodedList = new ArrayList<Pair<String, String>>();
+        list.forEach(
+                t -> {
+                    var encodedKey = t.key();
+                    var decodedKey =
+                            new String(base64Url.decode(encodedKey), StandardCharsets.UTF_8).trim();
+                    var encodedValue = t.value();
+                    var decodedValue =
+                            new String(base64Url.decode(encodedValue), StandardCharsets.UTF_8)
+                                    .trim();
+                    decodedList.add(Pair.of(decodedKey, decodedValue));
+                });
+        var fileName =
+                decodedList.stream()
+                        .filter(t -> t.getKey().equals("fileName"))
+                        .map(Pair::getValue)
+                        .findFirst()
+                        .orElseThrow();
+        var classPrefix =
+                decodedList.stream()
+                        .filter(t -> t.getKey().equals("classPrefix"))
+                        .map(Pair::getValue)
+                        .findFirst()
+                        .orElseThrow();
+        var allowToString =
+                decodedList.stream()
+                        .filter(t -> t.getKey().equals("allowToString"))
+                        .map(Pair::getValue)
+                        .findFirst()
+                        .orElseThrow();
+        var allowConverter =
+                decodedList.stream()
+                        .filter(t -> t.getKey().equals("allowConverter"))
+                        .map(Pair::getValue)
+                        .findFirst()
+                        .orElseThrow();
+        // filename, classprefix, allowtostring, allowconverter
+        return new ProbeTemplate(
+                fileName,
+                classPrefix,
+                Boolean.valueOf(allowToString),
+                Boolean.valueOf(allowConverter));
+    }
+
+    @Blocking
+    public ProbeTemplate addTemplate(InputStream stream, String fileName)
+            throws IOException, SAXException {
+        try (stream) {
+            ProbeTemplate template = new ProbeTemplate();
+            template.setFileName(fileName);
+            template.deserialize(stream);
+            storage.putObject(
+                    PutObjectRequest.builder()
+                            .bucket(bucket)
+                            .key(fileName)
+                            .contentType(ContentType.APPLICATION_XML.getMimeType())
+                            .tagging(
+                                    createTemplateTagging(
+                                            fileName,
+                                            template.getClassPrefix(),
+                                            String.valueOf(template.getAllowToString()),
+                                            String.valueOf(template.getAllowConverter())))
+                            .build(),
+                    RequestBody.fromString(template.serialize()));
+            return template;
+        }
+    }
+
+    private Tagging createTemplateTagging(
+            String templateName, String classPrefix, String allowToString, String allowConverter) {
+        var map =
+                Map.of(
+                        "label",
+                        templateName,
+                        "classPrefix",
+                        classPrefix,
+                        "allowToString",
+                        allowToString,
+                        "allowConverter",
+                        allowConverter);
+        var tags = new ArrayList<Tag>();
+        tags.addAll(
+                map.entrySet().stream()
+                        .map(
+                                e ->
+                                        Tag.builder()
+                                                .key(
+                                                        base64Url.encodeAsString(
+                                                                e.getKey()
+                                                                        .getBytes(
+                                                                                StandardCharsets
+                                                                                        .UTF_8)))
+                                                .value(
+                                                        base64Url.encodeAsString(
+                                                                e.getValue()
+                                                                        .getBytes(
+                                                                                StandardCharsets
+                                                                                        .UTF_8)))
+                                                .build())
+                        .toList());
+        return Tagging.builder().tagSet(tags).build();
+    }
+}

--- a/src/main/java/io/cryostat/jmcagent/SerializableProbeTemplateInfo.java
+++ b/src/main/java/io/cryostat/jmcagent/SerializableProbeTemplateInfo.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright The Cryostat Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.cryostat.jmcagent;
+
+import java.util.Objects;
+
+import io.cryostat.core.agent.ProbeTemplate;
+
+public record SerializableProbeTemplateInfo(String name, String xml) {
+
+    public SerializableProbeTemplateInfo {
+        Objects.requireNonNull(name);
+        Objects.requireNonNull(xml);
+    }
+
+    public static SerializableProbeTemplateInfo fromProbeTemplate(ProbeTemplate p) {
+        var name = p.getFileName();
+        var xml = p.serialize().replaceAll("\n", "").replaceAll("\"", "");
+        return new SerializableProbeTemplateInfo(name, xml);
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -60,6 +60,7 @@ storage.transient-archives.ttl=60s
 storage.buckets.archives.name=archivedrecordings
 storage.buckets.archives.expiration-label=expiration
 storage.buckets.event-templates.name=eventtemplates
+storage.buckets.probe-templates.name=probes
 
 quarkus.quinoa.build-dir=dist
 quarkus.quinoa.enable-spa-routing=true


### PR DESCRIPTION
Fixes https://github.com/cryostatio/cryostat3/issues/14
Depends on https://github.com/cryostatio/cryostat-core/pull/373
Depends on https://github.com/cryostatio/cryostat3/pull/385

This PR re-implements the JMC Agent functionality for Cryostat 3.0.

I took inspiration from how the event templates system was rewritten for rewriting the probe template service. 

Opening as draft for the moment as it doesn't quite run properly yet and I still need to re add the notifications. There will likely need to be some cleanup done in core as well.
