### PR TITLE
fix(tls): return empty list if custom truststore dir is not accessible

### DIFF
--- a/src/main/java/io/cryostat/security/TrustStore.java
+++ b/src/main/java/io/cryostat/security/TrustStore.java
@@ -44,6 +44,14 @@ public class TrustStore {
     @Path("/api/v3/tls/certs")
     @Produces(MediaType.APPLICATION_JSON)
     public List<String> listCerts() throws IOException {
+        var accessible =
+                Files.exists(trustStoreDir)
+                        && Files.isDirectory(trustStoreDir)
+                        && Files.isReadable(trustStoreDir)
+                        && Files.isExecutable(trustStoreDir);
+        if (!accessible) {
+            return List.of();
+        }
         return Files.walk(trustStoreDir)
                 .map(java.nio.file.Path::toFile)
                 .filter(File::isFile)


### PR DESCRIPTION
# Welcome to Cryostat3! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat3/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] [Signed all commits using a GPG signature](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#gpg-commit-signature-verification)

**To recreate commits with GPG signature** `git fetch upstream && git rebase --force --gpg-sign upstream/main`
_______________________________________________

Fixes: #418

## Description of the change:
*This change allows an environment variable to be configured so that...*

## Motivation for the change:
*This change is helpful because users may want to...*

## How to manually test:
1. *Run CRYOSTAT_IMAGE=quay.io... bash smoketest.bash...*
2. *...*
