### PR TITLE
fix(db): correct use of Transactional annotation

### DIFF
--- a/compose/cryostat.yml
+++ b/compose/cryostat.yml
@@ -26,7 +26,7 @@ services:
       io.cryostat.jmxPort: "0"
       io.cryostat.jmxUrl: "service:jmx:rmi:///jndi/rmi://localhost:0/jmxrmi"
     environment:
-      QUARKUS_LOG_LEVEL: TRACE
+      QUARKUS_LOG_LEVEL: ALL
       QUARKUS_HTTP_HOST: "cryostat"
       QUARKUS_HTTP_PORT: ${CRYOSTAT_HTTP_PORT}
       QUARKUS_HIBERNATE_ORM_LOG_SQL: "true"

--- a/compose/db-viewer.yml
+++ b/compose/db-viewer.yml
@@ -4,7 +4,7 @@ services:
     depends_on:
       db:
         condition: service_healthy
-    image: ${DB_VIEWER_IMAGE:-docker.io/dpage/pgadmin4:7}
+    image: ${DB_VIEWER_IMAGE:-docker.io/dpage/pgadmin4:8}
     hostname: db-viewer
     ports:
       - "8989:8989"

--- a/compose/sample-apps.yml
+++ b/compose/sample-apps.yml
@@ -103,7 +103,18 @@ services:
     expose:
       - "9977"
     environment:
-      JAVA_OPTS_APPEND: "-Dquarkus.http.host=0.0.0.0 -Djava.util.logging.manager=org.jboss.logmanager.LogManager -javaagent:/deployments/app/cryostat-agent.jar"
+      JAVA_OPTS_APPEND: >-
+        -Dquarkus.http.host=0.0.0.0
+        -Djava.util.logging.manager=org.jboss.logmanager.LogManager
+        -javaagent:/deployments/app/cryostat-agent.jar
+        -Dcom.sun.management.jmxremote.autodiscovery=false
+        -Dcom.sun.management.jmxremote
+        -Dcom.sun.management.jmxremote.port=22222
+        -Dcom.sun.management.jmxremote.rmi.port=22222
+        -Djava.rmi.server.hostname=quarkus-test-agent
+        -Dcom.sun.management.jmxremote.authenticate=false
+        -Dcom.sun.management.jmxremote.ssl=false
+        -Dcom.sun.management.jmxremote.local.only=false
       QUARKUS_HTTP_PORT: 10010
       ORG_ACME_CRYOSTATSERVICE_ENABLED: "false"
       CRYOSTAT_AGENT_APP_NAME: quarkus-test-agent

--- a/schema/openapi.yaml
+++ b/schema/openapi.yaml
@@ -54,24 +54,6 @@ components:
             $ref: '#/components/schemas/ArchivedRecording'
           type: array
       type: object
-    Credential:
-      properties:
-        id:
-          format: int64
-          type: integer
-        matchExpression:
-          $ref: '#/components/schemas/MatchExpression'
-        password:
-          pattern: \S
-          type: string
-        username:
-          pattern: \S
-          type: string
-      required:
-        - matchExpression
-        - username
-        - password
-      type: object
     Data:
       type: object
     DiscoveryNode:
@@ -107,8 +89,6 @@ components:
         callback:
           format: uri
           type: string
-        credential:
-          $ref: '#/components/schemas/Credential'
         id:
           $ref: '#/components/schemas/UUID'
         realm:

--- a/schema/openapi.yaml
+++ b/schema/openapi.yaml
@@ -54,6 +54,24 @@ components:
             $ref: '#/components/schemas/ArchivedRecording'
           type: array
       type: object
+    Credential:
+      properties:
+        id:
+          format: int64
+          type: integer
+        matchExpression:
+          $ref: '#/components/schemas/MatchExpression'
+        password:
+          pattern: \S
+          type: string
+        username:
+          pattern: \S
+          type: string
+      required:
+        - matchExpression
+        - username
+        - password
+      type: object
     Data:
       type: object
     DiscoveryNode:
@@ -89,6 +107,8 @@ components:
         callback:
           format: uri
           type: string
+        credential:
+          $ref: '#/components/schemas/Credential'
         id:
           $ref: '#/components/schemas/UUID'
         realm:

--- a/src/main/java/io/cryostat/credentials/Credential.java
+++ b/src/main/java/io/cryostat/credentials/Credential.java
@@ -15,13 +15,16 @@
  */
 package io.cryostat.credentials;
 
