### PR TITLE
fix(certs): update generate-dev-certs.sh

### DIFF
--- a/certs/generate-dev-certs.sh
+++ b/certs/generate-dev-certs.sh
@@ -11,7 +11,7 @@ SSL_TRUSTSTORE=cryostat-truststore.p12
 SSL_KEYSTORE_PASS_FILE=keystore.pass
 
 if [ -z "$JAVA_HOME" ]; then
-    JAVA_HOME=$(readlink -f /usr/bin/java | grep -oP '.*?openjdk')
+    JAVA_HOME=/usr/lib/jvm/java
 fi
 
 cleanup() {

--- a/certs/generate-dev-certs.sh
+++ b/certs/generate-dev-certs.sh
@@ -10,9 +10,13 @@ SSL_TRUSTSTORE=cryostat-truststore.p12
 
 SSL_KEYSTORE_PASS_FILE=keystore.pass
 
+if [ -z "$JAVA_HOME" ]; then
+    JAVA_HOME=$(readlink -f /usr/bin/java | grep -oP '.*?openjdk')
+fi
+
 cleanup() {
     cd "$CERTS_DIR"
-    rm $SSL_TRUSTSTORE $SSL_KEYSTORE $SSL_KEYSTORE_PASS_FILE
+    rm -f $SSL_TRUSTSTORE $SSL_KEYSTORE $SSL_KEYSTORE_PASS_FILE
     cd -
 }
 
@@ -42,16 +46,11 @@ SSL_KEYSTORE_PASS=$(genpass)
 cd "$CERTS_DIR"
 trap "cd -" EXIT
 
-echo "$SSL_KEYSTORE_PASS" > $SSL_KEYSTORE_PASS_FILE
+if [ -f $SSL_KEYSTORE_PASS_FILE ]; then
+    cleanup
+fi
 
-keytool \
-    -importkeystore \
-    -noprompt \
-    -storetype PKCS12 \
-    -srckeystore /usr/lib/jvm/java-11-openjdk/lib/security/cacerts \
-    -srcstorepass changeit \
-    -destkeystore "$SSL_TRUSTSTORE" \
-    -deststorepass "$SSL_TRUSTSTORE_PASS"
+echo "$SSL_KEYSTORE_PASS" > $SSL_KEYSTORE_PASS_FILE
 
 keytool \
     -genkeypair -v \
@@ -70,13 +69,25 @@ keytool \
     -storepass "$SSL_KEYSTORE_PASS" \
     -file server.cer
 
-keytool \
-    -importcert -v \
-    -noprompt \
-    -trustcacerts \
-    -keystore "$SSL_TRUSTSTORE" \
-    -alias selftrust \
-    -file server.cer \
-    -storepass "$SSL_TRUSTSTORE_PASS"
+if [ -d "$CERTS_DIR/../truststore" ]; then
 
-mv server.cer "$CERTS_DIR/../truststore/dev-self-signed.cer"
+    keytool \
+    -importkeystore \
+    -noprompt \
+    -storetype PKCS12 \
+    -srckeystore ${JAVA_HOME}/lib/security/cacerts \
+    -srcstorepass changeit \
+    -destkeystore "$SSL_TRUSTSTORE" \
+    -deststorepass "$SSL_TRUSTSTORE_PASS"
+
+    keytool \
+        -importcert -v \
+        -noprompt \
+        -trustcacerts \
+        -keystore "$SSL_TRUSTSTORE" \
+        -alias selftrust \
+        -file server.cer \
+        -storepass "$SSL_TRUSTSTORE_PASS"
+
+   mv server.cer "$CERTS_DIR/../truststore/dev-self-signed.cer"
+fi


### PR DESCRIPTION
# Welcome to Cryostat3! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat3/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] [Signed all commits using a GPG signature](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#gpg-commit-signature-verification)

**To recreate commits with GPG signature** `git fetch upstream && git rebase --force --gpg-sign upstream/main`
_______________________________________________

Fixes: #421

## Description of the change:
- use JAVA_HOME variable instead of hard-coded java openjdk path
- cleanup existing keystore file when user generates new keystore pass
- check if truststore folder exists before generating truststore file