### PR TITLE
fix(discovery): fix duplicate pod nodes in container discovery

### DIFF
--- a/src/main/java/io/cryostat/discovery/ContainerDiscovery.java
+++ b/src/main/java/io/cryostat/discovery/ContainerDiscovery.java
@@ -396,7 +396,11 @@ public abstract class ContainerDiscovery {
         } else {
             Optional<Target> target =
                     Target.getTarget(
-                            (t) -> desc.Id.equals(t.discoveryNode.labels.get(CONTAINER_ID_LABEL)));
+                            (t) ->
+                                    realm.name.equals(t.annotations.cryostat().get("REALM"))
+                                            && desc.Id.equals(
+                                                    t.discoveryNode.labels.get(
+                                                            CONTAINER_ID_LABEL)));
             if (target.isEmpty()) {
                 return;
             }

--- a/src/main/java/io/cryostat/targets/Target.java
+++ b/src/main/java/io/cryostat/targets/Target.java
@@ -27,6 +27,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.function.Predicate;
 
 import io.cryostat.ConfigProperties;
 import io.cryostat.core.JvmIdentifier;
@@ -127,6 +128,11 @@ public class Target extends PanacheEntity {
 
     public static Optional<Target> getTargetByJvmId(String jvmId) {
         return find("jvmId", jvmId).firstResultOptional();
+    }
+
+    public static Optional<Target> getTarget(Predicate<Target> predicate) {
+        List<Target> targets = listAll();
+        return targets.stream().filter(predicate).findFirst();
     }
 
     public static boolean deleteByConnectUrl(URI connectUrl) {


### PR DESCRIPTION
# Welcome to Cryostat3! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat3/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] [Signed all commits using a GPG signature](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#gpg-commit-signature-verification)

**To recreate commits with GPG signature** `git fetch upstream && git rebase --force --gpg-sign upstream/main`
_______________________________________________

Fixes: #412 

## Description of the change:

- Fetched (pod) discovery node from database if any when handling `FOUND` event.
- Fixed deletion fails when deleting pods (i.e. podman), thus causing new containers to be considered duplicate.
  - Need a label to keep track of the container ID so that we just delete by container id instead of fetching for container information. In the case of `LOST` event, the query will return null -> NullPointerException.
  - With this fix, deleting a pod now works fine. 

![image](https://github.com/cryostatio/cryostat3/assets/68053619/8a2fd002-4c6d-49c4-8f0a-d0103499d881)


## Motivation for the change:

See #412 

## How to manually test:

```bash
podman pod create --replace --name cryostat-pod

podman run \
        --name jmxquarkus \
        --pod cryostat-pod \
        --label io.cryostat.discovery="true" \
        --label io.cryostat.jmxPort="51423" \
        --env QUARKUS_HTTP_PORT=10012 \
        --rm -d quay.io/roberttoyonaga/jmx:jmxquarkus@sha256:b067f29faa91312d20d43c55d194a2e076de7d0d094da3d43ee7d2b2b5a6f100

podman run \
        --name vertx-fib-demo-0 \
        --env HTTP_PORT=8079 \
        --env JMX_PORT=9089 \
        --env START_DELAY=60 \
        --pod cryostat-pod \
        --label io.cryostat.discovery="true" \
        --label io.cryostat.jmxHost="vertx-fib-demo-0" \
        --label io.cryostat.jmxPort="9089" \
        --rm -d quay.io/andrewazores/vertx-fib-demo:0.13.1
```