### PR TITLE
fix(template): correct return of String-encoded Optional

### DIFF
--- a/.github/workflows/pr-ci.yaml
+++ b/.github/workflows/pr-ci.yaml
@@ -156,7 +156,7 @@ jobs:
     - name: Set DOCKER_HOST environment variable
       run: echo "DOCKER_HOST=unix:///run/user/$(id -u)/podman/podman.sock" >> "$GITHUB_ENV"
     - name: Build application
-      run: ./mvnw -B -U -Dquarkus.container-image.build=false clean verify
+      run: ./mvnw -B -U clean verify
       continue-on-error: ${{ matrix.java != '17' }}
 
     - name: Add workflow result as comment on PR

--- a/src/main/docker/include/cryostat.jfc
+++ b/src/main/docker/include/cryostat.jfc
@@ -19,14 +19,6 @@
    0 ms
   </setting>
  </event>
- <event name="io.cyostat.net.web.MessagingServer.WsMessageEmitted">
-  <setting name="enabled">
-    true
-  </setting>
-  <setting name="threshold">
-    0 ms
-  </setting>
- </event>
  <event name="jdk.ThreadAllocationStatistics">
   <setting name="enabled">
    true

--- a/src/main/docker/include/cryostat.jfc
+++ b/src/main/docker/include/cryostat.jfc
@@ -3,7 +3,7 @@
      see Window -> Flight Recorder Template Manager.
 -->
 <configuration version="2.0" label="Cryostat" description="Continuous self-profiling for Cryostat" provider="Cryostat">
- <event name="io.cryostat.net.TargetConnectionManager.JMXConnectionOpened">
+ <event name="io.cryostat.targets.TargetConnectionManager.TargetConnectionOpened">
   <setting name="enabled">
   true
   </setting>
@@ -11,7 +11,7 @@
   0 ms
   </setting>
  </event>
- <event name="io.cryostat.net.TargetConnectionManager.JMXConnectionClosed">
+ <event name="io.cryostat.targets.TargetConnectionManager.TargetConnectionClosed">
   <setting name="enabled">
    true
   </setting>

--- a/src/main/docker/include/cryostat.jfc
+++ b/src/main/docker/include/cryostat.jfc
@@ -19,6 +19,22 @@
    0 ms
   </setting>
  </event>
+ <event name="io.cryostat.expressions.MatchExpressionEvaluator.MatchExpressionApplies">
+  <setting name="enabled">
+   true
+  </setting>
+  <setting name="threshold">
+   0 ms
+  </setting>
+ </event>
+ <event name="io.cryostat.expressions.MatchExpressionEvaluator.ScriptCreation">
+  <setting name="enabled">
+   true
+  </setting>
+  <setting name="threshold">
+   0 ms
+  </setting>
+ </event>
  <event name="jdk.ThreadAllocationStatistics">
   <setting name="enabled">
    true

--- a/src/main/docker/include/cryostat.jfc
+++ b/src/main/docker/include/cryostat.jfc
@@ -3,17 +3,6 @@
      see Window -> Flight Recorder Template Manager.
 -->
 <configuration version="2.0" label="Cryostat" description="Continuous self-profiling for Cryostat" provider="Cryostat">
- <event name="io.cryostat.net.OpenShiftAuthManager.AuthRequest">
-  <setting name="enabled">
-   true
-  </setting>
-  <setting name="threshold">
-   0 ms
-  </setting>
-  <setting name="stackTrace">
-    true
-  </setting>
- </event>
  <event name="io.cryostat.net.TargetConnectionManager.JMXConnectionOpened">
   <setting name="enabled">
   true
@@ -30,26 +19,7 @@
    0 ms
   </setting>
  </event>
- <event name="io.cyostat.net.web.WebServer.WebServerRequest">
-  <setting name="enabled">
-   true
-  </setting>
-  <setting name="threshold">
-    0 ms
-   </setting>
-  <setting name="stackTrace">
-    true
-  </setting>
- </event>
  <event name="io.cyostat.net.web.MessagingServer.WsMessageEmitted">
-  <setting name="enabled">
-    true
-  </setting>
-  <setting name="threshold">
-    0 ms
-  </setting>
- </event>
- <event name="io.cryostat.core.reports.InterruptibleReportGenerator.ReportRuleEvalEvent">
   <setting name="enabled">
     true
   </setting>

