### PR TITLE
feat(credentials): add missing credentials test endpoint

### DIFF
--- a/schema/openapi.yaml
+++ b/schema/openapi.yaml
@@ -397,7 +397,7 @@ paths:
       security:
         - SecurityScheme: []
       tags:
-        - Credentials Test
+        - Credential Check
   /api/beta/fs/recordings:
     get:
       responses:

--- a/schema/openapi.yaml
+++ b/schema/openapi.yaml
@@ -365,6 +365,39 @@ info:
   version: 3.0.0-snapshot
 openapi: 3.0.3
 paths:
+  /api/beta/credentials/{connectUrl}:
+    post:
+      parameters:
+        - in: path
+          name: connectUrl
+          required: true
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              properties:
+                password:
+                  type: string
+                username:
+                  type: string
+              type: object
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/V2Response'
+          description: OK
+        "401":
+          description: Not Authorized
+        "403":
+          description: Not Allowed
+      security:
+        - SecurityScheme: []
+      tags:
+        - Credentials Test
   /api/beta/fs/recordings:
     get:
       responses:

--- a/src/main/java/io/cryostat/credentials/CredentialCheck.java
+++ b/src/main/java/io/cryostat/credentials/CredentialCheck.java
@@ -34,7 +34,7 @@ import org.jboss.resteasy.reactive.RestForm;
 import org.jboss.resteasy.reactive.RestPath;
 
 @Path("")
