### PR TITLE
fix(auth): use X-Forwarded-User header to populate username response

### DIFF
--- a/src/main/java/io/cryostat/Health.java
+++ b/src/main/java/io/cryostat/Health.java
@@ -200,11 +200,7 @@ class Health {
                     .header("Access-Control-Allow-Origin", "http://localhost:9000")
                     .header(
                             "Access-Control-Allow-Headers",
-                            "accept, origin, authorization, content-type,"
-                                    + " x-requested-with, x-jmx-authorization")
-                    .header(
-                            "Access-Control-Expose-Headers",
-                            "x-www-authenticate, x-jmx-authenticate")
+                            "accept, origin, authorization, content-type," + " x-requested-with")
                     .header("Access-Control-Allow-Methods", "GET,POST,OPTIONS")
                     .header("Access-Control-Allow-Credentials", "true");
         }

--- a/src/main/java/io/cryostat/security/Auth.java
+++ b/src/main/java/io/cryostat/security/Auth.java
@@ -49,7 +49,6 @@ public class Auth {
     @Produces(MediaType.APPLICATION_JSON)
     public Response login(@Context RoutingContext context) {
         return Response.ok()
-                .header("X-WWW-Authenticate", "None")
                 .entity(V2Response.json(Response.Status.OK, Map.of("username", "user")))
                 .build();
     }

--- a/src/main/java/io/cryostat/security/Auth.java
+++ b/src/main/java/io/cryostat/security/Auth.java
@@ -28,6 +28,7 @@ import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.Context;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.core.SecurityContext;
 import org.jboss.resteasy.reactive.RestResponse;
 
 @Path("")
@@ -47,9 +48,16 @@ public class Auth {
     @Path("/api/v2.1/auth")
     @PermitAll
     @Produces(MediaType.APPLICATION_JSON)
-    public Response login(@Context RoutingContext context) {
+    public Response login(@Context RoutingContext context, SecurityContext securityContext) {
+        String user =
+                securityContext.getUserPrincipal() != null
+                        ? securityContext.getUserPrincipal().getName()
+                        : context.request().getHeader("X-Forwarded-User");
+        if (user == null) {
+            user = "";
+        }
         return Response.ok()
-                .entity(V2Response.json(Response.Status.OK, Map.of("username", "user")))
+                .entity(V2Response.json(Response.Status.OK, Map.of("username", user)))
                 .build();
     }
 }

--- a/src/main/resources/application-dev.properties
+++ b/src/main/resources/application-dev.properties
@@ -6,7 +6,6 @@ quarkus.http.cors=true
 # quarkus.http.cors.origins=http://localhost:9000,http://0.0.0.0:9000
 quarkus.http.cors.origins=http://localhost:9000
 quarkus.http.cors.access-control-allow-credentials=true
-quarkus.http.cors.exposed-headers=X-WWW-Authenticate
 # quarkus.http.cors.methods=GET,PUT,POST,PATCH,OPTIONS
 # quarkus.http.cors.access-control-max-age=1s
 


### PR DESCRIPTION
- **chore(headers): clean up unused headers references**
- **fix(auth): use X-Forwarded-User header to populate username response**

# Welcome to Cryostat3! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat3/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] [Signed all commits using a GPG signature](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#gpg-commit-signature-verification)

**To recreate commits with GPG signature** `git fetch upstream && git rebase --force --gpg-sign upstream/main`
_______________________________________________

Related to #489

## Description of the change:
If the `X-Forwarded-User` header is present in the request, use this to populate the `POST /api/v2.1/auth` response. This header may be provided to Cryostat by its auth proxy. If there is no such header (there is no proxy, or the proxy doesn't send this) then the empty string is used.

## Motivation for the change:
This may allow Cryostat to inform the client of the username that was provided to the auth proxy. In the case of the web-client this can be used to include the user's username in the application UI.

## How to manually test:
1. Not sure at this time. `oauth2_proxy` docs claim that the `X-Forwarded-User` header should be passed, but this may not be the case when using alpha configuration? It doesn't seem that it actually gets passed with any proxy configuration I try.
