### PR TITLE
chore(cleanup): Adjust for core changes to abstract away the Document type

### DIFF
--- a/src/main/java/io/cryostat/events/EventTemplates.java
+++ b/src/main/java/io/cryostat/events/EventTemplates.java
@@ -43,7 +43,6 @@ import org.jboss.resteasy.reactive.RestForm;
 import org.jboss.resteasy.reactive.RestPath;
 import org.jboss.resteasy.reactive.RestResponse;
 import org.jboss.resteasy.reactive.multipart.FileUpload;
-import org.jsoup.nodes.Document;
 
 @Path("")
 public class EventTemplates {
@@ -179,24 +178,24 @@ public class EventTemplates {
             @RestPath long id, @RestPath TemplateType templateType, @RestPath String templateName)
             throws Exception {
         Target target = Target.find("id", id).singleResult();
-        Document doc;
+        String xml;
         switch (templateType) {
             case TARGET:
-                doc =
+                xml =
                         targetTemplateServiceFactory
                                 .create(target)
                                 .getXml(templateName, templateType)
                                 .orElseThrow();
                 break;
             case CUSTOM:
-                doc = customTemplateService.getXml(templateName, templateType).orElseThrow();
+                xml = customTemplateService.getXml(templateName, templateType).orElseThrow();
                 break;
             default:
                 throw new BadRequestException();
         }
         return Response.status(RestResponse.Status.OK)
                 .header(HttpHeaders.CONTENT_TYPE, HttpMimeType.JFC.mime())
-                .entity(doc.toString())
+                .entity(xml)
                 .build();
     }
 }

--- a/src/main/java/io/cryostat/events/S3TemplateService.java
+++ b/src/main/java/io/cryostat/events/S3TemplateService.java
@@ -62,7 +62,6 @@ import org.apache.commons.lang3.tuple.Pair;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.jboss.logging.Logger;
 import org.jsoup.Jsoup;
-import org.jsoup.nodes.Document;
 import org.jsoup.parser.Parser;
 import software.amazon.awssdk.core.sync.RequestBody;
 import software.amazon.awssdk.services.s3.S3Client;
@@ -156,12 +155,12 @@ public class S3TemplateService implements MutableTemplateService {
     }
 
     @Override
-    public Optional<Document> getXml(String templateName, TemplateType unused)
+    public Optional<String> getXml(String templateName, TemplateType unused)
             throws FlightRecorderException {
         try (var stream = getModel(templateName)) {
             Document doc =
                     Jsoup.parse(stream, StandardCharsets.UTF_8.name(), "", Parser.xmlParser());
-            return Optional.of(doc);
+            return Optional.of(doc.outerHtml());
         } catch (IOException e) {
             logger.error(e);
             return Optional.empty();

--- a/src/main/java/io/cryostat/events/S3TemplateService.java
+++ b/src/main/java/io/cryostat/events/S3TemplateService.java
@@ -43,8 +43,6 @@ import io.cryostat.Producers;
 import io.cryostat.StorageBuckets;
 import io.cryostat.core.FlightRecorderException;
 import io.cryostat.core.templates.MutableTemplateService;
-import io.cryostat.core.templates.MutableTemplateService.InvalidEventTemplateException;
-import io.cryostat.core.templates.MutableTemplateService.InvalidXmlException;
 import io.cryostat.core.templates.Template;
 import io.cryostat.core.templates.TemplateType;
 import io.cryostat.ws.MessagingServer;
@@ -158,9 +156,9 @@ public class S3TemplateService implements MutableTemplateService {
     public Optional<String> getXml(String templateName, TemplateType unused)
             throws FlightRecorderException {
         try (var stream = getModel(templateName)) {
-            Document doc =
-                    Jsoup.parse(stream, StandardCharsets.UTF_8.name(), "", Parser.xmlParser());
-            return Optional.of(doc.outerHtml());
+            return Optional.of(
+                    Jsoup.parse(stream, StandardCharsets.UTF_8.name(), "", Parser.xmlParser())
+                            .outerHtml());
         } catch (IOException e) {
             logger.error(e);
             return Optional.empty();

--- a/src/main/java/io/cryostat/events/TargetTemplateService.java
+++ b/src/main/java/io/cryostat/events/TargetTemplateService.java
@@ -30,7 +30,6 @@ import io.cryostat.targets.TargetConnectionManager;
 
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
-import org.jsoup.nodes.Document;
 
 public class TargetTemplateService implements TemplateService {
 
@@ -62,11 +61,15 @@ public class TargetTemplateService implements TemplateService {
     }
 
     @Override
-    public Optional<Document> getXml(String templateName, TemplateType unused)
+    public Optional<String> getXml(String templateName, TemplateType unused)
             throws FlightRecorderException {
-        return connectionManager.executeConnectedTask(
-                target,
-                conn -> conn.getTemplateService().getXml(templateName, TemplateType.TARGET));
+        Optional doc =
+                connectionManager.executeConnectedTask(
+                        target,
+                        conn ->
+                                conn.getTemplateService()
+                                        .getXml(templateName, TemplateType.TARGET));
+        return doc.isPresent() ? Optional.of(doc.toString()) : Optional.empty();
     }
 
     @Override

--- a/src/main/java/io/cryostat/targets/AgentJFRService.java
+++ b/src/main/java/io/cryostat/targets/AgentJFRService.java
@@ -260,8 +260,7 @@ class AgentJFRService implements CryostatFlightRecorderService {
                             null,
                             templateService
                                     .getXml(templateName, preferredTemplateType)
-                                    .orElseThrow()
-                                    .outerHtml(),
+                                    .orElseThrow(),
                             duration,
                             maxSize,
                             maxAge);


### PR DESCRIPTION
# Welcome to Cryostat3! 👋
## Before contributing, make sure you have:
* [ ] Read the [contributing guidelines](https://github.com/cryostatio/cryostat3/blob/main/CONTRIBUTING.md)
* [ ] Linked a relevant issue which this PR resolves
* [ ] Linked any other relevant issues, PR's, or documentation, if any
* [ ] Resolved all conflicts, if any
* [ ] Rebased your branch PR on top of the latest upstream `main` branch
* [ ] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [ ] [Signed all commits using a GPG signature](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#gpg-commit-signature-verification)

**To recreate commits with GPG signature** `git fetch upstream && git rebase --force --gpg-sign upstream/main`
_______________________________________________

Fixes: https://github.com/cryostatio/cryostat-core/issues/300

Related To: https://github.com/cryostatio/cryostat-core/pull/389

## Description of the change:
Adjusts the S3TemplateService and API handlers to account for proposed changes to the TemplateService to avoid directly exposing the Document type.

The S3TemplateService still knows about the Document type and uses it since that's its' implementation, however it does not expose it to callers of getXML.

## Motivation for the change:
*This change is helpful because users may want to...*

## How to manually test:
1. *Run CRYOSTAT_IMAGE=quay.io... bash smoketest.bash...*
2. *...*

Tested with ./mvnw run:quarkus-dev and testing the event template functionality/starting recordings with templates.