### PR TITLE
test(smoketest): do not require truststore directory

### DIFF
--- a/smoketest.bash
+++ b/smoketest.bash
@@ -217,7 +217,9 @@ fi
 createJmxTlsCertVolume() {
     "${container_engine}" volume create jmxtls_cfg
     "${container_engine}" container create --name jmxtls_cfg_helper -v jmxtls_cfg:/truststore busybox
-    "${container_engine}" cp "${DIR}/truststore" jmxtls_cfg_helper:/truststore
+    if [ -d "${DIR}/truststore" ]; then
+        "${container_engine}" cp "${DIR}/truststore" jmxtls_cfg_helper:/truststore
+    fi
 }
 createJmxTlsCertVolume
 


### PR DESCRIPTION
# Welcome to Cryostat3! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat3/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] [Signed all commits using a GPG signature](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#gpg-commit-signature-verification)

**To recreate commits with GPG signature** `git fetch upstream && git rebase --force --gpg-sign upstream/main`
_______________________________________________

See #330

## Description of the change:
*This change allows an environment variable to be configured so that...*

## Motivation for the change:
*This change is helpful because users may want to...*

## How to manually test:
1. *Run CRYOSTAT_IMAGE=quay.io... bash smoketest.bash...*
2. *...*
