### PR TITLE
fix(recordings): correctly retrieve custom event templates from S3 storage

### DIFF
--- a/src/main/java/io/cryostat/recordings/RecordingHelper.java
+++ b/src/main/java/io/cryostat/recordings/RecordingHelper.java
@@ -369,11 +369,22 @@ public class RecordingHelper {
                             }
                             IConstrainedMap<String> recordingOptions = optionsBuilder.build();
 
-                            return conn.getService()
-                                    .start(
-                                            recordingOptions,
-                                            template.getName(),
-                                            template.getType());
+                            switch (template.getType()) {
+                                case CUSTOM:
+                                    return conn.getService()
+                                            .start(
+                                                    recordingOptions,
+                                                    customTemplateService
+                                                            .getXml(
+                                                                    template.getName(),
+                                                                    TemplateType.CUSTOM)
+                                                            .orElseThrow());
+                                case TARGET:
+                                    return conn.getService().start(recordingOptions, template);
+                                default:
+                                    throw new IllegalStateException(
+                                            "Unknown template type: " + template.getType());
+                            }
                         });
 
         Map<String, String> labels = new HashMap<>(rawLabels);

--- a/src/main/java/io/cryostat/targets/AgentConnection.java
+++ b/src/main/java/io/cryostat/targets/AgentConnection.java
@@ -36,6 +36,7 @@ import io.cryostat.core.net.MBeanMetrics;
 import io.cryostat.core.sys.Clock;
 import io.cryostat.core.templates.RemoteTemplateService;
 import io.cryostat.core.templates.TemplateService;
+import io.cryostat.events.S3TemplateService;
 
 import io.smallrye.common.annotation.Blocking;
 import jakarta.enterprise.context.ApplicationScoped;
