### PR TITLE
fix(transaction): ensure transactions occur in correct context/thread

### DIFF
--- a/src/main/java/io/cryostat/expressions/MatchExpressions.java
+++ b/src/main/java/io/cryostat/expressions/MatchExpressions.java
@@ -29,7 +29,6 @@ import io.smallrye.mutiny.Multi;
 import jakarta.annotation.security.RolesAllowed;
 import jakarta.inject.Inject;
 import jakarta.ws.rs.GET;
-import jakarta.ws.rs.NotFoundException;
 import jakarta.ws.rs.POST;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.core.Response;
@@ -73,10 +72,7 @@ public class MatchExpressions {
     @RolesAllowed("read")
     @Blocking
     public MatchedExpression get(@RestPath long id) throws ScriptException {
-        MatchExpression expr = MatchExpression.findById(id);
-        if (expr == null) {
-            throw new NotFoundException();
-        }
+        MatchExpression expr = MatchExpression.find("id", id).singleResult();
         return targetMatcher.match(expr);
     }
 

--- a/src/main/java/io/cryostat/graphql/ArchivedRecordings.java
+++ b/src/main/java/io/cryostat/graphql/ArchivedRecordings.java
@@ -78,6 +78,7 @@ public class ArchivedRecordings {
         return recording;
     }
 
+    @Blocking
     @NonNull
     public ArchivedRecording doPutMetadata(
             @Source ArchivedRecording recording, MetadataLabels metadataInput) {

--- a/src/main/java/io/cryostat/graphql/EnvironmentNodes.java
+++ b/src/main/java/io/cryostat/graphql/EnvironmentNodes.java
@@ -20,6 +20,7 @@ import java.util.List;
 import io.cryostat.discovery.DiscoveryNode;
 import io.cryostat.graphql.RootNode.DiscoveryNodeFilter;
 
+import io.smallrye.common.annotation.Blocking;
 import io.smallrye.graphql.api.Nullable;
 import org.eclipse.microprofile.graphql.Description;
 import org.eclipse.microprofile.graphql.GraphQLApi;
@@ -28,6 +29,7 @@ import org.eclipse.microprofile.graphql.Query;
 @GraphQLApi
 public class EnvironmentNodes {
 
+    @Blocking
     @Query("environmentNodes")
     @Description("Get all environment nodes in the discovery tree with optional filtering")
     public List<DiscoveryNode> environmentNodes(@Nullable DiscoveryNodeFilter filter) {

--- a/src/main/java/io/cryostat/graphql/RootNode.java
+++ b/src/main/java/io/cryostat/graphql/RootNode.java
@@ -24,6 +24,7 @@ import io.cryostat.discovery.DiscoveryNode;
 import io.cryostat.graphql.matchers.LabelSelectorMatcher;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import io.smallrye.common.annotation.Blocking;
 import io.smallrye.graphql.api.Nullable;
 import org.eclipse.microprofile.graphql.Description;
 import org.eclipse.microprofile.graphql.GraphQLApi;
@@ -33,12 +34,14 @@ import org.eclipse.microprofile.graphql.Source;
 @GraphQLApi
 public class RootNode {
 
+    @Blocking
     @Query("rootNode")
     @Description("Get the root target discovery node")
     public DiscoveryNode getRootNode() {
         return DiscoveryNode.getUniverse();
     }
 
+    @Blocking
     @Description(
             "Get target nodes that are descendants of this node. That is, get the set of leaf nodes"
                     + " from anywhere below this node's subtree.")

--- a/src/main/java/io/cryostat/graphql/TargetNodes.java
+++ b/src/main/java/io/cryostat/graphql/TargetNodes.java
@@ -36,8 +36,8 @@ import graphql.schema.DataFetchingEnvironment;
 import io.smallrye.common.annotation.Blocking;
 import io.smallrye.graphql.api.Context;
 import io.smallrye.graphql.api.Nullable;
-import io.smallrye.mutiny.Uni;
 import jakarta.inject.Inject;
+import jakarta.transaction.Transactional;
 import org.apache.commons.lang3.StringUtils;
 import org.eclipse.microprofile.graphql.Description;
 import org.eclipse.microprofile.graphql.GraphQLApi;
@@ -75,9 +75,10 @@ public class TargetNodes {
     // }
 
     @Blocking
+    @Transactional
     public ActiveRecordings activeRecordings(
             @Source Target target, @Nullable ActiveRecordingsFilter filter) {
-        var fTarget = Target.<Target>findById(target.id);
+        var fTarget = Target.getTargetById(target.id);
         var recordings = new ActiveRecordings();
         if (StringUtils.isNotBlank(fTarget.jvmId)) {
             recordings.data =
@@ -92,7 +93,7 @@ public class TargetNodes {
     @Blocking
     public ArchivedRecordings archivedRecordings(
             @Source Target target, @Nullable ArchivedRecordingsFilter filter) {
-        var fTarget = Target.<Target>findById(target.id);
+        var fTarget = Target.getTargetById(target.id);
         var recordings = new ArchivedRecordings();
         if (StringUtils.isNotBlank(fTarget.jvmId)) {
             recordings.data =
@@ -105,9 +106,10 @@ public class TargetNodes {
     }
 
     @Blocking
+    @Transactional
     @Description("Get the active and archived recordings belonging to this target")
     public Recordings recordings(@Source Target target, Context context) {
-        var fTarget = Target.<Target>findById(target.id);
+        var fTarget = Target.getTargetById(target.id);
         var recordings = new Recordings();
         if (StringUtils.isBlank(fTarget.jvmId)) {
             return recordings;
@@ -133,9 +135,9 @@ public class TargetNodes {
 
     @Blocking
     @Description("Get live MBean metrics snapshot from the specified Target")
-    public Uni<MBeanMetrics> mbeanMetrics(@Source Target target) {
-        var fTarget = Target.<Target>findById(target.id);
-        return connectionManager.executeConnectedTaskUni(fTarget, JFRConnection::getMBeanMetrics);
+    public MBeanMetrics mbeanMetrics(@Source Target target) {
+        var fTarget = Target.getTargetById(target.id);
+        return connectionManager.executeConnectedTask(fTarget, JFRConnection::getMBeanMetrics);
     }
 
     @SuppressFBWarnings(value = "URF_UNREAD_PUBLIC_OR_PROTECTED_FIELD")

--- a/src/main/java/io/cryostat/recordings/Recordings.java
+++ b/src/main/java/io/cryostat/recordings/Recordings.java
@@ -443,6 +443,7 @@ public class Recordings {
     }
 
     @GET
+    @Transactional
     @Path("/api/v3/targets/{id}/recordings")
     @RolesAllowed("read")
     public List<LinkedRecordingDescriptor> listForTarget(@RestPath long id) throws Exception {
@@ -763,6 +764,7 @@ public class Recordings {
 
     @POST
     @Blocking
+    @Transactional
     @Path("/api/v1/targets/{connectUrl}/recordings/{recordingName}/upload")
     @RolesAllowed("write")
     public Response uploadActiveToGrafanaV1(
@@ -947,10 +949,7 @@ public class Recordings {
     @Path("/api/v3/activedownload/{id}")
     @RolesAllowed("read")
     public Response handleActiveDownload(@RestPath long id) throws Exception {
-        ActiveRecording recording = ActiveRecording.findById(id);
-        if (recording == null) {
-            throw new NotFoundException();
-        }
+        ActiveRecording recording = ActiveRecording.find("id", id).singleResult();
         if (!transientArchivesEnabled) {
             return Response.status(RestResponse.Status.OK)
                     .header(

--- a/src/main/java/io/cryostat/reports/Reports.java
+++ b/src/main/java/io/cryostat/reports/Reports.java
@@ -31,6 +31,7 @@ import io.smallrye.mutiny.Uni;
 import jakarta.annotation.security.RolesAllowed;
 import jakarta.enterprise.event.Observes;
 import jakarta.inject.Inject;
+import jakarta.transaction.Transactional;
 import jakarta.ws.rs.ClientErrorException;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.NotFoundException;
@@ -109,6 +110,7 @@ public class Reports {
 
     @GET
     @Blocking
+    @Transactional
     @Path("/api/v1/targets/{targetId}/reports/{recordingName}")
     @Produces({MediaType.APPLICATION_JSON})
     @RolesAllowed("read")
@@ -137,10 +139,7 @@ public class Reports {
     @Deprecated(since = "3.0", forRemoval = true)
     public Uni<Map<String, AnalysisResult>> getActive(
             @RestPath long targetId, @RestPath long recordingId) throws Exception {
-        var target = Target.<Target>findById(targetId);
-        if (target == null) {
-            throw new NotFoundException();
-        }
+        var target = Target.getTargetById(targetId);
         var recording = target.getRecordingById(recordingId);
         if (recording == null) {
             throw new NotFoundException();

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -58,6 +58,7 @@ quarkus.smallrye-openapi.info-license-name=Apache 2.0
 quarkus.smallrye-openapi.info-license-url=https://github.com/cryostatio/cryostat3/blob/main/LICENSE
 
 quarkus.smallrye-graphql.events.enabled=true
+quarkus.smallrye-graphql.nonblocking.enabled=false
 quarkus.smallrye-graphql.root-path=/api/v3/graphql
 quarkus.smallrye-graphql.http.get.enabled=true
 quarkus.smallrye-graphql.print-data-fetcher-exception=true


### PR DESCRIPTION
# Welcome to Cryostat3! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat3/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] [Signed all commits using a GPG signature](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#gpg-commit-signature-verification)

**To recreate commits with GPG signature** `git fetch upstream && git rebase --force --gpg-sign upstream/main`
_______________________________________________

Fixes: #389
Based on #342

## Description of the change:
- ensures `Blocking` and `Transactional` annotations are applied correctly in GraphQL API entrypoints and HTTP API entrypoints
- disables GraphQL nonblocking support, improves performance but is more difficult to manage the concurrency - not worth gaining performance at the expense of correctness or reliability
- refactors some code using to ensure that database transactions occur on the calling thread where the transaction context is active, not on some delegated worker

## Motivation for the change:
*This change is helpful because users may want to...*

## How to manually test:
1. *Run CRYOSTAT_IMAGE=quay.io... bash smoketest.bash...*
2. *...*
