### PR TITLE
fix(Archived Recordings): Archived Recordings tables improperly react to "Recording Saved" notifications

### DIFF
--- a/src/main/java/io/cryostat/recordings/RecordingHelper.java
+++ b/src/main/java/io/cryostat/recordings/RecordingHelper.java
@@ -18,6 +18,7 @@ package io.cryostat.recordings;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.MalformedURLException;
+import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.net.URLDecoder;
@@ -875,10 +876,22 @@ public class RecordingHelper {
             throw e;
         }
         if (expiry == null) {
+            ArchivedRecording archivedRecording =
+                    new ArchivedRecording(
+                            recording.target.jvmId,
+                            filename,
+                            downloadUrl(recording.target.jvmId, filename),
+                            reportUrl(recording.target.jvmId, filename),
+                            recording.metadata,
+                            accum,
+                            now.getEpochSecond());
+
+            URI connectUrl = recording.target.connectUrl;
+
             var event =
-                    new ActiveRecordingEvent(
-                            Recordings.RecordingEventCategory.ACTIVE_SAVED,
-                            ActiveRecordingEvent.Payload.of(this, recording));
+                    new ArchivedRecordingEvent(
+                            Recordings.RecordingEventCategory.ARCHIVED_CREATED,
+                            ArchivedRecordingEvent.Payload.of(connectUrl, archivedRecording));
             bus.publish(event.category().category(), event.payload().recording());
             bus.publish(
                     MessagingServer.class.getName(),


### PR DESCRIPTION
# Welcome to Cryostat3! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat3/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] [Signed all commits using a GPG signature](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#gpg-commit-signature-verification)

**To recreate commits with GPG signature** `git fetch upstream && git rebase --force --gpg-sign upstream/main`
_______________________________________________

Fixes: #441

## Description of the change:
This change will update the Archived Recordings table with the correct data (i.e Name and Size), when Recordings are created and archived with `Automated Rules`.

## Motivation for the change:
Mentioned earlier by @andrewazores [https://github.com/cryostatio/cryostat3/issues/441](https://github.com/cryostatio/cryostat3/issues/441)

## How to manually test:
1. checkout on this PR and run smoketest. 
2. create an Automated Rule  -> `Automated Rules` -> `Create`
```{
  "id": 1,
  "name": "test",
  "description": "",
  "matchExpression": "target.connectUrl.contains('localhost:0')",
  "eventSpecifier": "template=Profiling,type=TARGET",
  "archivalPeriodSeconds": 10,
  "initialDelaySeconds": 0,
  "preservedArchives": 3,
  "maxAgeSeconds": 300,
  "maxSizeBytes": 0,
  "enabled": true
}
```
3. go to `Recordings` -> select the `localhost:0` as the target -> go to `Archived Recordings` tab
4. the `Automated Rule` should create `Archived Recordings`
5.  verify that all data is available and valid (especially `Name` and `Size`)
