### PR TITLE
fix(health): correctly check reports service health

### DIFF
--- a/src/main/java/io/cryostat/Health.java
+++ b/src/main/java/io/cryostat/Health.java
@@ -87,12 +87,13 @@ class Health {
         // other value then this means sidecar report generation is requested, so it is configured
         // and the availability must be tested.
         boolean reportsConfigured =
-                !StringUtils.isBlank(reportsClientURL)
+                StringUtils.isNotBlank(reportsClientURL)
                         && !Objects.equals(LOCAL_REPORT_GENERATION_URL, reportsClientURL);
-        checkUri(
-                reportsConfigured ? Optional.of(reportsClientURL) : Optional.empty(),
-                "/health",
-                reportsAvailable);
+        if (reportsConfigured) {
+            checkUri(Optional.of(reportsClientURL), "/health", reportsAvailable);
+        } else {
+            reportsAvailable.complete(true);
+        }
 
         return new PermittedResponseBuilder(
                         Response.ok(

--- a/src/main/java/io/cryostat/Health.java
+++ b/src/main/java/io/cryostat/Health.java
@@ -91,9 +91,7 @@ class Health {
         } else {
             reportsURL = Optional.of(reportsClientURL);
         }
-        reportsURL.ifPresentOrElse(
-                u -> checkUri(Optional.of(u), "/health", reportsAvailable),
-                () -> reportsAvailable.complete(true));
+        checkUri(reportsURL, "/health", reportsAvailable);
 
         return new PermittedResponseBuilder(
                         Response.ok(

--- a/src/test/java/io/cryostat/HealthTest.java
+++ b/src/test/java/io/cryostat/HealthTest.java
@@ -66,7 +66,7 @@ public class HealthTest {
                         "datasourceConfigured", is(true),
                         "datasourceAvailable", is(true),
                         "reportsConfigured", is(false),
-                        "reportsAvailable", is(false));
+                        "reportsAvailable", is(true));
     }
 
     @Test


### PR DESCRIPTION
# Welcome to Cryostat3! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat3/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] [Signed all commits using a GPG signature](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#gpg-commit-signature-verification)

**To recreate commits with GPG signature** `git fetch upstream && git rebase --force --gpg-sign upstream/main`
_______________________________________________

Fixes: #450

## Description of the change:
Implements the correct reports generation healthcheck behaviour, matching the previous 2.x versions.

## Motivation for the change:
This is useful for diagnosing reports sidecar configuration and is also used by some automated tests.

## How to manually test:
1. Check out and build PR
2. `./smoketest.bash -O`, then in another terminal `http --auth=user:pass :8080/health`. Check that reports are not configured but are available.
2. `./smoketest.bash -Or`, then in another terminal `http --auth=user:pass :8080/health`. Check that reports are both configured and available.
3. Edit `compose/reports.yml` and change the `QUARKUS_REST_CLIENT_REPORTS_URL` to a different port number or host name, then re-run `./smoketest.bash -Or`. Now it should say that reports are configured but unavailable.