--- a/src/main/java/io/cryostat/events/TargetTemplateService.java
+++ b/src/main/java/io/cryostat/events/TargetTemplateService.java
@@ -63,13 +63,9 @@ public class TargetTemplateService implements TemplateService {
     @Override
     public Optional<String> getXml(String templateName, TemplateType unused)
             throws FlightRecorderException {
-        Optional doc =
-                connectionManager.executeConnectedTask(
-                        target,
-                        conn ->
-                                conn.getTemplateService()
-                                        .getXml(templateName, TemplateType.TARGET));
-        return doc.isPresent() ? Optional.of(doc.toString()) : Optional.empty();
+        return connectionManager.executeConnectedTask(
+                target,
+                conn -> conn.getTemplateService().getXml(templateName, TemplateType.TARGET));
     }
 
     @Override

--- a/src/main/java/io/cryostat/expressions/MatchExpressionEvaluator.java
+++ b/src/main/java/io/cryostat/expressions/MatchExpressionEvaluator.java
@@ -74,7 +74,7 @@ public class MatchExpressionEvaluator {
     }
 
     Script createScript(String matchExpression) throws ScriptCreateException {
-        ScriptCreationEvent evt = new ScriptCreationEvent();
+        ScriptCreation evt = new ScriptCreation();
         try {
             evt.begin();
             return scriptHost
@@ -113,7 +113,7 @@ public class MatchExpressionEvaluator {
     }
 
     public boolean applies(MatchExpression matchExpression, Target target) throws ScriptException {
-        MatchExpressionAppliesEvent evt = new MatchExpressionAppliesEvent(matchExpression);
+        MatchExpressionApplies evt = new MatchExpressionApplies(matchExpression);
         try {
             evt.begin();
             return load(matchExpression.script, target);
@@ -147,27 +147,27 @@ public class MatchExpressionEvaluator {
         }
     }
 
-    @Name("io.cryostat.rules.MatchExpressionEvaluator.MatchExpressionAppliesEvent")
+    @Name("io.cryostat.rules.MatchExpressionEvaluator.MatchExpressionApplies")
     @Label("Match Expression Evaluation")
     @Category("Cryostat")
     @SuppressFBWarnings(value = {"EI_EXPOSE_REP", "URF_UNREAD_FIELD"})
-    public static class MatchExpressionAppliesEvent extends Event {
+    public static class MatchExpressionApplies extends Event {
 
         String matchExpression;
 
-        MatchExpressionAppliesEvent(MatchExpression matchExpression) {
+        MatchExpressionApplies(MatchExpression matchExpression) {
             this.matchExpression = matchExpression.script;
         }
     }
 
-    @Name("io.cryostat.rules.MatchExpressionEvaluator.ScriptCreationEvent")
+    @Name("io.cryostat.rules.MatchExpressionEvaluator.ScriptCreation")
     @Label("Match Expression Script Creation")
     @Category("Cryostat")
     // @SuppressFBWarnings(
     //         value = "URF_UNREAD_FIELD",
     //         justification = "The event fields are recorded with JFR instead of accessed
     // directly")
-    public static class ScriptCreationEvent extends Event {}
+    public static class ScriptCreation extends Event {}
 
     /**
      * Restricted view of a {@link io.cryostat.targets.Target} with only particular

--- a/src/test/java/itest/CryostatTemplateIT.java
+++ b/src/test/java/itest/CryostatTemplateIT.java
@@ -30,9 +30,7 @@ import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.DisabledIfEnvironmentVariable;
 
-@DisabledIfEnvironmentVariable(named = "CI", matches = "true")
 @QuarkusIntegrationTest
 public class CryostatTemplateIT extends StandardSelfTest {
 

--- a/src/test/java/itest/CryostatTemplateIT.java
+++ b/src/test/java/itest/CryostatTemplateIT.java
@@ -28,28 +28,22 @@ import itest.bases.StandardSelfTest;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 @QuarkusIntegrationTest
 public class CryostatTemplateIT extends StandardSelfTest {
 
-    File file;
-
-    @BeforeEach
-    void setup() throws Exception {
+    @Test
+    public void shouldHaveCryostatTemplate() throws Exception {
         String url =
                 String.format(
                         "/api/v1/targets/%s/templates/Cryostat/type/TARGET",
                         getSelfReferenceConnectUrlEncoded());
-        file =
+        File file =
                 downloadFile(url, "cryostat", ".jfc")
                         .get(REQUEST_TIMEOUT_SECONDS, TimeUnit.SECONDS)
                         .toFile();
-    }
 
-    @Test
-    public void shouldHaveCryostatTemplate() throws Exception {
         XMLModel model = EventConfiguration.createModel(file);
         model.checkErrors();
 


### PR DESCRIPTION
# Welcome to Cryostat3! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat3/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] [Signed all commits using a GPG signature](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#gpg-commit-signature-verification)

**To recreate commits with GPG signature** `git fetch upstream && git rebase --force --gpg-sign upstream/main`
_______________________________________________

Fixes: #481

## Description of the change:
There was a bit of jumbled handling of an Optional in the implementation from #449, which resulted in an Optional that wrapped around another `Optional#toString()` call erroneously. The original Optional itself is the expected return, not its String form.

This got missed because the test doesn't run in CI. I think this is because of the Maven property to not build container images during CI. This probably made sense previously when there were no real tests to run and so building the container image as a throwaway was just a waste of CI time, but now there are integration tests to be run which do need the container image to have been built first.

## How to manually test:
1. Check out PR
2. `./mvnw clean verify ; podman image prune -f`. All tests should pass
3. `./smoketest.bash -O`, once the test comes up open the UI and start a recording on Cryostat itself using `localhost:0` using the Cryostat template. Go to Security and define a stored credential that matches `cryostat3:9091` with `cryostat:password`, create another stored credential with `false` and `test:test`, go back to Recordings and select `cryostat3:9091`. Then download the recording you started and open it with JMC. Go to the Event Browser and verify that the events were captured.

![Screenshot_2024-05-29_16-08-06](https://github.com/cryostatio/cryostat3/assets/3787464/ee071ddc-fbcf-4b24-8af3-6eb86d76d5fb)