### PR TITLE
fix(discovery): observed containers should be checked with persisted nodes

### DIFF
--- a/compose/db.yml
+++ b/compose/db.yml
@@ -2,7 +2,7 @@ version: "3"
 services:
   cryostat:
     environment:
-      QUARKUS_HIBERNATE_ORM_DATABASE_GENERATION: drop-and-create
+      QUARKUS_HIBERNATE_ORM_DATABASE_GENERATION: ${DATABASE_GENERATION:-drop-and-create}
       QUARKUS_DATASOURCE_USERNAME: cryostat3
       QUARKUS_DATASOURCE_PASSWORD: cryostat3
       QUARKUS_DATASOURCE_JDBC_URL: jdbc:postgresql://db:5432/cryostat3

--- a/smoketest.bash
+++ b/smoketest.bash
@@ -65,6 +65,7 @@ while getopts "hs:prGtOVXcbn" opt; do
             ;;
         V)
             KEEP_VOLUMES=true
+            DATABASE_GENERATION=update
             ;;
         X)
             FILES+=("${DIR}/compose/db-viewer.yml")
@@ -111,6 +112,7 @@ fi
 export CRYOSTAT_HTTP_HOST
 export CRYOSTAT_HTTP_PORT
 export GRAFANA_DASHBOARD_EXT_URL
+export DATABASE_GENERATION
 
 s3Manifest="${DIR}/compose/s3-${s3}.yml"
 STORAGE_PORT="$(yq '.services.*.expose[0]' "${s3Manifest}" | grep -v null)"

--- a/src/main/java/io/cryostat/discovery/ContainerDiscovery.java
+++ b/src/main/java/io/cryostat/discovery/ContainerDiscovery.java
@@ -66,6 +66,7 @@ import jakarta.inject.Inject;
 import jakarta.persistence.NoResultException;
 import jakarta.resource.spi.IllegalStateException;
 import jakarta.transaction.Transactional;
+import jakarta.transaction.Transactional.TxType;
 import org.apache.commons.lang3.StringUtils;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.jboss.logging.Logger;
@@ -103,8 +104,8 @@ class PodmanDiscovery extends ContainerDiscovery {
     }
 
     @ConsumeEvent(blocking = true, ordered = true)