@@ -45,10 +46,12 @@ import org.jboss.logging.Logger;
 class AgentConnection implements JFRConnection {
 
     private final AgentClient client;
+    private final TemplateService customTemplateService;
     private final Logger logger = Logger.getLogger(getClass());
 
-    AgentConnection(AgentClient client) {
+    AgentConnection(AgentClient client, TemplateService customTemplateService) {
         this.client = client;
+        this.customTemplateService = customTemplateService;
     }
 
     @Override
@@ -113,7 +116,7 @@ class AgentConnection implements JFRConnection {
     @Override
     public CryostatFlightRecorderService getService()
             throws ConnectionException, IOException, ServiceNotAvailableException {
-        return new AgentJFRService(client, getTemplateService());
+        return new AgentJFRService(client, customTemplateService);
     }
 
     @Override
@@ -141,10 +144,11 @@ class AgentConnection implements JFRConnection {
     public static class Factory {
 
         @Inject AgentClient.Factory clientFactory;
+        @Inject S3TemplateService customTemplateService;
         @Inject Logger logger;
 
         public AgentConnection createConnection(Target target) {
-            return new AgentConnection(clientFactory.create(target));
+            return new AgentConnection(clientFactory.create(target), customTemplateService);
         }
     }
 }

--- a/src/main/java/io/cryostat/targets/AgentJFRService.java
+++ b/src/main/java/io/cryostat/targets/AgentJFRService.java
@@ -224,8 +224,6 @@ class AgentJFRService implements CryostatFlightRecorderService {
                     ParseException,
                     IOException,
                     QuantityConversionException {
-        StartRecordingRequest req;
-        String recordingName = recordingOptions.get("name").toString();
         long duration =
                 (Optional.ofNullable(
                                         (ITypedQuantity)
@@ -247,7 +245,14 @@ class AgentJFRService implements CryostatFlightRecorderService {
                                                         RecordingOptionsBuilder.KEY_MAX_AGE))
                                 .orElse(UnitLookup.MILLISECOND.quantity(0)))
                         .longValueIn(UnitLookup.MILLISECOND);
-        req = new StartRecordingRequest(recordingName, null, template, duration, maxSize, maxAge);
+        StartRecordingRequest req =
+                new StartRecordingRequest(
+                        recordingOptions.get("name").toString(),
+                        null,
+                        template,
+                        duration,
+                        maxSize,
+                        maxAge);
         return client.startRecording(req).await().atMost(client.getTimeout());
     }
 
@@ -264,39 +269,41 @@ class AgentJFRService implements CryostatFlightRecorderService {
                     QuantityConversionException,
                     EventOptionException,
                     EventTypeException {
-        StartRecordingRequest req;
-        String recordingName = recordingOptions.get("name").toString();
         if (template.getType().equals(TemplateType.CUSTOM)) {
             return start(
                     recordingOptions,
                     templateService.getXml(template.getName(), template.getType()).orElseThrow());
-        } else {
-            long duration =
-                    (Optional.ofNullable(
-                                            (ITypedQuantity)
-                                                    recordingOptions.get(
-                                                            RecordingOptionsBuilder.KEY_DURATION))
-                                    .orElse(UnitLookup.MILLISECOND.quantity(0)))
-                            .longValueIn(UnitLookup.MILLISECOND);
-            long maxSize =
-                    (Optional.ofNullable(
-                                            (ITypedQuantity)
-                                                    recordingOptions.get(
-                                                            RecordingOptionsBuilder.KEY_MAX_SIZE))
-                                    .orElse(UnitLookup.BYTE.quantity(0)))
-                            .longValueIn(UnitLookup.BYTE);
-            long maxAge =
-                    (Optional.ofNullable(
-                                            (ITypedQuantity)
-                                                    recordingOptions.get(
-                                                            RecordingOptionsBuilder.KEY_MAX_AGE))
-                                    .orElse(UnitLookup.MILLISECOND.quantity(0)))
-                            .longValueIn(UnitLookup.MILLISECOND);
-            req =
-                    new StartRecordingRequest(
-                            recordingName, template.getName(), null, duration, maxSize, maxAge);
-            return client.startRecording(req).await().atMost(client.getTimeout());
         }
+        long duration =
+                (Optional.ofNullable(
+                                        (ITypedQuantity)
+                                                recordingOptions.get(
+                                                        RecordingOptionsBuilder.KEY_DURATION))
+                                .orElse(UnitLookup.MILLISECOND.quantity(0)))
+                        .longValueIn(UnitLookup.MILLISECOND);
+        long maxSize =
+                (Optional.ofNullable(
+                                        (ITypedQuantity)
+                                                recordingOptions.get(
+                                                        RecordingOptionsBuilder.KEY_MAX_SIZE))
+                                .orElse(UnitLookup.BYTE.quantity(0)))
+                        .longValueIn(UnitLookup.BYTE);
+        long maxAge =
+                (Optional.ofNullable(
+                                        (ITypedQuantity)
+                                                recordingOptions.get(
+                                                        RecordingOptionsBuilder.KEY_MAX_AGE))
+                                .orElse(UnitLookup.MILLISECOND.quantity(0)))
+                        .longValueIn(UnitLookup.MILLISECOND);
+        StartRecordingRequest req =
+                new StartRecordingRequest(
+                        recordingOptions.get("name").toString(),
+                        template.getName(),
+                        null,
+                        duration,
+                        maxSize,
+                        maxAge);
+        return client.startRecording(req).await().atMost(client.getTimeout());
     }
 
     public static class UnimplementedException extends IllegalStateException {}


### PR DESCRIPTION
# Welcome to Cryostat3! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat3/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] [Signed all commits using a GPG signature](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#gpg-commit-signature-verification)

**To recreate commits with GPG signature** `git fetch upstream && git rebase --force --gpg-sign upstream/main`
_______________________________________________

Fixes: #491
Depends on https://github.com/cryostatio/cryostat-core/pull/403
See #342
See https://github.com/cryostatio/cryostat-core/pull/389

## Description of the change:
Some recent patches to Cryostat and cryostat-core changed how event templates are handled. The current Cryostat `main` has a bug where custom event templates can be successfully uploaded to storage, listed, and downloaded back from storage, but when trying to use the template to create a new recording then the action fails. The root of the failure is that Cryostat tries to start the recording by asking the -core service implementation to start the recording using the custom event template, but that is no longer implemented in 3.0 - this is the code path that in <=2.4 would check for the custom event template on direct disk storage. The new implementation in this PR checks if the desired template is a custom one, and if so retrieves it from S3 storage first before passing it back through the same old code path to start the recording.

## How to manually test:
1. Check out related core PR, `./mvnw clean install` it. Then check out and build this PR: `./mvnw -o clean package ; podman image prune -f`. `./smoktest.bash -Ot`
2. Get a custom event template, ex. download an existing template and modify the top `<configuration>` element
3. Upload the new custom event template
4. Try to start a recording using this template
