### PR TITLE
fix(discovery): null check for compatible port name and number

### DIFF
--- a/src/main/java/io/cryostat/discovery/KubeApiDiscovery.java
+++ b/src/main/java/io/cryostat/discovery/KubeApiDiscovery.java
@@ -71,6 +71,10 @@ public class KubeApiDiscovery {
 
     public static final String DISCOVERY_NAMESPACE_LABEL_KEY = "discovery.cryostat.io/namespace";
 
+    private static final List<String> EMPTY_PORT_NAMES = new ArrayList<>();
+
+    private static final List<Integer> EMPTY_PORT_NUMBERS = new ArrayList<>();
+
     @Inject Logger logger;
 
     @Inject KubeConfig kubeConfig;
@@ -188,9 +192,8 @@ public class KubeApiDiscovery {
     }
 
     private boolean isCompatiblePort(EndpointPort port) {
-        return (port.getName() != null && jmxPortNames.orElse(List.of()).contains(port.getName()))
-                || (port.getPort() != null
-                        && jmxPortNumbers.orElse(List.of()).contains(port.getPort()));
+        return jmxPortNames.orElse(EMPTY_PORT_NAMES).contains(port.getName())
+                || jmxPortNumbers.orElse(EMPTY_PORT_NUMBERS).contains(port.getPort());
     }
 
     private List<TargetTuple> getTargetTuplesFrom(Endpoints endpoints) {

--- a/src/main/java/io/cryostat/discovery/KubeApiDiscovery.java
+++ b/src/main/java/io/cryostat/discovery/KubeApiDiscovery.java
@@ -188,8 +188,9 @@ public class KubeApiDiscovery {
     }
 
     private boolean isCompatiblePort(EndpointPort port) {
-        return jmxPortNames.orElse(List.of()).contains(port.getName())
-                || jmxPortNumbers.orElse(List.of()).contains(port.getPort());
+        return (port.getName() != null && jmxPortNames.orElse(List.of()).contains(port.getName()))
+                || (port.getPort() != null
+                        && jmxPortNumbers.orElse(List.of()).contains(port.getPort()));
     }
 
     private List<TargetTuple> getTargetTuplesFrom(Endpoints endpoints) {


### PR DESCRIPTION
# Welcome to Cryostat3! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat3/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] [Signed all commits using a GPG signature](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#gpg-commit-signature-verification)

**To recreate commits with GPG signature** `git fetch upstream && git rebase --force --gpg-sign upstream/main`
_______________________________________________

Fixes: #416 

## Description of the change:

Null check for `EndpointPort.getName` and `EndpointPort.getPort`.

## Motivation for the change:

In cases, where the endpoint's port does have a name. It can fail with NullPointerException. See #416 