### PR TITLE
fix(jvmId): correct query for Targets with null jvmId

### DIFF
--- a/src/main/java/io/cryostat/discovery/Discovery.java
+++ b/src/main/java/io/cryostat/discovery/Discovery.java
@@ -229,8 +229,7 @@ public class Discovery {
             // check if a plugin record with the same callback already exists. If it does,
             // ping it:
             // if it's still there reject this request as a duplicate, otherwise delete the
-            // previous
-            // record and accept this new one as a replacement
+            // previous record and accept this new one as a replacement
             DiscoveryPlugin.<DiscoveryPlugin>find("callback", unauthCallback)
                     .singleResultOptional()
                     .ifPresent(


### PR DESCRIPTION
# Welcome to Cryostat3! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat3/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] [Signed all commits using a GPG signature](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#gpg-commit-signature-verification)

**To recreate commits with GPG signature** `git fetch upstream && git rebase --force --gpg-sign upstream/main`
_______________________________________________

Fixes: #495

## Description of the change:
Corrects a database query. Previously it queried with `find("id", (String) null)`, which generates a SQL query like `select from Target where jvmId = null` and returns no results, even when there are targets with null JVM IDs. The new query is slightly different: `select from Target where jvmId is null`, with the **is null** being the significant difference. With this the database query correctly comes back with the targets with a null JVM ID.

https://stackoverflow.com/questions/9581745/sql-is-null-and-null

## Motivation for the change:
This fixes the Target persist hook that is responsible for checking if newly stored credentials apply to targets, checking for targets which do not yet have a JVM ID, and then using the new credentials to try to set the target's JVM ID.

## How to manually test:
1. Check out and build PR
2. `./smoketest.bash -Ot`
3. Go to Topology, confirm that two of the vertx-fib-demo targets have a warning icon and no JVM ID
4. Go to Security and define a new credential: `target.alias.contains('andrew')`, `admin:adminpass123`. The `CredentialsStored` notification should appear, and so should a target update notification for each target
5. Go back to Topology. The two targets should now have no warning icon and should have a JVM ID