+import io.cryostat.discovery.DiscoveryPlugin;
 import io.cryostat.expressions.MatchExpression;
 import io.cryostat.ws.MessagingServer;
 import io.cryostat.ws.Notification;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.quarkus.hibernate.orm.panache.PanacheEntity;
 import io.vertx.mutiny.core.eventbus.EventBus;
+import jakarta.annotation.Nullable;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import jakarta.persistence.CascadeType;
@@ -67,6 +70,16 @@ public class Credential extends PanacheEntity {
     @NotBlank
     @JsonProperty(access = JsonProperty.Access.WRITE_ONLY)
     public String password;
+
+    @OneToOne(
+            optional = true,
+            fetch = FetchType.LAZY,
+            mappedBy = "credential",
+            cascade = CascadeType.REMOVE)
+    @JoinColumn(name = "discoveryPlugin_id")
+    @JsonIgnore
+    @Nullable
+    public DiscoveryPlugin discoveryPlugin;
 
     @ApplicationScoped
     static class Listener {

--- a/src/main/java/io/cryostat/credentials/Credentials.java
+++ b/src/main/java/io/cryostat/credentials/Credentials.java
@@ -98,8 +98,7 @@ public class Credentials {
     @RolesAllowed("write")
     @Path("/{id}")
     public void delete(@RestPath long id) {
-        Credential credential = Credential.find("id", id).singleResult();
-        credential.delete();
+        Credential.find("id", id).singleResult().delete();
     }
 
     static Map<String, Object> notificationResult(Credential credential) throws ScriptException {

--- a/src/main/java/io/cryostat/discovery/CustomDiscovery.java
+++ b/src/main/java/io/cryostat/discovery/CustomDiscovery.java
@@ -179,6 +179,8 @@ public class CustomDiscovery {
             node.persist();
             realm.persist();
 
+            QuarkusTransaction.commit();
+
             return Response.created(URI.create("/api/v3/targets/" + target.id))
                     .entity(V2Response.json(Response.Status.CREATED, target))
                     .build();

--- a/src/main/java/io/cryostat/discovery/Discovery.java
+++ b/src/main/java/io/cryostat/discovery/Discovery.java
@@ -191,6 +191,19 @@ public class Discovery {
         String realmName = body.getString("realm");
         URI callbackUri = new URI(body.getString("callback"));
 
+        DiscoveryPlugin.<DiscoveryPlugin>find("callback", callbackUri)
+                .singleResultOptional()
+                .ifPresent(
+                        plugin -> {
+                            try {
+                                var cb = PluginCallback.create(plugin);
+                                cb.ping();
+                            } catch (Exception e) {
+                                logger.error(e);
+                                plugin.delete();
+                            }
+                        });
+
         // TODO apply URI range validation to the remote address
         InetAddress remoteAddress = getRemoteAddress(ctx);
         URI location;

--- a/src/main/java/io/cryostat/discovery/Discovery.java
+++ b/src/main/java/io/cryostat/discovery/Discovery.java
@@ -342,10 +342,8 @@ public class Discovery {
             scheduler.deleteJob(key);
         }
 
-        plugin.realm.delete();
-        plugin.delete();
         getStoredCredential(plugin).ifPresent(Credential::delete);
-        DiscoveryNode.getUniverse().children.remove(plugin.realm);
+        plugin.delete();
         return Map.of(
                 "meta",
                         Map.of(

--- a/src/main/java/io/cryostat/discovery/Discovery.java
+++ b/src/main/java/io/cryostat/discovery/Discovery.java
@@ -189,8 +189,8 @@ public class Discovery {
                     SchedulerException {
         String pluginId = body.getString("id");
         String priorToken = body.getString("token");
-        String realmName = body.getString("realm");
-        URI callbackUri = new URI(body.getString("callback"));
+        String realmName = requireNonBlank(body.getString("realm"), "realm");
+        URI callbackUri = new URI(requireNonBlank(body.getString("callback"), "callback"));
 
         // TODO apply URI range validation to the remote address
         InetAddress remoteAddress = getRemoteAddress(ctx);

--- a/src/main/java/io/cryostat/discovery/Discovery.java
+++ b/src/main/java/io/cryostat/discovery/Discovery.java
@@ -410,12 +410,11 @@ public class Discovery {
                 if (plugin != null) {
                     logger.debugv(
                             e, "Pruned discovery plugin: {0} @ {1}", plugin.realm, plugin.callback);
-                    plugin.realm.delete();
-                    plugin.delete();
                     new DiscoveryPlugin.PluginCallback.DiscoveryPluginAuthorizationHeaderFactory(
                                     plugin)
                             .getCredential()
                             .ifPresent(Credential::delete);
+                    plugin.delete();
                 } else {
                     try {
                         scheduler.deleteJob(context.getJobDetail().getKey());

--- a/src/main/java/io/cryostat/discovery/Discovery.java
+++ b/src/main/java/io/cryostat/discovery/Discovery.java
@@ -383,6 +383,7 @@ public class Discovery {
 
     static class RefreshPluginJob implements Job {
         @Inject Logger logger;
+        @Inject Scheduler scheduler;
 
         @Override
         @Transactional
@@ -415,6 +416,12 @@ public class Discovery {
                                     plugin)
                             .getCredential()
                             .ifPresent(Credential::delete);
+                } else {
+                    try {
+                        scheduler.deleteJob(context.getJobDetail().getKey());
+                    } catch (SchedulerException se) {
+                        logger.warn(se);
+                    }
                 }
                 throw new JobExecutionException(e);
             }

--- a/src/main/java/io/cryostat/discovery/Discovery.java
+++ b/src/main/java/io/cryostat/discovery/Discovery.java
@@ -192,6 +192,7 @@ public class Discovery {
         String priorToken = body.getString("token");
         String realmName = body.getString("realm");
         URI callbackUri = new URI(body.getString("callback"));
+        URI unauthCallback = UriBuilder.fromUri(callbackUri).userInfo(null).build();
 
         // TODO apply URI range validation to the remote address
         InetAddress remoteAddress = getRemoteAddress(ctx);
@@ -205,7 +206,7 @@ public class Discovery {
             if (!Objects.equals(plugin.realm.name, realmName)) {
                 throw new ForbiddenException();
             }
-            if (!Objects.equals(plugin.callback, callbackUri)) {
+            if (!Objects.equals(plugin.callback, unauthCallback)) {
                 throw new BadRequestException();
             }
             location = jwtFactory.getPluginLocation(plugin);
@@ -214,7 +215,6 @@ public class Discovery {
             // check if a plugin record with the same callback already exists. If it does, ping it:
             // if it's still there reject this request as a duplicate, otherwise delete the previous
             // record and accept this new one as a replacement
-            URI unauthCallback = UriBuilder.fromUri(callbackUri).userInfo(null).build();
             DiscoveryPlugin.<DiscoveryPlugin>find("callback", unauthCallback)
                     .singleResultOptional()
                     .ifPresent(

--- a/src/main/java/io/cryostat/discovery/Discovery.java
+++ b/src/main/java/io/cryostat/discovery/Discovery.java
@@ -190,8 +190,8 @@ public class Discovery {
                     SchedulerException {
         String pluginId = body.getString("id");
         String priorToken = body.getString("token");
-        String realmName = requireNonBlank(body.getString("realm"), "realm");
-        URI callbackUri = new URI(requireNonBlank(body.getString("callback"), "callback"));
+        String realmName = body.getString("realm");
+        URI callbackUri = new URI(body.getString("callback"));
 
         // TODO apply URI range validation to the remote address
         InetAddress remoteAddress = getRemoteAddress(ctx);

--- a/src/main/java/io/cryostat/discovery/Discovery.java
+++ b/src/main/java/io/cryostat/discovery/Discovery.java
@@ -179,6 +179,7 @@ public class Discovery {
     @Produces(MediaType.APPLICATION_JSON)
     @Consumes(MediaType.APPLICATION_JSON)
     @RolesAllowed("write")
+    @SuppressFBWarnings("DLS_DEAD_LOCAL_STORE")
     public Response register(@Context RoutingContext ctx, JsonObject body)
             throws URISyntaxException,
                     JOSEException,
@@ -395,13 +396,12 @@ public class Discovery {
         return DiscoveryPlugin.find("id", id).singleResult();
     }
 
+    @SuppressFBWarnings("RCN_REDUNDANT_NULLCHECK_OF_NULL_VALUE")
     static class RefreshPluginJob implements Job {
         @Inject Logger logger;
         @Inject Scheduler scheduler;
 
         @Override
-        @Transactional
-        @SuppressFBWarnings("RCN_REDUNDANT_NULLCHECK_OF_NULL_VALUE")
         public void execute(JobExecutionContext context) {
             QuarkusTransaction.requiringNew()
                     .run(

--- a/src/main/java/io/cryostat/discovery/DiscoveryNode.java
+++ b/src/main/java/io/cryostat/discovery/DiscoveryNode.java
@@ -30,6 +30,7 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.annotation.JsonView;
 import io.quarkus.hibernate.orm.panache.PanacheEntity;
+import io.quarkus.narayana.jta.QuarkusTransaction;
 import io.vertx.mutiny.core.eventbus.EventBus;
 import jakarta.annotation.Nullable;
 import jakarta.enterprise.context.ApplicationScoped;
@@ -130,25 +131,33 @@ public class DiscoveryNode extends PanacheEntity {
     }
 
     public static DiscoveryNode environment(String name, NodeType nodeType) {
-        DiscoveryNode node = new DiscoveryNode();
-        node.name = name;
-        node.nodeType = nodeType.getKind();
-        node.labels = new HashMap<>();
-        node.children = new ArrayList<>();
-        node.target = null;
-        node.persist();
-        return node;
+        return QuarkusTransaction.joiningExisting()
+                .call(
+                        () -> {
+                            DiscoveryNode node = new DiscoveryNode();
+                            node.name = name;
+                            node.nodeType = nodeType.getKind();
+                            node.labels = new HashMap<>();
+                            node.children = new ArrayList<>();
+                            node.target = null;
+                            node.persist();
+                            return node;
+                        });
     }
 
     public static DiscoveryNode target(Target target, NodeType nodeType) {
-        DiscoveryNode node = new DiscoveryNode();
-        node.name = target.connectUrl.toString();
-        node.nodeType = nodeType.getKind();
-        node.labels = new HashMap<>(target.labels);
-        node.children = null;
-        node.target = target;
-        node.persist();
-        return node;
+        return QuarkusTransaction.joiningExisting()
+                .call(
+                        () -> {
+                            DiscoveryNode node = new DiscoveryNode();
+                            node.name = target.connectUrl.toString();
+                            node.nodeType = nodeType.getKind();
+                            node.labels = new HashMap<>(target.labels);
+                            node.children = null;
+                            node.target = target;
+                            node.persist();
+                            return node;
+                        });
     }
 
     @Override

--- a/src/main/java/io/cryostat/discovery/DiscoveryPlugin.java
+++ b/src/main/java/io/cryostat/discovery/DiscoveryPlugin.java
@@ -81,7 +81,6 @@ public class DiscoveryPlugin extends PanacheEntityBase {
             cascade = {CascadeType.ALL},
             orphanRemoval = true,
             fetch = FetchType.LAZY)
-    @NotNull
     public Credential credential;
 
     @JsonProperty(access = JsonProperty.Access.READ_ONLY)

--- a/src/main/java/io/cryostat/discovery/DiscoveryPlugin.java
+++ b/src/main/java/io/cryostat/discovery/DiscoveryPlugin.java
@@ -101,9 +101,11 @@ public class DiscoveryPlugin extends PanacheEntityBase {
                 plugin.delete();
                 throw new IllegalArgumentException();
             }
-            var credential = getCredential(plugin);
-            plugin.credential = credential;
-            plugin.callback = UriBuilder.fromUri(plugin.callback).userInfo(null).build();
+            if (plugin.credential == null) {
+                var credential = getCredential(plugin);
+                plugin.credential = credential;
+                plugin.callback = UriBuilder.fromUri(plugin.callback).userInfo(null).build();
+            }
             try {
                 PluginCallback.create(plugin).ping();
                 logger.infov(

--- a/src/main/java/io/cryostat/discovery/DiscoveryPlugin.java
+++ b/src/main/java/io/cryostat/discovery/DiscoveryPlugin.java
@@ -81,6 +81,7 @@ public class DiscoveryPlugin extends PanacheEntityBase {
             cascade = {CascadeType.ALL},
             orphanRemoval = true,
             fetch = FetchType.LAZY)
+    @NotNull
     public Credential credential;
 
     @JsonProperty(access = JsonProperty.Access.READ_ONLY)

--- a/src/main/java/io/cryostat/discovery/DiscoveryPlugin.java
+++ b/src/main/java/io/cryostat/discovery/DiscoveryPlugin.java
@@ -72,7 +72,7 @@ public class DiscoveryPlugin extends PanacheEntityBase {
     @NotNull
     public DiscoveryNode realm;
 
-    @Column(unique = true, updatable = false)
+    @Column(nullable = true, unique = true, updatable = false)
     @Convert(converter = UriConverter.class)
     public URI callback;
 

--- a/src/main/java/io/cryostat/discovery/DiscoveryPlugin.java
+++ b/src/main/java/io/cryostat/discovery/DiscoveryPlugin.java
@@ -23,10 +23,12 @@ import java.util.UUID;
 
 import io.cryostat.credentials.Credential;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.quarkus.hibernate.orm.panache.PanacheEntityBase;
 import io.quarkus.rest.client.reactive.QuarkusRestClientBuilder;
+import jakarta.annotation.Nullable;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import jakarta.persistence.CascadeType;
@@ -78,9 +80,10 @@ public class DiscoveryPlugin extends PanacheEntityBase {
 
     @OneToOne(
             optional = true, // only nullable for builtins
-            cascade = {CascadeType.ALL},
-            orphanRemoval = true,
-            fetch = FetchType.LAZY)
+            fetch = FetchType.LAZY,
+            cascade = CascadeType.REMOVE)
+    @JsonIgnore
+    @Nullable
     public Credential credential;
 
     @JsonProperty(access = JsonProperty.Access.READ_ONLY)

--- a/src/main/java/io/cryostat/discovery/DiscoveryPlugin.java
+++ b/src/main/java/io/cryostat/discovery/DiscoveryPlugin.java
@@ -77,7 +77,7 @@ public class DiscoveryPlugin extends PanacheEntityBase {
     public URI callback;
 
     @OneToOne(
-            optional = false,
+            optional = true, // only nullable for builtins
             cascade = {CascadeType.ALL},
             orphanRemoval = true,
             fetch = FetchType.LAZY)

--- a/src/main/java/io/cryostat/discovery/JDPDiscovery.java
+++ b/src/main/java/io/cryostat/discovery/JDPDiscovery.java
@@ -101,10 +101,7 @@ public class JDPDiscovery implements Consumer<JvmDiscoveryEvent> {
     @Override
     public void accept(JvmDiscoveryEvent evt) {
         Infrastructure.getDefaultWorkerPool()
-                .execute(
-                        () ->
-                                QuarkusTransaction.joiningExisting()
-                                        .run(() -> this.handleJdpEvent(evt)));
+                .execute(() -> QuarkusTransaction.joiningExisting().run(() -> handleJdpEvent(evt)));
     }
 
     void handleJdpEvent(JvmDiscoveryEvent evt) {

--- a/src/main/java/io/cryostat/discovery/KubeApiDiscovery.java
+++ b/src/main/java/io/cryostat/discovery/KubeApiDiscovery.java
@@ -154,7 +154,7 @@ public class KubeApiDiscovery {
 
     @Transactional
     void onAfterStart(@Observes StartupEvent evt) {
-        if (!(enabled() && available())) {
+        if (!enabled() || !available()) {
             return;
         }
         safeGetInformers();

--- a/src/main/java/io/cryostat/rules/RuleService.java
+++ b/src/main/java/io/cryostat/rules/RuleService.java
@@ -73,6 +73,7 @@ public class RuleService {
     private final Map<Long, CopyOnWriteArrayList<ActiveRecording>> ruleRecordingMap =
             new ConcurrentHashMap<>();
 
+    @Transactional
     void onStart(@Observes StartupEvent ev) {
         logger.trace("RuleService started");
         try (Stream<Rule> rules = Rule.streamAll()) {
@@ -86,6 +87,7 @@ public class RuleService {
     }
 
     @ConsumeEvent(value = Rule.RULE_ADDRESS, blocking = true)
+    @Transactional
     public void handleRuleModification(RuleEvent event) {
         Rule rule = event.rule();
         var relatedRecordings =
@@ -130,8 +132,7 @@ public class RuleService {
                 });
     }
 
-    @Transactional
-    public void activate(Rule rule, Target target) throws Exception {
+    void activate(Rule rule, Target target) throws Exception {
         var options = createRecordingOptions(rule);
 
         Pair<String, TemplateType> pair = recordingHelper.parseEventSpecifier(rule.eventSpecifier);
@@ -168,7 +169,6 @@ public class RuleService {
                 Optional.ofNullable((long) rule.maxAgeSeconds));
     }
 
-    @Transactional
     void applyRuleToMatchingTargets(Rule rule) {
         try (Stream<Target> targets = Target.streamAll()) {
             targets.filter(

--- a/src/main/java/io/cryostat/rules/RuleService.java
+++ b/src/main/java/io/cryostat/rules/RuleService.java
@@ -208,9 +208,9 @@ public class RuleService {
         }
 
         Map<String, Object> data = jobDetail.getJobDataMap();
-        data.put("rule", rule);
-        data.put("target", target);
-        data.put("recording", recording);
+        data.put("rule", rule.id);
+        data.put("target", target.id);
+        data.put("recording", recording.id);
 
         Trigger trigger =
                 TriggerBuilder.newTrigger()

--- a/src/main/java/io/cryostat/rules/ScheduledArchiveJob.java
+++ b/src/main/java/io/cryostat/rules/ScheduledArchiveJob.java
@@ -52,7 +52,7 @@ class ScheduledArchiveJob implements Job {
         long ruleId = (long) ctx.getJobDetail().getJobDataMap().get("rule");
         Rule rule = Rule.find("id", ruleId).singleResult();
         long targetId = (long) ctx.getJobDetail().getJobDataMap().get("target");
-        Target target = Target.find("id", id).singleResult();
+        Target target = Target.find("id", targetId).singleResult();
         long recordingId = (long) ctx.getJobDetail().getJobDataMap().get("recording");
         ActiveRecording recording = ActiveRecording.find("id", recordingId).singleResult();
 

--- a/src/main/java/io/cryostat/rules/ScheduledArchiveJob.java
+++ b/src/main/java/io/cryostat/rules/ScheduledArchiveJob.java
@@ -26,12 +26,13 @@ import io.cryostat.recordings.ActiveRecording;
 import io.cryostat.recordings.RecordingHelper;
 import io.cryostat.targets.Target;
 
-import io.quarkus.narayana.jta.QuarkusTransaction;
 import jakarta.inject.Inject;
+import jakarta.transaction.Transactional;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.jboss.logging.Logger;
 import org.quartz.Job;
 import org.quartz.JobExecutionContext;
+import org.quartz.JobExecutionException;
 
 class ScheduledArchiveJob implements Job {
 
@@ -46,25 +47,27 @@ class ScheduledArchiveJob implements Job {
     String archiveBucket;
 
     @Override
-    public void execute(JobExecutionContext ctx) {
-        var rule = (Rule) ctx.getJobDetail().getJobDataMap().get("rule");
-        var target = (Target) ctx.getJobDetail().getJobDataMap().get("target");
-        var recording = (ActiveRecording) ctx.getJobDetail().getJobDataMap().get("recording");
+    @Transactional
+    public void execute(JobExecutionContext ctx) throws JobExecutionException {
+        long ruleId = (long) ctx.getJobDetail().getJobDataMap().get("rule");
+        Rule rule = Rule.find("id", ruleId).singleResult();
+        long targetId = (long) ctx.getJobDetail().getJobDataMap().get("target");
+        Target target = Target.find("id", id).singleResult();
+        long recordingId = (long) ctx.getJobDetail().getJobDataMap().get("recording");
+        ActiveRecording recording = ActiveRecording.find("id", recordingId).singleResult();
 
         Queue<String> previousRecordings = new ArrayDeque<>(rule.preservedArchives);
 
         initPreviousRecordings(target, rule, previousRecordings);
-
         while (previousRecordings.size() >= rule.preservedArchives) {
             pruneArchive(target, previousRecordings, previousRecordings.remove());
         }
-        previousRecordings.add(
-                QuarkusTransaction.joiningExisting()
-                        .call(
-                                () ->
-                                        recordingHelper
-                                                .archiveRecording(recording, null, null)
-                                                .name()));
+
+        try {
+            previousRecordings.add(recordingHelper.archiveRecording(recording, null, null).name());
+        } catch (Exception e) {
+            throw new JobExecutionException(e);
+        }
     }
 
     void initPreviousRecordings(Target target, Rule rule, Queue<String> previousRecordings) {

--- a/src/main/java/io/cryostat/rules/ScheduledArchiveJob.java
+++ b/src/main/java/io/cryostat/rules/ScheduledArchiveJob.java
@@ -47,6 +47,7 @@ class ScheduledArchiveJob implements Job {
     String archiveBucket;
 
     @Override
+    @Transactional
     public void execute(JobExecutionContext ctx) throws JobExecutionException {
         try {
             var rule = (Rule) ctx.getJobDetail().getJobDataMap().get("rule");
@@ -67,7 +68,6 @@ class ScheduledArchiveJob implements Job {
         }
     }
 
-    @Transactional
     void initPreviousRecordings(Target target, Rule rule, Queue<String> previousRecordings) {
         recordingHelper.listArchivedRecordingObjects().stream()
                 .sorted((a, b) -> a.lastModified().compareTo(b.lastModified()))
@@ -89,14 +89,12 @@ class ScheduledArchiveJob implements Job {
                         });
     }
 
-    @Transactional
     void performArchival(ActiveRecording recording, Queue<String> previousRecordings)
             throws Exception {
         String filename = recordingHelper.archiveRecording(recording, null, null).name();
         previousRecordings.add(filename);
     }
 
-    @Transactional
     void pruneArchive(Target target, Queue<String> previousRecordings, String filename)
             throws Exception {
         recordingHelper.deleteArchivedRecording(target.jvmId, filename);

--- a/src/main/java/io/cryostat/targets/AgentClient.java
+++ b/src/main/java/io/cryostat/targets/AgentClient.java
@@ -39,7 +39,7 @@ import io.cryostat.ConfigProperties;
 import io.cryostat.core.net.MBeanMetrics;
 import io.cryostat.core.serialization.SerializableRecordingDescriptor;
 import io.cryostat.credentials.Credential;
-import io.cryostat.credentials.CredentialsFinder;
+import io.cryostat.discovery.DiscoveryPlugin;
 import io.cryostat.targets.AgentJFRService.StartRecordingRequest;
 import io.cryostat.util.HttpStatusCodeIdentifier;
 
@@ -74,20 +74,14 @@ public class AgentClient {
     private final WebClient webClient;
     private final Duration httpTimeout;
     private final ObjectMapper mapper;
-    private final CredentialsFinder credentialsFinder;
     private final Logger logger = Logger.getLogger(getClass());
 
     private AgentClient(
-            Target target,
-            WebClient webClient,
-            ObjectMapper mapper,
-            Duration httpTimeout,
-            CredentialsFinder credentialsFinder) {
+            Target target, WebClient webClient, ObjectMapper mapper, Duration httpTimeout) {
         this.target = target;
         this.webClient = webClient;
         this.mapper = mapper;
         this.httpTimeout = httpTimeout;
-        this.credentialsFinder = credentialsFinder;
     }
 
     Target getTarget() {
@@ -402,10 +396,9 @@ public class AgentClient {
                         .followRedirects(true)
                         .as(codec);
         Credential credential =
-                credentialsFinder.getCredentialsForConnectUrl(getUri()).orElse(null);
-        if (credential == null || credential.username == null || credential.password == null) {
-            throw new IllegalStateException(NULL_CREDENTIALS + " " + getUri());
-        }
+                DiscoveryPlugin.<DiscoveryPlugin>find("callback", getUri())
+                        .singleResult()
+                        .credential;
         req =
                 req.authentication(
                         new UsernamePasswordCredentials(credential.username, credential.password));
@@ -424,14 +417,13 @@ public class AgentClient {
 
         @Inject ObjectMapper mapper;
         @Inject WebClient webClient;
-        @Inject CredentialsFinder credentialsFinder;
         @Inject Logger logger;
 
         @ConfigProperty(name = ConfigProperties.CONNECTIONS_FAILED_TIMEOUT)
         Duration timeout;
 
         public AgentClient create(Target target) {
-            return new AgentClient(target, webClient, mapper, timeout, credentialsFinder);
+            return new AgentClient(target, webClient, mapper, timeout);
         }
     }
 

--- a/src/main/java/io/cryostat/targets/AgentClient.java
+++ b/src/main/java/io/cryostat/targets/AgentClient.java
@@ -40,6 +40,7 @@ import io.cryostat.core.net.MBeanMetrics;
 import io.cryostat.core.serialization.SerializableRecordingDescriptor;
 import io.cryostat.credentials.Credential;
 import io.cryostat.credentials.CredentialsFinder;
+import io.cryostat.discovery.DiscoveryPlugin;
 import io.cryostat.targets.AgentJFRService.StartRecordingRequest;
 import io.cryostat.util.HttpStatusCodeIdentifier;
 
@@ -63,7 +64,6 @@ import jakarta.ws.rs.ForbiddenException;
 import jdk.jfr.RecordingState;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.tuple.Pair;
-import org.apache.hc.client5.http.auth.InvalidCredentialsException;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.jboss.logging.Logger;
 
@@ -402,20 +402,14 @@ public class AgentClient {
                         .timeout(httpTimeout.toMillis())
                         .followRedirects(true)
                         .as(codec);
-        try {
-            Credential credential =
-                    credentialsFinder.getCredentialsForConnectUrl(getUri()).orElse(null);
-            if (credential == null || credential.username == null || credential.password == null) {
-                throw new InvalidCredentialsException(NULL_CREDENTIALS + " " + getUri());
-            }
-            req =
-                    req.authentication(
-                            new UsernamePasswordCredentials(
-                                    credential.username, credential.password));
-        } catch (InvalidCredentialsException e) {
-            logger.error("Authentication exception", e);
-            throw new IllegalStateException(e);
-        }
+
+        Credential credential =
+                DiscoveryPlugin.<DiscoveryPlugin>find("callback", getUri())
+                        .singleResult()
+                        .credential;
+        req =
+                req.authentication(
+                        new UsernamePasswordCredentials(credential.username, credential.password));
 
         Uni<HttpResponse<T>> uni;
         if (payload != null) {

--- a/src/main/java/io/cryostat/targets/TargetConnectionManager.java
+++ b/src/main/java/io/cryostat/targets/TargetConnectionManager.java
@@ -58,7 +58,6 @@ import io.smallrye.mutiny.unchecked.Unchecked;
 import io.vertx.ext.web.handler.HttpException;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
-import jakarta.transaction.Transactional;
 import jdk.jfr.Category;
 import jdk.jfr.Event;
 import jdk.jfr.FlightRecorder;
@@ -298,7 +297,6 @@ public class TargetConnectionManager {
         }
     }
 
-    @Transactional
     JFRConnection connect(URI connectUrl) throws Exception {
         var credentials = credentialsFinder.getCredentialsForConnectUrl(connectUrl);
         return connect(connectUrl, credentials);

--- a/src/main/java/io/cryostat/targets/TargetConnectionManager.java
+++ b/src/main/java/io/cryostat/targets/TargetConnectionManager.java
@@ -52,6 +52,7 @@ import com.github.benmanes.caffeine.cache.Caffeine;
 import com.github.benmanes.caffeine.cache.RemovalCause;
 import com.github.benmanes.caffeine.cache.Scheduler;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import io.quarkus.narayana.jta.QuarkusTransaction;
 import io.quarkus.vertx.ConsumeEvent;
 import io.smallrye.mutiny.Uni;
 import io.smallrye.mutiny.unchecked.Unchecked;
@@ -298,8 +299,13 @@ public class TargetConnectionManager {
     }
 
     JFRConnection connect(URI connectUrl) throws Exception {
-        var credentials = credentialsFinder.getCredentialsForConnectUrl(connectUrl);
-        return connect(connectUrl, credentials);
+        return QuarkusTransaction.joiningExisting()
+                .call(
+                        () -> {
+                            var credentials =
+                                    credentialsFinder.getCredentialsForConnectUrl(connectUrl);
+                            return connect(connectUrl, credentials);
+                        });
     }
 
     JFRConnection connect(URI connectUrl, Optional<Credential> credentials) throws Exception {


### PR DESCRIPTION
# Welcome to Cryostat3! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat3/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] [Signed all commits using a GPG signature](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#gpg-commit-signature-verification)

**To recreate commits with GPG signature** `git fetch upstream && git rebase --force --gpg-sign upstream/main`
_______________________________________________

Fixes: #405
Fixes: #440

## Description of the change:
Removes useless instances of `Transactional` annotation and replaces them with `QuarkusTransaction.joiningExisting()` invocations where applicable.

## Motivation for the change:
Ensures operations actually occur in a transactional context as expected

## How to manually test:
1. *Run CRYOSTAT_IMAGE=quay.io... bash smoketest.bash...*
2. Click around UI performing actions and ensure general functionality works as expected. Pay particular attention to Topology view/actions, Archives > All Targets, and Automated Rules, since these exercise things the most.
3. Create an automated rule like the one below and ensure that it correctly creates a new recording when enabled, that the recording gets archived every 10 seconds, and after there are 3 archived copies that the oldest one gets pruned when a new one is created. Disabling a rule should stop new archives from being saved.

```json
{
  "id": 1,
  "name": "test",
  "description": "",
  "matchExpression": "target.connectUrl.contains('localhost:0')",
  "eventSpecifier": "template=Profiling,type=TARGET",
  "archivalPeriodSeconds": 10,
  "initialDelaySeconds": 0,
  "preservedArchives": 3,
  "maxAgeSeconds": 300,
  "maxSizeBytes": 0,
  "enabled": true
}
```