-public class CredentialsTest {
+public class CredentialCheck {
 
     @Inject TargetConnectionManager connectionManager;
 
@@ -42,7 +42,7 @@ public class CredentialsTest {
     @Blocking
     @RolesAllowed("read")
     @Path("/api/beta/credentials/{connectUrl}")
-    public Uni<V2Response> testCredentialForTarget(
+    public Uni<V2Response> checkCredentialForTarget(
             @RestPath String connectUrl, @RestForm String username, @RestForm String password)
             throws URISyntaxException {
         Target target = Target.getTargetByConnectUrl(new URI(connectUrl));

--- a/src/main/java/io/cryostat/credentials/CredentialsTest.java
+++ b/src/main/java/io/cryostat/credentials/CredentialsTest.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright The Cryostat Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.cryostat.credentials;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.Optional;
+
+import io.cryostat.V2Response;
+import io.cryostat.targets.Target;
+import io.cryostat.targets.TargetConnectionManager;
+
+import io.smallrye.common.annotation.Blocking;
+import io.smallrye.mutiny.Uni;
+import jakarta.annotation.security.RolesAllowed;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.core.Response.Status;
+import org.jboss.resteasy.reactive.RestForm;
+import org.jboss.resteasy.reactive.RestPath;
+
+@Path("")
+public class CredentialsTest {
+
+    @Inject TargetConnectionManager connectionManager;
+
+    @POST
+    @Blocking
+    @RolesAllowed("read")
+    @Path("/api/beta/credentials/{connectUrl}")
+    public Uni<V2Response> testCredentialForTarget(
+            @RestPath String connectUrl, @RestForm String username, @RestForm String password)
+            throws URISyntaxException {
+        Target target = Target.getTargetByConnectUrl(new URI(connectUrl));
+        return connectionManager
+                .executeDirect(
+                        target,
+                        Optional.empty(),
+                        (conn) -> {
+                            conn.connect();
+                            return CredentialTestResult.NA;
+                        })
+                .onFailure()
+                .recoverWithUni(
+                        () -> {
+                            Credential cred = new Credential();
+                            cred.username = username;
+                            cred.password = password;
+                            return connectionManager
+                                    .executeDirect(
+                                            target,
+                                            Optional.of(cred),
+                                            (conn) -> {
+                                                conn.connect();
+                                                return CredentialTestResult.SUCCESS;
+                                            })
+                                    .onFailure()
+                                    .recoverWithItem(t -> CredentialTestResult.FAILURE);
+                        })
+                .map(r -> V2Response.json(Status.OK, r));
+    }
+
+    static enum CredentialTestResult {
+        SUCCESS,
+        FAILURE,
+        NA;
+    }
+}

--- a/src/main/java/io/cryostat/credentials/CredentialsTest.java
+++ b/src/main/java/io/cryostat/credentials/CredentialsTest.java
@@ -68,7 +68,11 @@ public class CredentialsTest {
                                                 conn.connect();
                                                 return CredentialTestResult.SUCCESS;
                                             })
-                                    .onFailure()
+                                    .onFailure(
+                                            t ->
+                                                    connectionManager.isJmxAuthFailure(t)
+                                                            || connectionManager.isAgentAuthFailure(
+                                                                    t))
                                     .recoverWithItem(t -> CredentialTestResult.FAILURE);
                         })
                 .map(r -> V2Response.json(Status.OK, r));

--- a/src/main/java/io/cryostat/targets/AgentClient.java
+++ b/src/main/java/io/cryostat/targets/AgentClient.java
@@ -39,7 +39,6 @@ import io.cryostat.ConfigProperties;
 import io.cryostat.core.net.MBeanMetrics;
 import io.cryostat.core.serialization.SerializableRecordingDescriptor;
 import io.cryostat.credentials.Credential;
-import io.cryostat.credentials.CredentialsFinder;
 import io.cryostat.discovery.DiscoveryPlugin;
 import io.cryostat.targets.AgentJFRService.StartRecordingRequest;
 import io.cryostat.util.HttpStatusCodeIdentifier;
@@ -75,20 +74,14 @@ public class AgentClient {
     private final WebClient webClient;
     private final Duration httpTimeout;
     private final ObjectMapper mapper;
-    private final CredentialsFinder credentialsFinder;
     private final Logger logger = Logger.getLogger(getClass());
 
     private AgentClient(
-            Target target,
-            WebClient webClient,
-            ObjectMapper mapper,
-            Duration httpTimeout,
-            CredentialsFinder credentialsFinder) {
+            Target target, WebClient webClient, ObjectMapper mapper, Duration httpTimeout) {
         this.target = target;
         this.webClient = webClient;
         this.mapper = mapper;
         this.httpTimeout = httpTimeout;
-        this.credentialsFinder = credentialsFinder;
     }
 
     Target getTarget() {
@@ -426,14 +419,13 @@ public class AgentClient {
 
         @Inject ObjectMapper mapper;
         @Inject WebClient webClient;
-        @Inject CredentialsFinder credentialsFinder;
         @Inject Logger logger;
 
         @ConfigProperty(name = ConfigProperties.CONNECTIONS_FAILED_TIMEOUT)
         Duration timeout;
 
         public AgentClient create(Target target) {
-            return new AgentClient(target, webClient, mapper, timeout, credentialsFinder);
+            return new AgentClient(target, webClient, mapper, timeout);
         }
     }
 

--- a/src/main/java/io/cryostat/targets/TargetConnectionManager.java
+++ b/src/main/java/io/cryostat/targets/TargetConnectionManager.java
@@ -390,7 +390,7 @@ public class TargetConnectionManager {
         return cause;
     }
 
-    private boolean isTargetConnectionFailure(Throwable t) {
+    public boolean isTargetConnectionFailure(Throwable t) {
         if (!(t instanceof Exception)) {
             return false;
         }
@@ -403,7 +403,7 @@ public class TargetConnectionManager {
      * Check if the exception happened because the connection required authentication, and we had no
      * credentials to present.
      */
-    private boolean isJmxAuthFailure(Throwable t) {
+    public boolean isJmxAuthFailure(Throwable t) {
         if (!(t instanceof Exception)) {
             return false;
         }
@@ -414,11 +414,20 @@ public class TargetConnectionManager {
                 || ExceptionUtils.indexOfType(e, SaslException.class) >= 0;
     }
 
+    public boolean isAgentAuthFailure(Throwable t) {
+        int index = ExceptionUtils.indexOfType(t, ConnectionException.class);
+        if (index >= 0) {
+            Throwable ce = ExceptionUtils.getThrowableList(t).get(index);
+            return ce.getMessage().contains(AgentClient.NULL_CREDENTIALS);
+        }
+        return false;
+    }
+
     /**
      * Check if the exception happened because the connection presented an SSL/TLS cert which we
      * don't trust.
      */
-    private boolean isJmxSslFailure(Throwable t) {
+    public boolean isJmxSslFailure(Throwable t) {
         if (!(t instanceof Exception)) {
             return false;
         }
@@ -428,7 +437,7 @@ public class TargetConnectionManager {
     }
 
     /** Check if the exception happened because the port connected to a non-JMX service. */
-    private boolean isServiceTypeFailure(Throwable t) {
+    public boolean isServiceTypeFailure(Throwable t) {
         if (!(t instanceof Exception)) {
             return false;
         }
@@ -438,7 +447,7 @@ public class TargetConnectionManager {
     }
 
     /** Check if the exception happened because an MBean was not found */
-    private boolean isInstanceNotFoundFailure(Throwable t) {
+    public boolean isInstanceNotFoundFailure(Throwable t) {
         if (!(t instanceof Exception)) {
             return false;
         }


### PR DESCRIPTION
# Welcome to Cryostat3! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat3/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] [Signed all commits using a GPG signature](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#gpg-commit-signature-verification)

**To recreate commits with GPG signature** `git fetch upstream && git rebase --force --gpg-sign upstream/main`
_______________________________________________

Fixes: #478
Related to #2

## Description of the change:
Reimplements the `/api/beta/credentials/{connectUrl}` endpoint. This is used on the Security > Store Credentials > List view for testing credentials against targets before actually storing the credential.

## How to manually test:
1. Check out and build PR
2. `./smoktest.bash -Ot`
3. Go to Security > Store Credentials
4. Enter a test credential with the match expression `true` and credentials `admin:adminpass123`
5. Click the List tab and click Test for each target
6. Verify that the credential is Valid for vertx-fib-demo targets with ports 9094 and 9095, Invalid for cryostat3:9091, and Not Applicable for all others

![image](https://github.com/cryostatio/cryostat3/assets/3787464/88d1159c-3883-4e52-a393-9eb962398e23)

Before this PR, all of the results would come back with Invalid responses for everything since the endpoint would always return a 404.