### PR TITLE
fix(matchexpr): correct lookup of Target objects for match expression testing

### DIFF
--- a/src/main/java/io/cryostat/expressions/MatchExpressionEvaluator.java
+++ b/src/main/java/io/cryostat/expressions/MatchExpressionEvaluator.java
@@ -33,6 +33,7 @@ import io.quarkus.cache.CacheManager;
 import io.quarkus.cache.CacheResult;
 import io.quarkus.cache.CompositeCacheKey;
 import io.quarkus.vertx.ConsumeEvent;
+import io.smallrye.common.annotation.Blocking;
 import jakarta.annotation.Nullable;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
@@ -76,6 +77,7 @@ public class MatchExpressionEvaluator {
     }
 
     @Transactional
+    @Blocking
     @ConsumeEvent(value = Target.TARGET_JVM_DISCOVERY, blocking = true)
     void onMessage(TargetDiscovery event) {
         var target = Target.<Target>find("id", event.serviceRef().id).singleResultOptional();
@@ -99,11 +101,11 @@ public class MatchExpressionEvaluator {
             evt.begin();
             return scriptHost
                     .buildScript(matchExpression)
+                    .withTypes(SimplifiedTarget.class)
                     .withDeclarations(
                             Decls.newVar(
                                     "target",
                                     Decls.newObjectType(SimplifiedTarget.class.getName())))
-                    .withTypes(SimplifiedTarget.class)
                     .build();
         } finally {
             evt.end();


### PR DESCRIPTION
- **fix(matchexpr): invalidate expression cache on Target event**
- **fix(matchexpr): correct lookup of Target objects for match expression testing**

# Welcome to Cryostat3! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat3/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] [Signed all commits using a GPG signature](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#gpg-commit-signature-verification)

**To recreate commits with GPG signature** `git fetch upstream && git rebase --force --gpg-sign upstream/main`
_______________________________________________

Fixes #511

The most important change is in `MatchExpressions.java`. The backend should not trust the client to provide the list of whole `Target` objects to evalute match expressions against. This endpoint should really just take a list of target database IDs that the client wants to test with the provided match expression, but it is late to make such a change now. With this patch the server picks only the `connectUrl` from each of the client's provided targets, then looks up each actual Target instance from the database that has that `connectUrl`, and tests the provided match expression against this reconstructed list. This ensures that the client is not lying about any properties of the targets, and also ensures that the server doesn't skip evaluating any properties of the target that the client did not include with the request (such as the labels and annotations, which are the root of the associated bug).

## How to manually test:
1. Check out and build PR
2. `./smoketest.bash -Ot`
3. Go to Automated Rules > Create
4. Test a match expression like `'PORT' in target.annotations.cryostat`
