### PR TITLE
chore(jmacagent): Update JMC Agent handlers to account for core changes

### DIFF
--- a/src/main/java/io/cryostat/jmcagent/JMCAgent.java
+++ b/src/main/java/io/cryostat/jmcagent/JMCAgent.java
@@ -23,10 +23,10 @@ import java.util.List;
 import java.util.Map;
 
 import io.cryostat.V2Response;
-import io.cryostat.core.agent.AgentJMXHelper;
-import io.cryostat.core.agent.AgentJMXHelper.ProbeDefinitionException;
-import io.cryostat.core.agent.Event;
-import io.cryostat.core.agent.ProbeTemplate;
+import io.cryostat.core.jmcagent.Event;
+import io.cryostat.core.jmcagent.JMCAgentJMXHelper;
+import io.cryostat.core.jmcagent.JMCAgentJMXHelper.ProbeDefinitionException;
+import io.cryostat.core.jmcagent.ProbeTemplate;
 import io.cryostat.core.sys.FileSystem;
 import io.cryostat.targets.Target;
 import io.cryostat.targets.TargetConnectionManager;
@@ -70,7 +70,7 @@ public class JMCAgent {
             return connectionManager.executeConnectedTask(
                     target,
                     connection -> {
-                        AgentJMXHelper helper = new AgentJMXHelper(connection.getHandle());
+                        JMCAgentJMXHelper helper = new JMCAgentJMXHelper(connection.getHandle());
                         try {
                             ProbeTemplate template = new ProbeTemplate();
                             // Retrieve template and deserialize to validate
@@ -129,7 +129,8 @@ public class JMCAgent {
                     target,
                     connection -> {
                         try {
-                            AgentJMXHelper helper = new AgentJMXHelper(connection.getHandle());
+                            JMCAgentJMXHelper helper =
+                                    new JMCAgentJMXHelper(connection.getHandle());
                             // The convention for removing probes in the agent controller mbean is
                             // to call defineEventProbes with a null argument.
                             helper.defineEventProbes(null);
@@ -172,7 +173,7 @@ public class JMCAgent {
             return connectionManager.executeConnectedTask(
                     target,
                     connection -> {
-                        AgentJMXHelper helper = new AgentJMXHelper(connection.getHandle());
+                        JMCAgentJMXHelper helper = new JMCAgentJMXHelper(connection.getHandle());
                         List<Event> result = new ArrayList<>();
                         String probes = helper.retrieveEventProbes();
                         try {

--- a/src/main/java/io/cryostat/jmcagent/S3ProbeTemplateService.java
+++ b/src/main/java/io/cryostat/jmcagent/S3ProbeTemplateService.java
@@ -26,8 +26,8 @@ import java.util.Objects;
 import io.cryostat.ConfigProperties;
 import io.cryostat.Producers;
 import io.cryostat.StorageBuckets;
-import io.cryostat.core.agent.ProbeTemplate;
-import io.cryostat.core.agent.ProbeTemplateService;
+import io.cryostat.core.jmcagent.ProbeTemplate;
+import io.cryostat.core.jmcagent.ProbeTemplateService;
 import io.cryostat.ws.MessagingServer;
 import io.cryostat.ws.Notification;
 

--- a/src/main/java/io/cryostat/jmcagent/SerializableProbeTemplateInfo.java
+++ b/src/main/java/io/cryostat/jmcagent/SerializableProbeTemplateInfo.java
@@ -17,7 +17,7 @@ package io.cryostat.jmcagent;
 
 import java.util.Objects;
 
-import io.cryostat.core.agent.ProbeTemplate;
+import io.cryostat.core.jmcagent.ProbeTemplate;
 
 public record SerializableProbeTemplateInfo(String name, String xml) {
 


### PR DESCRIPTION
Fixes: https://github.com/cryostatio/cryostat-core/issues/297

## Description of the change:
Accounts for changes in core to rename the jmc agent classes and clean up the LocalProbeTemplateService

## How to manually test:
1. Add the JMC Agent to the cryostat image
2. Manually test the agent handlers/functionality

Depends on https://github.com/cryostatio/cryostat-core/pull/398