### PR TITLE
chore(deps): ignore major/minor Quarkus updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,9 +10,9 @@ updates:
       - "safe-to-test"
     open-pull-requests-limit: 20
     ignore:
-      - dependency-name: io.quarkus/*
+      - dependency-name: io.quarkus:*
         update-types: ["version-update:semver-major", "version-update:semver-minor"]
-      - dependency-name: io.quarkus.platform/*
+      - dependency-name: io.quarkus.platform:*
         update-types: ["version-update:semver-major", "version-update:semver-minor"]
 
   - package-ecosystem: "docker"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,11 @@ updates:
       - "chore"
       - "safe-to-test"
     open-pull-requests-limit: 20
+    ignore:
+      - dependency-name: io.quarkus/*
+        update-types: ["version-update:semver-major", "version-update:semver-minor"]
+      - dependency-name: io.quarkus.platform/*
+        update-types: ["version-update:semver-major", "version-update:semver-minor"]
 
   - package-ecosystem: "docker"
     directory: "/src/main/docker"


### PR DESCRIPTION
# Welcome to Cryostat3! 👋
## Before contributing, make sure you have:
* [ ] Read the [contributing guidelines](https://github.com/cryostatio/cryostat3/blob/main/CONTRIBUTING.md)
* [ ] Linked a relevant issue which this PR resolves
* [ ] Linked any other relevant issues, PR's, or documentation, if any
* [ ] Resolved all conflicts, if any
* [ ] Rebased your branch PR on top of the latest upstream `main` branch
* [ ] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [ ] [Signed all commits using a GPG signature](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#gpg-commit-signature-verification)

**To recreate commits with GPG signature** `git fetch upstream && git rebase --force --gpg-sign upstream/main`
_______________________________________________

Related to: #363
Related to #364 

## Description of the change:
* Tells Dependabot to ignore major and minor versions of Quarkus dependencies.

## Motivation for the change:
* Makes it easier to pull in Quarkus bugfix releases
