### PR TITLE
chore(release): prepare for 3.0.0 release

### DIFF
--- a/.github/workflows/push-ci.yaml
+++ b/.github/workflows/push-ci.yaml
@@ -117,8 +117,7 @@ jobs:
       with:
         image: ${{ env.CI_IMG }}
         archs: amd64, arm64
-        # tags: ${{ env.IMAGE_VERSION }} ${{ github.ref == 'refs/heads/main' && 'latest' || '' }}
-        tags: ${{ env.IMAGE_VERSION }}
+        tags: ${{ env.IMAGE_VERSION }} ${{ github.ref == 'refs/heads/main' && 'latest' || '' }}
         containerfiles: |
           ./src/main/docker/Dockerfile.jvm
     - name: Push to quay.io

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,14 +1,14 @@
 pull_request_rules:
-  #- name: backport patches to cryostat-v3.0 branch
-  #  conditions:
-  #   - base=main
-  #   - label=backport
-  #  actions:
-  #    backport:
-  #      branches:
-  #        - cryostat-v3.0
-  #      assignees:
-  #        - "{{ author }}"
+  - name: backport patches to cryostat-v3.0 branch
+    conditions:
+     - base=main
+     - label=backport
+    actions:
+      backport:
+        branches:
+          - cryostat-v3.0
+        assignees:
+          - "{{ author }}"
 
   - name: auto label PRs from reviewers
     conditions:

--- a/compose/cryostat.yml
+++ b/compose/cryostat.yml
@@ -6,7 +6,7 @@ services:
         limits:
           cpus: '2'
           memory: 512m
-    image: ${CRYOSTAT_IMAGE:-quay.io/cryostat/cryostat:3.0.0-snapshot}
+    image: ${CRYOSTAT_IMAGE:-quay.io/cryostat/cryostat:latest}
     volumes:
       - ${XDG_RUNTIME_DIR}/podman/podman.sock:/run/user/1000/podman/podman.sock:Z
       - jmxtls_cfg:/truststore:U

--- a/compose/cryostat_docker.yml
+++ b/compose/cryostat_docker.yml
@@ -11,7 +11,7 @@ services:
         limits:
           cpus: '2'
           memory: 512m
-    image: ${CRYOSTAT_IMAGE:-quay.io/cryostat/cryostat:3.0.0-snapshot}
+    image: ${CRYOSTAT_IMAGE:-quay.io/cryostat/cryostat:latest}
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock:Z
     security_opt:

--- a/compose/cryostat_k8s.yml
+++ b/compose/cryostat_k8s.yml
@@ -6,7 +6,7 @@ services:
         condition: service_healthy
       s3:
         condition: service_healthy
-    image: ${CRYOSTAT_IMAGE:-quay.io/cryostat/cryostat:3.0.0-snapshot}
+    image: ${CRYOSTAT_IMAGE:-quay.io/cryostat/cryostat:latest}
     hostname: cryostat3
     expose:
       - "9091"

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>io.cryostat</groupId>
   <artifactId>cryostat3</artifactId>
-  <version>3.0.0-SNAPSHOT</version>
+  <version>4.0.0-SNAPSHOT</version>
 
   <repositories>
     <repository>
@@ -38,7 +38,7 @@
 
     <build.arch>amd64</build.arch>
 
-    <io.cryostat.core.version>3.0.0-SNAPSHOT</io.cryostat.core.version>
+    <io.cryostat.core.version>4.0.0-SNAPSHOT</io.cryostat.core.version>
     <org.openjdk.jmc.version>9.0.0</org.openjdk.jmc.version>
 
     <org.apache.commons.codec.version>1.16.1</org.apache.commons.codec.version>

--- a/schema/openapi.yaml
+++ b/schema/openapi.yaml
@@ -362,7 +362,7 @@ info:
     name: Apache 2.0
     url: https://github.com/cryostatio/cryostat3/blob/main/LICENSE
   title: Cryostat API
-  version: 3.0.0-snapshot
+  version: 4.0.0-snapshot
 openapi: 3.0.3
 paths:
   /api/beta/credentials/{connectUrl}:

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -114,6 +114,6 @@ quarkus.container-image.registry=quay.io
 quarkus.container-image.group=cryostat
 quarkus.container-image.name=cryostat
 quarkus.container-image.tag=${quarkus.application.version}
-quarkus.container-image.additional-tags=dev
+quarkus.container-image.additional-tags=dev,latest
 
 quarkus.native.additional-build-args=--initialize-at-run-time=org.openjdk.jmc.jdp.client.JDPClient\\,io.cryostat.core.net.discovery.JvmDiscoveryClient\\,java.net.Inet4Address\\,java.net.Inet6Address


### PR DESCRIPTION
- **ci(tags): tag images as 'latest'**
- **test(smoketest): run 'latest' Cryostat image tag**
- **chore(release): enable mergify backport rule**
- **chore(release): update project to 4.0.0-SNAPSHOT, use -core 4.0.0-SNAPSHOT**

# Welcome to Cryostat3! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat3/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] [Signed all commits using a GPG signature](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#gpg-commit-signature-verification)

**To recreate commits with GPG signature** `git fetch upstream && git rebase --force --gpg-sign upstream/main`
_______________________________________________

Related to #469

## Description of the change:
*This change allows an environment variable to be configured so that...*

## Motivation for the change:
*This change is helpful because users may want to...*

## How to manually test:
1. *Run CRYOSTAT_IMAGE=quay.io... bash smoketest.bash...*
2. *...*
