### PR TITLE
chore(pom): remove build.os property that breaks Dependabot scanning

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,6 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
-    <build.os>linux</build.os>
     <build.arch>amd64</build.arch>
 
     <io.cryostat.core.version>2.30.1</io.cryostat.core.version>
@@ -432,7 +431,7 @@
         </property>
       </activation>
       <properties>
-        <io.netty.netty-transport-native-epoll.classifier>${build.os}-x86_64</io.netty.netty-transport-native-epoll.classifier>
+        <io.netty.netty-transport-native-epoll.classifier>linux-x86_64</io.netty.netty-transport-native-epoll.classifier>
         <io.netty.netty-transport-native-epoll.scope>compile</io.netty.netty-transport-native-epoll.scope>
       </properties>
     </profile>
@@ -445,7 +444,7 @@
         </property>
       </activation>
       <properties>
-        <io.netty.netty-transport-native-epoll.classifier>${build.os}-x86_64</io.netty.netty-transport-native-epoll.classifier>
+        <io.netty.netty-transport-native-epoll.classifier>linux-x86_64</io.netty.netty-transport-native-epoll.classifier>
         <io.netty.netty-transport-native-epoll.scope>compile</io.netty.netty-transport-native-epoll.scope>
       </properties>
     </profile>
@@ -458,7 +457,7 @@
         </property>
       </activation>
       <properties>
-        <io.netty.netty-transport-native-epoll.classifier>${build.os}-aarch_64</io.netty.netty-transport-native-epoll.classifier>
+        <io.netty.netty-transport-native-epoll.classifier>linux-aarch_64</io.netty.netty-transport-native-epoll.classifier>
         <io.netty.netty-transport-native-epoll.scope>compile</io.netty.netty-transport-native-epoll.scope>
       </properties>
     </profile>
@@ -490,7 +489,7 @@
         </property>
       </activation>
       <properties>
-        <io.netty.netty-transport-native-epoll.classifier>${build.os}-x86_64</io.netty.netty-transport-native-epoll.classifier>
+        <io.netty.netty-transport-native-epoll.classifier>linux-x86_64</io.netty.netty-transport-native-epoll.classifier>
         <io.netty.netty-transport-native-epoll.scope>provided</io.netty.netty-transport-native-epoll.scope>
       </properties>
       <dependencies>


### PR DESCRIPTION
# Welcome to Cryostat3! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat3/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] [Signed all commits using a GPG signature](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#gpg-commit-signature-verification)

**To recreate commits with GPG signature** `git fetch upstream && git rebase --force --gpg-sign upstream/main`
_______________________________________________

Related to #371

## Description of the change:
*This change allows an environment variable to be configured so that...*

## Motivation for the change:
*This change is helpful because users may want to...*

## How to manually test:
1. *Run CRYOSTAT_IMAGE=quay.io... bash smoketest.bash...*
2. *...*