-    @Transactional
-    protected void handleContainerEvent(ContainerDiscoveryEvent evt) {
+    @Transactional(TxType.REQUIRES_NEW)
+    public void handleContainerEvent(ContainerDiscoveryEvent evt) {
         try {
             updateDiscoveryTree(evt);
         } catch (IllegalStateException e) {
@@ -149,8 +150,8 @@ class DockerDiscovery extends ContainerDiscovery {
     }
 
     @ConsumeEvent(blocking = true, ordered = true)
-    @Transactional
-    protected void handleContainerEvent(ContainerDiscoveryEvent evt) {
+    @Transactional(TxType.REQUIRES_NEW)
+    public void handleContainerEvent(ContainerDiscoveryEvent evt) {
         try {
             updateDiscoveryTree(evt);
         } catch (IllegalStateException e) {
@@ -323,7 +324,7 @@ public abstract class ContainerDiscovery {
                     Infrastructure.getDefaultWorkerPool()
                             .execute(
                                     () ->
-                                            QuarkusTransaction.joiningExisting()
+                                            QuarkusTransaction.requiringNew()
                                                     .run(() -> handleObservedContainers(current)));
                 });
     }
@@ -518,7 +519,7 @@ public abstract class ContainerDiscovery {
 
     protected abstract String notificationAddress();
 
-    protected abstract void handleContainerEvent(ContainerDiscoveryEvent evt);
+    public abstract void handleContainerEvent(ContainerDiscoveryEvent evt);
 
     static record PortSpec(
             long container_port, String host_ip, long host_port, String protocol, long range) {}

--- a/src/main/java/io/cryostat/discovery/ContainerDiscovery.java
+++ b/src/main/java/io/cryostat/discovery/ContainerDiscovery.java
@@ -102,13 +102,15 @@ class PodmanDiscovery extends ContainerDiscovery {
         return enabled;
     }
 
-    @ConsumeEvent(
-            value = "io.cryostat.discovery.ContainerDiscovery",
-            blocking = true,
-            ordered = true)
+    @ConsumeEvent(blocking = true, ordered = true)
     @Transactional
     void handleContainerEvent(ContainerDiscoveryEvent evt) {
         updateDiscoveryTree(evt);
+    }
+
+    @Override
+    protected String notificationAddress() {
+        return PodmanDiscovery.class.getName();
     }
 }
 
@@ -142,13 +144,15 @@ class DockerDiscovery extends ContainerDiscovery {
         return enabled;
     }
 
-    @ConsumeEvent(
-            value = "io.cryostat.discovery.ContainerDiscovery",
-            blocking = true,
-            ordered = true)
+    @ConsumeEvent(blocking = true, ordered = true)
     @Transactional
     void handleContainerEvent(ContainerDiscoveryEvent evt) {
         updateDiscoveryTree(evt);
+    }
+
+    @Override
+    protected String notificationAddress() {
+        return DockerDiscovery.class.getName();
     }
 }
 
@@ -487,7 +491,7 @@ public abstract class ContainerDiscovery {
     }
 
     protected void notify(ContainerDiscoveryEvent evt) {
-        bus.publish(ContainerDiscovery.class.getName(), evt);
+        bus.publish(notificationAddress(), evt);
     }
 
     protected abstract SocketAddress getSocket();
@@ -499,6 +503,8 @@ public abstract class ContainerDiscovery {
     protected abstract String getContainerQueryURL(ContainerSpec spec);
 
     protected abstract boolean enabled();
+
+    protected abstract String notificationAddress();
 
     static record PortSpec(
             long container_port, String host_ip, long host_port, String protocol, long range) {}

--- a/src/main/java/io/cryostat/discovery/ContainerDiscovery.java
+++ b/src/main/java/io/cryostat/discovery/ContainerDiscovery.java
@@ -24,6 +24,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
@@ -62,6 +63,7 @@ import jakarta.enterprise.event.Observes;
 import jakarta.inject.Inject;
 import jakarta.transaction.Transactional;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.tuple.Pair;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.jboss.logging.Logger;
 
@@ -338,7 +340,7 @@ public abstract class ContainerDiscovery {
                                     DiscoveryNode.findAllByNodeType(BaseNodeType.JVM).stream()
                                             .filter(
                                                     (n) ->
-                                                            n.target != null
+                                                            Objects.nonNull(n.target)
                                                                     && getRealm()
                                                                             .equals(
                                                                                     n.target
@@ -349,7 +351,13 @@ public abstract class ContainerDiscovery {
                                             .collect(Collectors.toList());
 
                             Map<Target, ContainerSpec> containerRefMap = new HashMap<>();
-                            current.forEach((desc) -> containerRefMap.put(toTarget(desc), desc));
+                            current.stream()
+                                    .map((desc) -> Pair.of(desc, toTarget(desc)))
+                                    .filter((pair) -> Objects.nonNull(pair.getRight()))
+                                    .forEach(
+                                            (pair) ->
+                                                    containerRefMap.put(
+                                                            pair.getRight(), pair.getLeft()));
 
                             Set<Target> persistedTargets =
                                     targetNodes.stream()

--- a/src/main/java/io/cryostat/discovery/ContainerDiscovery.java
+++ b/src/main/java/io/cryostat/discovery/ContainerDiscovery.java
@@ -298,7 +298,6 @@ public abstract class ContainerDiscovery {
     }
 
     private void doContainerListRequest(Consumer<List<ContainerSpec>> successHandler) {
-        logger.trace(String.format("Shutting down %s client", getRealm()));
         URI requestPath = URI.create(getContainersQueryURL());
         try {
             webClient
@@ -405,6 +404,9 @@ public abstract class ContainerDiscovery {
     @Transactional
     @ConsumeEvent(value = "io.cryostat.discovery.ContainerDiscovery", blocking = true)
     public void updateDiscoveryTree(ContainerDiscoveryEvent evt) {
+        if (!(enabled() && available())) {
+            return;
+        }
         EventKind evtKind = evt.eventKind;
         Target target = evt.target;
         ContainerSpec desc = evt.desc;

--- a/src/main/java/io/cryostat/discovery/ContainerDiscovery.java
+++ b/src/main/java/io/cryostat/discovery/ContainerDiscovery.java
@@ -139,8 +139,6 @@ public abstract class ContainerDiscovery {
     public static final String JMX_URL_LABEL = "io.cryostat.jmxUrl";
     public static final String JMX_HOST_LABEL = "io.cryostat.jmxHost";
     public static final String JMX_PORT_LABEL = "io.cryostat.jmxPort";
-    public static final String CONTAINER_DISCOVERY_ADDRESS =
-            "io.cryostat.discovery.ContainerDiscovery";
 
     @Inject Logger logger;
     @Inject FileSystem fs;
@@ -398,15 +396,12 @@ public abstract class ContainerDiscovery {
     }
 
     private void notify(ContainerDiscoveryEvent evt) {
-        bus.publish(CONTAINER_DISCOVERY_ADDRESS, evt);
+        bus.publish(ContainerDiscovery.class.getName(), evt);
     }
 
     @Transactional
-    @ConsumeEvent(value = "io.cryostat.discovery.ContainerDiscovery", blocking = true)
+    @ConsumeEvent(blocking = true)
     public void updateDiscoveryTree(ContainerDiscoveryEvent evt) {
-        if (!(enabled() && available())) {
-            return;
-        }
         EventKind evtKind = evt.eventKind;
         Target target = evt.target;
         ContainerSpec desc = evt.desc;

--- a/src/main/java/io/cryostat/discovery/ContainerDiscovery.java
+++ b/src/main/java/io/cryostat/discovery/ContainerDiscovery.java
@@ -59,7 +59,6 @@ import io.vertx.mutiny.core.eventbus.EventBus;
 import io.vertx.mutiny.core.net.SocketAddress;
 import io.vertx.mutiny.ext.web.client.WebClient;
 import io.vertx.mutiny.ext.web.codec.BodyCodec;
-import jakarta.annotation.Priority;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.event.Observes;
 import jakarta.inject.Inject;
@@ -187,10 +186,8 @@ public abstract class ContainerDiscovery {
 
     protected long timerId;
 
-    // Priority is set higher than default 0 such that onStart is called first before onAfterStart
-    // This ensures realm node is persisted before querying for containers
     @Transactional
-    void onStart(@Observes @Priority(1) StartupEvent evt) {
+    void onStart(@Observes StartupEvent evt) {
         if (!enabled()) {
             return;
         }
@@ -215,12 +212,6 @@ public abstract class ContainerDiscovery {
         }
 
         logger.infov("Starting {0} client", getRealm());
-    }
-
-    void onAfterStart(@Observes StartupEvent evt) {
-        if (!(enabled() && available())) {
-            return;
-        }
 
         queryContainers();
         this.timerId = vertx.setPeriodic(pollPeriod.toMillis(), unused -> queryContainers());

--- a/src/main/java/io/cryostat/discovery/ContainerDiscovery.java
+++ b/src/main/java/io/cryostat/discovery/ContainerDiscovery.java
@@ -21,10 +21,9 @@ import java.net.URISyntaxException;
 import java.nio.file.Path;
 import java.time.Duration;
 import java.util.ArrayList;
-import java.util.HashSet;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
@@ -33,6 +32,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.function.Consumer;
+import java.util.stream.Collectors;
 
 import javax.management.remote.JMXServiceURL;
 
@@ -50,7 +50,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.sun.security.auth.module.UnixSystem;
 import io.quarkus.runtime.ShutdownEvent;
 import io.quarkus.runtime.StartupEvent;
-import io.smallrye.mutiny.infrastructure.Infrastructure;
 import io.vertx.core.http.HttpMethod;
 import io.vertx.mutiny.core.Vertx;
 import io.vertx.mutiny.core.net.SocketAddress;
@@ -133,7 +132,6 @@ public abstract class ContainerDiscovery {
     public static final String JMX_URL_LABEL = "io.cryostat.jmxUrl";
     public static final String JMX_HOST_LABEL = "io.cryostat.jmxHost";
     public static final String JMX_PORT_LABEL = "io.cryostat.jmxPort";
-    public static final String CONTAINER_ID_LABEL = "io.cryostat.containerId";
 
     @Inject Logger logger;
     @Inject FileSystem fs;
@@ -192,44 +190,106 @@ public abstract class ContainerDiscovery {
         vertx.cancelTimer(timerId);
     }
 
+    private Target toTarget(ContainerSpec desc) {
+        URI connectUrl;
+        String hostname;
+        int jmxPort;
+        try {
+            JMXServiceURL serviceUrl;
+            URI rmiTarget;
+            if (desc.Labels.containsKey(JMX_URL_LABEL)) {
+                serviceUrl = new JMXServiceURL(desc.Labels.get(JMX_URL_LABEL));
+                connectUrl = URI.create(serviceUrl.toString());
+                try {
+                    rmiTarget = URIUtil.getRmiTarget(serviceUrl);
+                    hostname = rmiTarget.getHost();
+                    jmxPort = rmiTarget.getPort();
+                } catch (IllegalArgumentException e) {
+                    hostname = serviceUrl.getHost();
+                    jmxPort = serviceUrl.getPort();
+                }
+            } else {
+                jmxPort = Integer.parseInt(desc.Labels.get(JMX_PORT_LABEL));
+                hostname = desc.Labels.get(JMX_HOST_LABEL);
+                if (hostname == null) {
+                    try {
+                        hostname =
+                                doContainerInspectRequest(desc)
+                                        .get(2, TimeUnit.SECONDS)
+                                        .Config
+                                        .Hostname;
+                    } catch (InterruptedException | TimeoutException | ExecutionException e) {
+                        containers.remove(desc);
+                        logger.warnv(e, "Invalid {0} target observed", getRealm());
+                        return null;
+                    }
+                }
+            }
+            serviceUrl = connectionToolkit.createServiceURL(hostname, jmxPort);
+            connectUrl = URI.create(serviceUrl.toString());
+        } catch (MalformedURLException | URISyntaxException e) {
+            containers.remove(desc);
+            logger.warnv(e, "Invalid {0} target observed", getRealm());
+            return null;
+        }
+
+        Target target = new Target();
+        target.activeRecordings = new ArrayList<>();
+        target.connectUrl = connectUrl;
+        target.alias = Optional.ofNullable(desc.Names.get(0)).orElse(desc.Id);
+        target.labels = desc.Labels;
+        target.annotations = new Annotations();
+        target.annotations
+                .cryostat()
+                .putAll(
+                        Map.of(
+                                "REALM", // AnnotationKey.REALM,
+                                getRealm(),
+                                "HOST", // AnnotationKey.HOST,
+                                hostname,
+                                "PORT", // "AnnotationKey.PORT,
+                                Integer.toString(jmxPort)));
+
+        return target;
+    }
+
     private void queryContainers() {
         doContainerListRequest(
                 current -> {
-                    Set<ContainerSpec> previous = new HashSet<>(containers);
-                    Set<ContainerSpec> updated = new HashSet<>(current);
+                    List<DiscoveryNode> targetNodes =
+                            DiscoveryNode.findAllByNodeType(BaseNodeType.JVM).stream()
+                                    .filter(
+                                            (n) ->
+                                                    getRealm()
+                                                            .equals(
+                                                                    n.target
+                                                                            .annotations
+                                                                            .cryostat()
+                                                                            .get("REALM")))
+                                    .collect(Collectors.toList());
 
-                    Set<ContainerSpec> intersection = new HashSet<>(containers);
-                    intersection.retainAll(updated);
+                    Map<Target, ContainerSpec> containerRefMap = new HashMap<>();
+                    current.forEach((desc) -> containerRefMap.put(toTarget(desc), desc));
 
-                    Set<ContainerSpec> removed = new HashSet<>(previous);
-                    removed.removeAll(intersection);
+                    Set<Target> persistedTargets =
+                            targetNodes.stream().map((n) -> n.target).collect(Collectors.toSet());
+                    Set<Target> observedTargets = containerRefMap.keySet();
 
-                    Set<ContainerSpec> added = new HashSet<>(updated);
-                    added.removeAll(intersection);
+                    Target.compare(persistedTargets)
+                            .to(observedTargets)
+                            .added()
+                            .forEach(
+                                    (t) ->
+                                            handleContainerEvent(
+                                                    containerRefMap.get(t), t, EventKind.FOUND));
 
-                    containers.removeAll(removed);
-                    Infrastructure.getDefaultWorkerPool()
-                            .execute(
-                                    () ->
-                                            removed.stream()
-                                                    .filter(Objects::nonNull)
-                                                    .forEach(
-                                                            container ->
-                                                                    handleContainerEvent(
-                                                                            container,
-                                                                            EventKind.LOST)));
-
-                    containers.addAll(added);
-                    Infrastructure.getDefaultWorkerPool()
-                            .execute(
-                                    () ->
-                                            added.stream()
-                                                    .filter(Objects::nonNull)
-                                                    .forEach(
-                                                            container ->
-                                                                    handleContainerEvent(
-                                                                            container,
-                                                                            EventKind.FOUND)));
+                    Target.compare(persistedTargets)
+                            .to(observedTargets)
+                            .removed()
+                            .forEach(
+                                    (t) ->
+                                            handleContainerEvent(
+                                                    containerRefMap.get(t), t, EventKind.LOST));
                 });
     }
 
@@ -292,72 +352,18 @@ public abstract class ContainerDiscovery {
     }
 
     @Transactional
-    public void handleContainerEvent(ContainerSpec desc, EventKind evtKind) {
+    public void handleContainerEvent(ContainerSpec desc, Target target, EventKind evtKind) {
         DiscoveryNode realm = DiscoveryNode.getRealm(getRealm()).orElseThrow();
 
         if (evtKind == EventKind.FOUND) {
-            URI connectUrl;
-            String hostname;
-            int jmxPort;
-            try {
-                JMXServiceURL serviceUrl;
-                URI rmiTarget;
-                if (desc.Labels.containsKey(JMX_URL_LABEL)) {
-                    serviceUrl = new JMXServiceURL(desc.Labels.get(JMX_URL_LABEL));
-                    connectUrl = URI.create(serviceUrl.toString());
-                    try {
-                        rmiTarget = URIUtil.getRmiTarget(serviceUrl);
-                        hostname = rmiTarget.getHost();
-                        jmxPort = rmiTarget.getPort();
-                    } catch (IllegalArgumentException e) {
-                        hostname = serviceUrl.getHost();
-                        jmxPort = serviceUrl.getPort();
-                    }
-                } else {
-                    jmxPort = Integer.parseInt(desc.Labels.get(JMX_PORT_LABEL));
-                    hostname = desc.Labels.get(JMX_HOST_LABEL);
-                    if (hostname == null) {
-                        try {
-                            hostname =
-                                    doContainerInspectRequest(desc)
-                                            .get(2, TimeUnit.SECONDS)
-                                            .Config
-                                            .Hostname;
-                        } catch (InterruptedException | TimeoutException | ExecutionException e) {
-                            containers.remove(desc);
-                            logger.warnv(e, "Invalid {0} target observed", getRealm());
-                            return;
-                        }
-                    }
-                }
-                serviceUrl = connectionToolkit.createServiceURL(hostname, jmxPort);
-                connectUrl = URI.create(serviceUrl.toString());
-            } catch (MalformedURLException | URISyntaxException e) {
-                containers.remove(desc);
-                logger.warnv(e, "Invalid {0} target observed", getRealm());
+            if (target.isPersistent()) {
+                logger.infov(
+                        "Target with serviceURL {0} already exist in discovery tree. Skipped"
+                                + " adding",
+                        target.connectUrl);
                 return;
             }
-
-            Target target = new Target();
-            target.activeRecordings = new ArrayList<>();
-            target.connectUrl = connectUrl;
-            target.alias = Optional.ofNullable(desc.Names.get(0)).orElse(desc.Id);
-            target.labels = desc.Labels;
-            target.annotations = new Annotations();
-            target.annotations
-                    .cryostat()
-                    .putAll(
-                            Map.of(
-                                    "REALM", // AnnotationKey.REALM,
-                                    getRealm(),
-                                    "HOST", // AnnotationKey.HOST,
-                                    hostname,
-                                    "PORT", // "AnnotationKey.PORT,
-                                    Integer.toString(jmxPort)));
-
             DiscoveryNode node = DiscoveryNode.target(target, BaseNodeType.JVM);
-            node.labels.put(
-                    CONTAINER_ID_LABEL, desc.Id); // Add container Id retrieve node during deletion
             target.discoveryNode = node;
 
             String podName = desc.PodName;
@@ -394,18 +400,15 @@ public abstract class ContainerDiscovery {
             node.persist();
             realm.persist();
         } else {
-            Optional<Target> target =
-                    Target.getTarget(
-                            (t) ->
-                                    realm.name.equals(t.annotations.cryostat().get("REALM"))
-                                            && desc.Id.equals(
-                                                    t.discoveryNode.labels.get(
-                                                            CONTAINER_ID_LABEL)));
-            if (target.isEmpty()) {
+            if (!target.isPersistent()) {
+                logger.infov(
+                        "Target with serviceURL {0} does not exist in discovery tree. Skipped"
+                                + " deleting",
+                        target.connectUrl);
                 return;
             }
 
-            DiscoveryNode node = target.get().discoveryNode;
+            DiscoveryNode node = target.discoveryNode;
 
             while (true) {
                 DiscoveryNode parent = node.parent;
@@ -425,7 +428,7 @@ public abstract class ContainerDiscovery {
             }
 
             realm.persist();
-            target.get().delete();
+            target.delete();
         }
     }
 

--- a/src/main/java/io/cryostat/discovery/ContainerDiscovery.java
+++ b/src/main/java/io/cryostat/discovery/ContainerDiscovery.java
@@ -347,7 +347,7 @@ public abstract class ContainerDiscovery {
         return result;
     }
 
-    public void handleContainerEvent(List<ContainerSpec> current) {
+    public synchronized void handleContainerEvent(List<ContainerSpec> current) {
         QuarkusTransaction.joiningExisting()
                 .run(
                         () -> {

--- a/src/main/java/io/cryostat/discovery/ContainerDiscovery.java
+++ b/src/main/java/io/cryostat/discovery/ContainerDiscovery.java
@@ -103,7 +103,7 @@ class PodmanDiscovery extends ContainerDiscovery {
 
     @ConsumeEvent(blocking = true, ordered = true)
     @Transactional
-    void handleContainerEvent(ContainerDiscoveryEvent evt) {
+    protected void handleContainerEvent(ContainerDiscoveryEvent evt) {
         updateDiscoveryTree(evt);
     }
 
@@ -145,7 +145,7 @@ class DockerDiscovery extends ContainerDiscovery {
 
     @ConsumeEvent(blocking = true, ordered = true)
     @Transactional
-    void handleContainerEvent(ContainerDiscoveryEvent evt) {
+    protected void handleContainerEvent(ContainerDiscoveryEvent evt) {
         updateDiscoveryTree(evt);
     }
 
@@ -510,6 +510,8 @@ public abstract class ContainerDiscovery {
     protected abstract boolean enabled();
 
     protected abstract String notificationAddress();
+
+    protected abstract void handleContainerEvent(ContainerDiscoveryEvent evt);
 
     static record PortSpec(
             long container_port, String host_ip, long host_port, String protocol, long range) {}

--- a/src/main/java/io/cryostat/discovery/ContainerDiscovery.java
+++ b/src/main/java/io/cryostat/discovery/ContainerDiscovery.java
@@ -27,7 +27,6 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
@@ -151,8 +150,6 @@ public abstract class ContainerDiscovery {
 
     protected long timerId;
 
-    protected final CopyOnWriteArrayList<ContainerSpec> containers = new CopyOnWriteArrayList<>();
-
     // Priority is set higher than default 0 such that onStart is called first before onAfterStart
     // This ensures realm node is persisted before querying for containers
     @Transactional
@@ -235,7 +232,6 @@ public abstract class ContainerDiscovery {
                                         .Config
                                         .Hostname;
                     } catch (InterruptedException | TimeoutException | ExecutionException e) {
-                        containers.remove(desc);
                         logger.warnv(e, "Invalid {0} target observed", getRealm());
                         return null;
                     }
@@ -244,7 +240,6 @@ public abstract class ContainerDiscovery {
             serviceUrl = connectionToolkit.createServiceURL(hostname, jmxPort);
             connectUrl = URI.create(serviceUrl.toString());
         } catch (MalformedURLException | URISyntaxException e) {
-            containers.remove(desc);
             logger.warnv(e, "Invalid {0} target observed", getRealm());
             return null;
         }

--- a/src/main/java/io/cryostat/discovery/ContainerDiscovery.java
+++ b/src/main/java/io/cryostat/discovery/ContainerDiscovery.java
@@ -161,8 +161,6 @@ public abstract class ContainerDiscovery {
     public static final String JMX_URL_LABEL = "io.cryostat.jmxUrl";
     public static final String JMX_HOST_LABEL = "io.cryostat.jmxHost";
     public static final String JMX_PORT_LABEL = "io.cryostat.jmxPort";
-    public static final String CONTAINER_DISCOVERY_ADDRESS =
-            "io.cryostat.discovery.ContainerDiscovery";
 
     @Inject Logger logger;
     @Inject FileSystem fs;

--- a/src/main/java/io/cryostat/discovery/ContainerDiscovery.java
+++ b/src/main/java/io/cryostat/discovery/ContainerDiscovery.java
@@ -299,12 +299,12 @@ public abstract class ContainerDiscovery {
         return target;
     }
 
-    private boolean isTargetUnderRealm(String realm, URI connectUrl) throws IllegalStateException {
+    private boolean isTargetUnderRealm(URI connectUrl) throws IllegalStateException {
         // Check for any targets with the same connectUrl in other realms
         try {
             Target persistedTarget = Target.getTargetByConnectUrl(connectUrl);
             String realmOfTarget = persistedTarget.annotations.cryostat().get("REALM");
-            if (!realm.equals(realmOfTarget)) {
+            if (!getRealm().equals(realmOfTarget)) {
                 logger.warnv(
                         "Expected persisted target with serviceURL {0} to be under realm"
                                 + " {1} but found under {2} ",
@@ -428,7 +428,7 @@ public abstract class ContainerDiscovery {
         DiscoveryNode realm = DiscoveryNode.getRealm(getRealm()).orElseThrow();
 
         if (evtKind == EventKind.FOUND) {
-            if (isTargetUnderRealm(getRealm(), target.connectUrl)) {
+            if (isTargetUnderRealm(target.connectUrl)) {
                 logger.infov(
                         "Target with serviceURL {0} already exist in discovery tree. Skip adding",
                         target.connectUrl);
@@ -471,7 +471,7 @@ public abstract class ContainerDiscovery {
             node.persist();
             realm.persist();
         } else {
-            if (!isTargetUnderRealm(getRealm(), target.connectUrl)) {
+            if (!isTargetUnderRealm(target.connectUrl)) {
                 logger.infov(
                         "Target with serviceURL {0} does not exist in discovery tree. Skip"
                                 + " deleting",

--- a/src/main/java/io/cryostat/discovery/ContainerDiscovery.java
+++ b/src/main/java/io/cryostat/discovery/ContainerDiscovery.java
@@ -239,6 +239,7 @@ public abstract class ContainerDiscovery {
         return fs.exists(socketPath) && fs.isReadable(socketPath);
     }
 
+    // Construct a target representation (non-persistent) of the container spec
     private Target toTarget(ContainerSpec desc) {
         URI connectUrl;
         String hostname;
@@ -479,6 +480,10 @@ public abstract class ContainerDiscovery {
                         target.connectUrl);
                 return;
             }
+            // Retrieve the latest snapshot of the target
+            // The target received from event message is outdated as it belongs to the previous
+            // transaction
+            target = Target.getTargetByConnectUrl(target.connectUrl);
             DiscoveryNode node = target.discoveryNode;
 
             while (true) {

--- a/src/main/java/io/cryostat/discovery/ContainerDiscovery.java
+++ b/src/main/java/io/cryostat/discovery/ContainerDiscovery.java
@@ -281,6 +281,7 @@ public abstract class ContainerDiscovery {
                         persistedTarget.connectUrl, getRealm(), realmOfTarget);
                 return null;
             }
+            return persistedTarget;
         } catch (NoResultException e) {
         }
 

--- a/src/main/java/io/cryostat/targets/Target.java
+++ b/src/main/java/io/cryostat/targets/Target.java
@@ -28,6 +28,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.function.Predicate;
+import java.util.stream.Collectors;
 
 import io.cryostat.ConfigProperties;
 import io.cryostat.core.JvmIdentifier;
@@ -137,6 +138,14 @@ public class Target extends PanacheEntity {
 
     public static boolean deleteByConnectUrl(URI connectUrl) {
         return delete("connectUrl", connectUrl) > 0;
+    }
+
+    public static List<Target> findByRealm(String realm) {
+        List<Target> targets = findAll().list();
+
+        return targets.stream()
+                .filter((t) -> realm.equals(t.annotations.cryostat().get("REALM")))
+                .collect(Collectors.toList());
     }
 
     public ActiveRecording getRecordingById(long remoteId) {


### PR DESCRIPTION
# Welcome to Cryostat3! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat3/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] [Signed all commits using a GPG signature](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#gpg-commit-signature-verification)

**To recreate commits with GPG signature** `git fetch upstream && git rebase --force --gpg-sign upstream/main`
_______________________________________________

Related to #420 

## Description of the change:

- Update container event handler to check with persisted targets.

## Motivation for the change:

See https://github.com/cryostatio/cryostat3/pull/420#issuecomment-2079879609. This fixes the problem when cryostat is restarted, observed targets will cause duplicate key violation and removed targets remain in database (stale).

## How to manually test

```
mvn clean package -DskipTests=true
CRYOSTAT_DISCOVERY_JDP_ENABLED=false bash smoketest.bash -O
```
