### PR TITLE
test(smoketest): cleanup, add config to run without S3

### DIFF
--- a/compose/cryostat.yml
+++ b/compose/cryostat.yml
@@ -1,11 +1,6 @@
 version: "3"
 services:
   cryostat:
-    depends_on:
-      db:
-        condition: service_healthy
-      s3:
-        condition: service_healthy
     deploy:
       resources:
         limits:

--- a/compose/db.yml
+++ b/compose/db.yml
@@ -1,6 +1,9 @@
 version: "3"
 services:
   cryostat:
+    depends_on:
+      db:
+        condition: service_healthy
     environment:
       QUARKUS_HIBERNATE_ORM_DATABASE_GENERATION: ${DATABASE_GENERATION:-drop-and-create}
       QUARKUS_DATASOURCE_USERNAME: cryostat3

--- a/compose/s3-cloudserver.yml
+++ b/compose/s3-cloudserver.yml
@@ -1,6 +1,9 @@
 version: "3"
 services:
   cryostat:
+    depends_on:
+      s3:
+        condition: service_healthy
     environment:
       STORAGE_BUCKETS_ARCHIVES_NAME: archivedrecordings
       QUARKUS_S3_ENDPOINT_OVERRIDE: http://s3:8000

--- a/compose/s3-localstack.yml
+++ b/compose/s3-localstack.yml
@@ -1,6 +1,9 @@
 version: "3"
 services:
   cryostat:
+    depends_on:
+      s3:
+        condition: service_healthy
     environment:
       STORAGE_BUCKETS_ARCHIVES_NAME: archivedrecordings
       QUARKUS_S3_ENDPOINT_OVERRIDE: http://s3:4566

--- a/compose/s3-minio.yml
+++ b/compose/s3-minio.yml
@@ -1,6 +1,9 @@
 version: "3"
 services:
   cryostat:
+    depends_on:
+      s3:
+        condition: service_healthy
     environment:
       STORAGE_BUCKETS_ARCHIVES_NAME: archivedrecordings
       QUARKUS_S3_ENDPOINT_OVERRIDE: http://s3:9000

--- a/compose/s3-none.yml
+++ b/compose/s3-none.yml
@@ -1,0 +1,12 @@
+version: "3"
+services:
+  cryostat:
+    environment:
+      QUARKUS_S3_ENDPOINT_OVERRIDE: http://s3:4566
+      QUARKUS_S3_PATH_STYLE_ACCESS: "true" # needed since compose setup does not support DNS subdomain resolution
+      QUARKUS_S3_AWS_REGION: us-east-1
+      QUARKUS_S3_AWS_CREDENTIALS_TYPE: static
+      QUARKUS_S3_AWS_CREDENTIALS_STATIC_PROVIDER_ACCESS_KEY_ID: unused
+      QUARKUS_S3_AWS_CREDENTIALS_STATIC_PROVIDER_SECRET_ACCESS_KEY: unused
+      AWS_ACCESS_KEY_ID: unused
+      AWS_SECRET_ACCESS_KEY: unused

--- a/compose/s3-seaweed.yml
+++ b/compose/s3-seaweed.yml
@@ -1,6 +1,9 @@
 version: "3"
 services:
   cryostat:
+    depends_on:
+      s3:
+        condition: service_healthy
     environment:
       STORAGE_BUCKETS_ARCHIVES_NAME: archivedrecordings
       CRYOSTAT_SERVICES_REPORTS_STORAGE_CACHE_NAME: archivedreports


### PR DESCRIPTION
# Welcome to Cryostat3! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat3/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] [Signed all commits using a GPG signature](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#gpg-commit-signature-verification)

**To recreate commits with GPG signature** `git fetch upstream && git rebase --force --gpg-sign upstream/main`
_______________________________________________

## Description of the change:
1. Cleans up some service dependency declarations to be placed in the correct files so that services are easier to mix and match.
2. Adds `s3-none.yml`, which is an intentionally stub-out of the S3 provider, pointing Cryostat at a nonexistent S3 service and not starting any S3 service. This would not be useful in normal circumstances but can be used to check Cryostat's behaviour if its S3 object storage goes offline or is otherwise unreachable.

## How to manually test:
1. Check out PR
2. `./smoketest.bash -O -s none`
3. This should hang for quite a while as Cryostat repeatedly tries to check for the storage buckets it expects, but is unable to resolve the object storage container (since there is none). The smoketest should eventually bail out.