### PR TITLE
fix(discovery): JDP event bus broadcast to correct address

### DIFF
--- a/src/main/java/io/cryostat/discovery/JDPDiscovery.java
+++ b/src/main/java/io/cryostat/discovery/JDPDiscovery.java
@@ -102,7 +102,7 @@ public class JDPDiscovery implements Consumer<JvmDiscoveryEvent> {
 
     @Override
     public void accept(JvmDiscoveryEvent evt) {
-        eventBus.publish(getClass().getName(), evt);
+        eventBus.publish(JDPDiscovery.class.getName(), evt);
     }
 
     @ConsumeEvent(blocking = true, ordered = true)


### PR DESCRIPTION
# Welcome to Cryostat3! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat3/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] [Signed all commits using a GPG signature](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#gpg-commit-signature-verification)

**To recreate commits with GPG signature** `git fetch upstream && git rebase --force --gpg-sign upstream/main`
_______________________________________________

Related to #415 / #407

## Description of the change:
Fixes missed change correcting the eventbus publication address of JDP discovery messages.

## Motivation for the change:
JDP discovery works again.

## How to manually test:
1. Check out and build PR
2. `./smoketest.bash -Ot`
3. Go to Topology view and ensure JDP nodes are discovered